### PR TITLE
[Bug Fix] Fix frozen LoRA parameters when adapter already exists

### DIFF
--- a/src/flow_factory/models/abc.py
+++ b/src/flow_factory/models/abc.py
@@ -833,7 +833,12 @@ class BaseAdapter(ABC):
                 # Already a PeftModel, check for existing adapter
                 has_default = "default" in model_component.peft_config
                 if has_default and not overwrite:
-                    logger.info(f"Component {comp} already has 'default' adapter. Skipping.")
+                    logger.info(f"Component {comp} already has 'default' adapter. Skipping initialization but enabling gradients.")
+                    # We must unfreeze the lora parameters because `_freeze_components` might have frozen them!
+                    for name, param in model_component.named_parameters():
+                        if any(k in name for k in self.lora_keys):
+                            param.requires_grad = True
+                    results[comp] = model_component
                     continue
 
                 if has_default and overwrite:


### PR DESCRIPTION
This PR fixes a critical bug in apply_lora() that causes silent training failures when an adapter already exists on a component. This is especially relevant in workflows involving LoRA fusing or checkpoint resuming.

The Problem

I encountered this issue while implementing a workflow where I fuse a pre-trained LoRA into the base model weights an then attempt to train a new LoRA adapter on top of the fused model using GRPO.

Even though the fusing was successful, the subsequent training phase failed to learn anything
(loss stayed flat).

Root Cause:
When a component is already wrapped as a PeftModel (which happens after the first LoRA is loaded/fused), apply_lora() checks if a "default" adapter exists. If it finds one and overwrite=False (default), the function originally logged "Skipping." and executed a continue.

This led to two major issues:

1. Frozen Parameters:
   LoRA parameters (lora_A, lora_B, etc.) might have been frozen by _freeze_components() earlier in the initialization process. Because apply_lora skipped the component, it never ensured requires_grad=True for these parameters.

2. Empty Results:
   The component was not added to the results dictionary. If apply_lora is called for a single component, it would return an empty dict instead of the model, breaking the trainer's initialization.

The Fix

Instead of skipping when an adapter is already present, the function now:

- Explicitly enables gradients for all LoRA-related parameters (lora_ and modules_to_save) to ensure they are indeed trainable for the new session.
- Adds the component to results, ensuring the caller (e.g., the Trainer) receives the correct model reference.

How to Reproduce
1. Load a model and fuse a LoRA adapter.
2. Call adapter.apply_lora(target_modules="default", components="transformer").
3. Check transformer.parameters(); notice that LoRA-related tensors have requires_grad=False despite being the target of the new training session.