### PR TITLE
[data_utils] refactor: unify per-rank shard path helpers

### DIFF
--- a/src/flow_factory/data_utils/dataset.py
+++ b/src/flow_factory/data_utils/dataset.py
@@ -72,9 +72,6 @@ class PreprocessCallable(Protocol):
 # GeneralDataset Class
 # ========================================================================================
 
-_MAX_FINGERPRINT_LEN = 64
-_SHARD_SUFFIX_RESERVE = 15  # Reserve for "_shardXXofYY"
-
 class GeneralDataset(Dataset):
     """
     General-purpose dataset for multi-modal data (text, images, videos).
@@ -249,14 +246,19 @@ class GeneralDataset(Dataset):
         )
 
         if self.num_shards and self.num_shards > 1:
+            if self.shard_index is None:
+                raise ValueError(
+                    f"shard_index must be set when num_shards > 1, "
+                    f"got num_shards={self.num_shards}, shard_index=None"
+                )
             raw_dataset = self._shard_dataset(raw_dataset, self.shard_index, self.num_shards)
             shard_fingerprint = (
                 f"{os.path.basename(self.merged_cache_path)}"
-                f"_shard{self.shard_index}of{self.num_shards - 1}"
+                f"{self._shard_suffix(self.shard_index, self.num_shards)}"
             )
             desc = (
                 f"[Preprocessing {self.split} dataset] "
-                f"Shard {self.shard_index}/{self.num_shards - 1}"
+                f"Shard {self.shard_index:04d}/{self.num_shards - 1:04d}"
             )
         else:
             shard_fingerprint = os.path.basename(self.merged_cache_path)
@@ -535,11 +537,60 @@ class GeneralDataset(Dataset):
         
         return os.path.join(os.path.expanduser(cache_dir), fingerprint)
 
+    @staticmethod
+    def _shard_suffix(shard_idx: int, num_shards: int) -> str:
+        """``_shard{X:04d}of{Y:04d}`` — per-rank suffix shared by:
+
+          * the Arrow filename embedded in :meth:`build_part_arrow_path`
+          * the HF ``Dataset.map(new_fingerprint=...)`` string in
+            :meth:`_preprocess_dataset`
+
+        Changing the format here keeps both in lockstep; no caller of this class
+        may hand-craft the suffix.
+        """
+        return f"_shard{shard_idx:04d}of{num_shards - 1:04d}"
+
+    @staticmethod
+    def build_part_arrow_path(
+        merged_cache_path: str, shard_idx: int, num_shards: int
+    ) -> str:
+        """Deterministic per-rank Arrow file path inside ``{merged_cache_path}.tmp``.
+
+        Single source of truth for the per-rank cache file layout. Called by:
+
+          * the writer (each rank's ``Dataset.map(cache_file_name=...)`` target
+            in :func:`flow_factory.data_utils.loader._create_or_load_dataset`)
+          * :meth:`consolidate_parts` (reconstructs every rank's path to build
+            the merged dataset's ``state.json``)
+
+        Layout::
+
+            {merged_cache_path}.tmp/_parts/rank_{X:04d}_of_{N:04d}/
+                cache-{basename}{_shard_suffix(X, N)}.arrow
+
+        Args:
+            merged_cache_path: Final merged-cache directory (without the
+                ``.tmp`` suffix). ``{merged_cache_path}.tmp`` is the build dir.
+            shard_idx: Shard index (``0 <= shard_idx < num_shards``).
+            num_shards: Total number of shards participating in preprocessing.
+
+        Returns:
+            Absolute path to this rank's Arrow file inside the build directory.
+        """
+        build_dir = merged_cache_path + ".tmp"
+        merged_fp = os.path.basename(merged_cache_path)
+        return os.path.join(
+            build_dir,
+            "_parts",
+            f"rank_{shard_idx:04d}_of_{num_shards:04d}",
+            f"cache-{merged_fp}{GeneralDataset._shard_suffix(shard_idx, num_shards)}.arrow",
+        )
+
     @classmethod
     def consolidate_parts(
         cls,
         merged_cache_path: str,
-        part_arrow_paths: List[str],
+        num_shards: int,
         split: Optional[str] = None,
     ) -> None:
         """Promote per-rank Arrow files into a valid HF dataset directory without copying data.
@@ -551,11 +602,15 @@ class GeneralDataset(Dataset):
         is re-serialized: each shard's bytes stay where ``Dataset.map(cache_file_name=...)``
         wrote them.
 
+        Paths of the ``num_shards`` per-rank Arrow files are derived via
+        :meth:`build_part_arrow_path`, so the writer and the consolidator cannot
+        drift.
+
         Args:
             merged_cache_path: Final destination directory. The function reads from
                 ``merged_cache_path + ".tmp"`` and renames it to this path on success.
-            part_arrow_paths: Absolute paths to every per-rank Arrow file inside
-                the build directory, in rank order. Listed in the produced
+            num_shards: Total number of per-rank Arrow files expected under the
+                build directory, in rank order. Listed in the produced
                 ``state.json`` as ``_data_files`` (relative to ``merged_cache_path``);
                 ``load_from_disk`` will memory-map them in this order.
             split: Optional split tag stored as ``state["_split"]`` (round-trips to
@@ -564,7 +619,7 @@ class GeneralDataset(Dataset):
         Raises:
             FileNotFoundError: If the build directory or any expected per-rank Arrow
                 file is missing. The message includes ``merged_cache_path`` and
-                ``num_parts`` to make distributed debugging tractable.
+                ``num_shards`` to make distributed debugging tractable.
         """
         build_dir = merged_cache_path + ".tmp"
         if not os.path.isdir(build_dir):
@@ -572,12 +627,16 @@ class GeneralDataset(Dataset):
                 f"expected build dir for consolidation, missing: {build_dir} "
                 f"(merged_cache_path={merged_cache_path})"
             )
+        part_arrow_paths = [
+            cls.build_part_arrow_path(merged_cache_path, i, num_shards)
+            for i in range(num_shards)
+        ]
         for p in part_arrow_paths:
             if not os.path.isfile(p):
                 raise FileNotFoundError(
                     f"expected per-rank arrow file, missing: {p} "
                     f"(merged_cache_path={merged_cache_path}, "
-                    f"num_parts={len(part_arrow_paths)})"
+                    f"num_shards={num_shards})"
                 )
 
         template = HFDataset.from_file(part_arrow_paths[0])

--- a/src/flow_factory/data_utils/dataset.py
+++ b/src/flow_factory/data_utils/dataset.py
@@ -256,6 +256,8 @@ class GeneralDataset(Dataset):
                 f"{os.path.basename(self.merged_cache_path)}"
                 f"{self._shard_suffix(self.shard_index, self.num_shards)}"
             )
+            # Display convention matches :meth:`_shard_suffix`: the second
+            # number is the last shard index (``num_shards - 1``), not the total.
             desc = (
                 f"[Preprocessing {self.split} dataset] "
                 f"Shard {self.shard_index:04d}/{self.num_shards - 1:04d}"
@@ -539,7 +541,16 @@ class GeneralDataset(Dataset):
 
     @staticmethod
     def _shard_suffix(shard_idx: int, num_shards: int) -> str:
-        """``_shard{X:04d}of{Y:04d}`` — per-rank suffix shared by:
+        """Per-rank suffix ``_shard{X:04d}of{Y:04d}`` where ``Y = num_shards - 1``.
+
+        IMPORTANT: ``Y`` is the *last* shard index (inclusive), **not** the
+        total shard count. The rank range covered is ``[0, Y]``, i.e.
+        ``num_shards`` ranks in total. Example::
+
+            _shard_suffix(shard_idx=0, num_shards=4) -> "_shard0000of0003"
+            _shard_suffix(shard_idx=3, num_shards=4) -> "_shard0003of0003"
+
+        Shared by:
 
           * the Arrow filename embedded in :meth:`build_part_arrow_path`
           * the HF ``Dataset.map(new_fingerprint=...)`` string in
@@ -570,13 +581,17 @@ class GeneralDataset(Dataset):
 
         Args:
             merged_cache_path: Final merged-cache directory (without the
-                ``.tmp`` suffix). ``{merged_cache_path}.tmp`` is the build dir.
+                ``.tmp`` suffix). A leading ``~`` is expanded internally; no
+                other normalization is applied, so the return value is
+                absolute iff ``merged_cache_path`` is absolute after
+                ``expanduser``. ``{merged_cache_path}.tmp`` is the build dir.
             shard_idx: Shard index (``0 <= shard_idx < num_shards``).
             num_shards: Total number of shards participating in preprocessing.
 
         Returns:
-            Absolute path to this rank's Arrow file inside the build directory.
+            Path to this rank's Arrow file inside the build directory.
         """
+        merged_cache_path = os.path.expanduser(merged_cache_path)
         build_dir = merged_cache_path + ".tmp"
         merged_fp = os.path.basename(merged_cache_path)
         return os.path.join(
@@ -609,6 +624,9 @@ class GeneralDataset(Dataset):
         Args:
             merged_cache_path: Final destination directory. The function reads from
                 ``merged_cache_path + ".tmp"`` and renames it to this path on success.
+                A leading ``~`` is expanded internally to keep ``build_dir`` and
+                :meth:`build_part_arrow_path` outputs on the same form (otherwise
+                ``os.path.relpath`` would cross forms and produce bogus prefixes).
             num_shards: Total number of per-rank Arrow files expected under the
                 build directory, in rank order. Listed in the produced
                 ``state.json`` as ``_data_files`` (relative to ``merged_cache_path``);
@@ -621,6 +639,7 @@ class GeneralDataset(Dataset):
                 file is missing. The message includes ``merged_cache_path`` and
                 ``num_shards`` to make distributed debugging tractable.
         """
+        merged_cache_path = os.path.expanduser(merged_cache_path)
         build_dir = merged_cache_path + ".tmp"
         if not os.path.isdir(build_dir):
             raise FileNotFoundError(

--- a/src/flow_factory/data_utils/loader.py
+++ b/src/flow_factory/data_utils/loader.py
@@ -114,8 +114,6 @@ def _create_or_load_dataset(
 
     shard_idx = kwargs["shard_index"]
     num_shards = kwargs["num_shards"]
-    merged_fp = os.path.basename(merged_cache_path)
-    shard_fp = f"{merged_fp}_shard{shard_idx}of{num_shards - 1}"
 
     build_dir = merged_cache_path + ".tmp"
     sentinel = os.path.join(build_dir, "_build_meta.json")
@@ -167,17 +165,16 @@ def _create_or_load_dataset(
 
     # 2. Per-rank Arrow file. Basename is byte-equivalent to today's HF auto-cache
     #    name; the rank_*_of_N subdir prevents cross-config collisions if a stale
-    #    .tmp directory survives a launch-config change between runs.
-    part_arrow_path = os.path.join(
-        build_dir,
-        "_parts",
-        f"rank_{shard_idx:05d}_of_{num_shards:05d}",
-        f"cache-{shard_fp}.arrow",
+    #    .tmp directory survives a launch-config change between runs. Layout is
+    #    owned by GeneralDataset so the writer and the consolidator cannot drift.
+    part_arrow_path = GeneralDataset.build_part_arrow_path(
+        merged_cache_path, shard_idx, num_shards
     )
     kwargs["target_arrow_path"] = part_arrow_path
 
     logger.info(
-        f"Preprocessing {split} dataset shard {shard_idx}/{num_shards - 1} -> {part_arrow_path}"
+        f"Preprocessing {split} dataset shard {shard_idx:04d}/{num_shards - 1:04d} "
+        f"-> {part_arrow_path}"
     )
     _ = GeneralDataset(split=split, **kwargs)
 
@@ -185,18 +182,11 @@ def _create_or_load_dataset(
         accelerator.wait_for_everyone()
 
     # 3. Consolidate: write top-level state.json + dataset_info.json (no row data
-    #    copied) and atomically rename .tmp -> merged_cache_path.
+    #    copied) and atomically rename .tmp -> merged_cache_path. A single call;
+    #    consolidate_parts iterates the per-rank layout itself via
+    #    GeneralDataset.build_part_arrow_path.
     if is_orchestrator:
-        all_parts = [
-            os.path.join(
-                build_dir,
-                "_parts",
-                f"rank_{i:05d}_of_{num_shards:05d}",
-                f"cache-{merged_fp}_shard{i}of{num_shards - 1}.arrow",
-            )
-            for i in range(num_shards)
-        ]
-        GeneralDataset.consolidate_parts(merged_cache_path, all_parts, split=split)
+        GeneralDataset.consolidate_parts(merged_cache_path, num_shards, split=split)
         mode_label = preprocess_parallelism if enable_distributed else "single"
         logger.info(
             f"[{mode_label}] Consolidated {num_shards} part(s) for {split} split "


### PR DESCRIPTION
## Summary

Unify the per-rank Arrow shard path under **two staticmethods on `GeneralDataset`** so the writer (`loader.py`), the consolidator (`consolidate_parts`), and the HF fingerprint string can never drift:

- `_shard_suffix(shard_idx, num_shards)` — owns the `_shard{X:04d}of{Y:04d}` suffix.
- `build_part_arrow_path(merged_cache_path, shard_idx, num_shards)` — owns the full `{merged_cache_path}.tmp/_parts/rank_{X:04d}_of_{N:04d}/cache-{basename}{_shard_suffix(X, N)}.arrow` layout.

`consolidate_parts` now takes `num_shards: int` and builds the per-rank paths internally, so the loader's orchestrator branch collapses to a single call.

## Motivation

Before this PR, three call sites independently spelled `rank_{X}_of_{N}` / `_shard{X}of{Y}`:

1. `loader.py` writer — built `part_arrow_path` inline.
2. `loader.py` orchestrator — rebuilt the same paths as an `all_parts` list-comp for `consolidate_parts`.
3. `dataset.py::_preprocess_dataset` — built `shard_fingerprint` + `desc` strings.

The writer used `:05d` for rank-dir zero-padding; the shard-number portion was unpadded; every change to the format had to touch all three sites in lockstep. A drift between the writer and the consolidator would silently produce a `FileNotFoundError` deep inside `consolidate_parts`.

## Changes

### `src/flow_factory/data_utils/dataset.py`

- **Add** two staticmethods: `_shard_suffix` and `build_part_arrow_path` — single source of truth for the shard format.
- **Simplify** `consolidate_parts` signature: `(merged_cache_path, num_shards, split=None)` (was `part_arrow_paths: List[str]`). Paths are now derived internally via `build_part_arrow_path`.
- **Route** `_preprocess_dataset`'s `shard_fingerprint` through `_shard_suffix`; pad the `desc` display (`X:04d/Y:04d`) inline.
- **Delete** unreferenced module-level constants `_MAX_FINGERPRINT_LEN` / `_SHARD_SUFFIX_RESERVE`.
- **Fail-fast narrowing**: raise `ValueError` at the top of the `num_shards > 1` branch when `shard_index is None`; also eliminates the pre-existing `Optional[int]` basedpyright lint on the `_shard_dataset` / `_shard_suffix` call sites.

### `src/flow_factory/data_utils/loader.py`

- Writer uses `GeneralDataset.build_part_arrow_path(...)`.
- Orchestrator uses the new 3-arg `GeneralDataset.consolidate_parts(merged_cache_path, num_shards, split=split)`.
- Delete intermediate `merged_fp` / `shard_fp` vars and the `all_parts` list comp.
- Pad the `logger.info` progress message with `:04d`.

### Zero-padding

`:05d` (rank directory only) → uniform `:04d` applied to every `{shard_idx}` / `{num_shards}` occurrence across filenames, logs, and display strings. `:04d` is a *minimum* width (Python will widen to 5 digits for the rare >9999-shard case). 10,000 shards is already an order of magnitude above any realistic preprocessing-parallelism bound.

## Diff summary

```
src/flow_factory/data_utils/dataset.py | 79 +++++++++++++++++++++++++++++-----
src/flow_factory/data_utils/loader.py  | 30 +++++--------
2 files changed, 79 insertions(+), 30 deletions(-)
```

## Verification

- `rg '_shard\{.*of' src/flow_factory/data_utils/` — matches only inside `_shard_suffix` (docstring + return value).
- `rg ':05d' src/flow_factory/data_utils/` — no matches.
- `rg 'consolidate_parts' src/` — exactly one caller (`loader.py`) with the new 3-arg signature, one definition.
- `rg 'merged_fp|shard_fp|all_parts' src/flow_factory/data_utils/loader.py` — no matches.
- Both files `ast.parse` cleanly.
- `ReadLints`: **9 errors** post-refactor vs **10 errors** baseline on `origin/main` (net -1). Zero new lints introduced; the fail-fast narrowing fixed one pre-existing `Optional[int]` warning.

## Risk / compatibility

- **Fresh runs** (cache dir empty or `force_reprocess=True`): zero risk; format is internally consistent end-to-end through the helpers.
- **Already-consolidated caches** under `merged_cache_path/` (built under the old `:05d` / unpadded format): zero risk. Their per-rank paths are baked into `state.json` at consolidation time and are **never re-derived** by the new code — `load_from_disk` just follows the stored relative paths.
- **Mid-preprocess `.tmp` directories** from before this change: one-time wasted compute on the next run (old `rank_{X:05d}_of_{N:05d}/` subdirs are orphaned; each rank re-preprocesses into the new layout). No data corruption. Optional mitigation: pass `force_reprocess=True` once or manually `rm -rf {cache}*.tmp`.
- **`consolidate_parts` signature change**: zero external risk — only one in-repo caller (`loader.py`) and no cross-module import (grep-verified).

## Test plan

- [ ] Fresh single-process preprocess (`num_shards=1`): produces merged cache, re-runs hit cache.
- [ ] Fresh multi-process preprocess (`num_shards>1`, `preprocess_parallelism="local"`): each rank writes its Arrow file, local main consolidates, subsequent runs load from merged cache.
- [ ] `preprocess_parallelism="global"` on a shared FS: rank 0 is the sole orchestrator; all ranks' Arrow files land under the `:04d`-padded rank dirs; consolidate succeeds.
- [ ] Pre-existing consolidated cache (built before this PR) still loads via `load_from_disk`.
- [ ] `num_shards > 1` with `shard_index=None` raises `ValueError` with the expected message.


Made with [Cursor](https://cursor.com)