### PR TITLE
[hparams] fix: promote DataArguments.cache_dir to a real field and warn on extras

### DIFF
--- a/src/flow_factory/data_utils/loader.py
+++ b/src/flow_factory/data_utils/loader.py
@@ -100,7 +100,7 @@ def _create_or_load_dataset(
     merged_cache_path = GeneralDataset.compute_cache_path(
         dataset_dir=kwargs["dataset_dir"],
         split=split,
-        cache_dir=kwargs.get("cache_dir", "~/.cache/flow_factory/datasets"),
+        cache_dir=kwargs["cache_dir"],
         max_dataset_size=kwargs.get("max_dataset_size"),
         preprocess_func=kwargs.get("preprocess_func"),
         preprocess_kwargs=kwargs.get("preprocess_kwargs"),

--- a/src/flow_factory/hparams/abc.py
+++ b/src/flow_factory/hparams/abc.py
@@ -18,6 +18,10 @@ from dataclasses import dataclass, field, fields, asdict
 from typing import Any, Dict
 from abc import ABC, abstractmethod
 
+from ..utils.logger_utils import setup_logger
+
+logger = setup_logger(__name__, rank_zero_only=True)
+
 
 @dataclass(kw_only=True)
 class ArgABC(ABC):
@@ -41,6 +45,14 @@ class ArgABC(ABC):
                 init_data[k] = v
             else:
                 extras[k] = v
+
+        if extras:
+            logger.warning(
+                f"{cls.__name__}.from_dict captured {len(extras)} unknown key(s) into extra_kwargs: "
+                f"{sorted(extras.keys())}. "
+                "Verify these are intentional (e.g., adapter-specific kwargs); "
+                "typos against declared fields will be silently accepted otherwise."
+            )
 
         # 2. If the class has an 'extra_kwargs' field, inject the leftovers there
         if "extra_kwargs" in field_names:

--- a/src/flow_factory/hparams/args.py
+++ b/src/flow_factory/hparams/args.py
@@ -363,6 +363,14 @@ class Arguments(ArgABC):
             else:
                 extras[k] = v
 
+        if extras:
+            logger.warning(
+                f"{cls.__name__}.from_dict captured {len(extras)} unknown top-level key(s) into extra_kwargs: "
+                f"{sorted(extras.keys())}. "
+                "Verify these are intentional (expected sections are "
+                f"{sorted(nested_map.keys())}); typos will be silently accepted otherwise."
+            )
+
         # 4. Handle explicit 'extra_kwargs' if present in YAML and merge
         if "extra_kwargs" in init_kwargs:
             extras.update(init_kwargs["extra_kwargs"])

--- a/src/flow_factory/hparams/args.py
+++ b/src/flow_factory/hparams/args.py
@@ -364,11 +364,14 @@ class Arguments(ArgABC):
                 extras[k] = v
 
         if extras:
+            expected_top_level_keys = sorted(
+                set(nested_map.keys()) | (valid_field_names - {"extra_kwargs"})
+            )
             logger.warning(
                 f"{cls.__name__}.from_dict captured {len(extras)} unknown top-level key(s) into extra_kwargs: "
                 f"{sorted(extras.keys())}. "
-                "Verify these are intentional (expected sections are "
-                f"{sorted(nested_map.keys())}); typos will be silently accepted otherwise."
+                "Verify these are intentional (expected top-level keys are "
+                f"{expected_top_level_keys}); typos will be silently accepted otherwise."
             )
 
         # 4. Handle explicit 'extra_kwargs' if present in YAML and merge

--- a/src/flow_factory/hparams/data_args.py
+++ b/src/flow_factory/hparams/data_args.py
@@ -26,6 +26,10 @@ class DataArguments(ArgABC):
         default="data",
         metadata={"help": "Path to the folder containing the datasets."},
     )
+    cache_dir: str = field(
+        default="~/.cache/flow_factory/datasets",
+        metadata={"help": "Directory for caching preprocessed datasets (fingerprinted by content hash)."},
+    )
     image_dir: Optional[str] = field(
         default=None,
         metadata={"help": "Path to the folder containing conditioning images. Defaults to 'images' subfolder in dataset_dir."},


### PR DESCRIPTION
## Summary

- **`DataArguments.cache_dir`** is now a first-class field instead of silently flowing through `extra_kwargs`. Every example YAML already sets it (46 configs) and `GeneralDataset` consumes it for cache-path computation, but it only worked by accident — `ArgABC.__getattr__` + `keys()` + a defensive `.get(..., DEFAULT)` in `loader.py` masked the missing declaration. Typos like `chache_dir` would silently fall back to the default cache directory with no signal.
- **`ArgABC.from_dict` / `Arguments.from_dict`** now emit a rank-0 `logger.warning` listing every key captured into `extra_kwargs`, with the class name (and, for the top level, the set of expected sections). YAML typos surface immediately instead of being absorbed.
- **`loader.py`** drops `kwargs.get("cache_dir", "~/.cache/flow_factory/datasets")` in favor of `kwargs["cache_dir"]`, so any future regression in the `data_args -> dataset` forwarding path fails fast instead of silently routing to the default cache directory (matches `.cursor/rules/no-defensive-except.mdc` and the project fail-fast rule).

### Why this is safe

- The new `cache_dir` field's default (`"~/.cache/flow_factory/datasets"`) matches the previous `loader.py` fallback and the `GeneralDataset.__init__` default — zero behavior change for any current config.
- All 46 example YAMLs already have `data.cache_dir`; they will now bind to the field instead of going through extras (same value).
- Warning uses `setup_logger(rank_zero_only=True)`, no per-rank log spam in distributed runs.
- `extra_kwargs` written explicitly under `extra_kwargs:` in YAML is still treated as intentional and does **not** trigger the warning (only silently captured top-level keys do).

### Files changed

- `src/flow_factory/hparams/data_args.py` — add `cache_dir` field
- `src/flow_factory/hparams/abc.py` — module-level `logger`, warn when `from_dict` captures unknown keys
- `src/flow_factory/hparams/args.py` — mirror the warning at the top-level `Arguments.from_dict`
- `src/flow_factory/data_utils/loader.py` — `kwargs.get(...)` → `kwargs["cache_dir"]`

## Test plan

- [ ] Dry-run any GRPO example (e.g. `examples/grpo/lora/flux1.yaml`); confirm:
  - no `DataArguments.from_dict captured ... ['cache_dir']` warning at startup (proves field-binding)
  - cache path still resolves to `~/.cache/flow_factory/datasets/<fingerprint>`
- [ ] Temporarily mistype to `chache_dir:` in a YAML; confirm a single rank-0 warning appears listing the typo'd key
- [ ] `grep -rn 'cache_dir' src/flow_factory` — no `kwargs.get("cache_dir", ...)` residue

Made with [Cursor](https://cursor.com)