### PR TITLE
[trainer,hparams,examples,docs] feat: add DGPO (Direct Group Preference Optimization) trainer

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -93,11 +93,13 @@ All three registries map string keys → lazy import paths. Resolution: registry
 ### Registered Components
 
 **Trainers** (`trainers/registry.py`):
+
 | Key | Class | Paradigm | Base Class |
 |-----|-------|----------|------------|
 | `grpo` | `GRPOTrainer` | Coupled | `BaseTrainer` |
 | `grpo-guard` | `GRPOGuardTrainer` | Coupled | `GRPOTrainer` |
 | `dpo` | `DPOTrainer` | Decoupled | `BaseTrainer` |
+| `dgpo` | `DGPOTrainer` | Decoupled | `BaseTrainer` |
 | `nft` | `DiffusionNFTTrainer` | Decoupled | `BaseTrainer` |
 | `awm` | `AWMTrainer` | Decoupled | `BaseTrainer` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Flow-Factory is a unified **online RL fine-tuning framework** for diffusion/flow-matching models. It provides a modular architecture where trainers, model adapters, and reward models are independently extensible via a registry-based plugin system.
 
-- **Algorithms**: GRPO, GRPO-Guard, DPO, DiffusionNFT, AWM
+- **Algorithms**: GRPO, GRPO-Guard, DPO, DGPO, DiffusionNFT, AWM
 - **Models**: FLUX.1/2, SD3.5, Wan2.1/2.2, Qwen-Image, Z-Image
 - **Rewards**: PickScore, CLIP, OCR, VLM-Evaluate, and custom rewards
 - **Python**: >=3.10 | **PyTorch**: >=2.6.0 | **License**: Apache-2.0
@@ -59,7 +59,7 @@ See `architecture.md` "Module Dependency Graph" for full details.
 | Document | Purpose |
 |----------|---------|
 | `guidance/workflow.md` | 6-stage training pipeline with code examples |
-| `guidance/algorithms.md` | GRPO, DiffusionNFT, AWM deep dive |
+| `guidance/algorithms.md` | GRPO, DiffusionNFT, DGPO, AWM deep dive |
 | `guidance/rewards.md` | Reward system design, custom model creation |
 | `guidance/new_model.md` | Step-by-step model adapter integration |
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This experimental feature leverages `diffusers`'s `transformer.set_attention_bac
 | GRPO-Guard     | grpo-guard     |
 | DiffusionNFT   | nft            |
 | AWM            | awm            |
+| DPO            | dpo            |
+| DGPO           | dgpo           |
 
 See [`Algorithm Guidance`](guidance/algorithms.md) for more information.
 
@@ -134,7 +136,7 @@ We provide a set of guidance documents to help you understand the framework and 
 | Document | Description |
 |---|---|
 | [Workflow](guidance/workflow.md) | End-to-end training pipeline: the overall stages from data preprocessing to policy optimization |
-| [Algorithms](guidance/algorithms.md) | Supported RL algorithms (GRPO, GRPO-Guard, DiffusionNFT, AWM) and their configurations |
+| [Algorithms](guidance/algorithms.md) | Supported RL algorithms (GRPO, GRPO-Guard, DiffusionNFT, AWM, DPO, DGPO) and their configurations |
 | [Rewards](guidance/rewards.md) | Reward model system: built-in models, custom rewards, and remote reward servers |
 | [New Model](guidance/new_model.md) | How to add support for a new Diffusion/Flow-Matching model |
 

--- a/examples/dgpo/lora/sd3_5.yaml
+++ b/examples/dgpo/lora/sd3_5.yaml
@@ -1,0 +1,159 @@
+# DGPO reproduction config for SD3.5-medium + PickScore.
+#
+# Direct port of the official `pickscore_sd3_4gpu` preset in the DGPO repo:
+#   https://github.com/Luo-Yihong/DGPO/blob/main/config/dgpo.py#L140
+# Values inherited from the `compressibility()` / `base.get_config()`
+# presets are noted in comments alongside the field they map to.
+#
+# The upstream preset is named "..._4gpu" and assumes 4 ranks. Its batch
+# geometry with the authors' recommended ``num_groups = 24`` (flagged in
+# the upstream config as "set to be 24 for better performance") is:
+#   num_batches_per_epoch
+#     = num_groups / (gpu_number * sample.train_batch_size / num_image_per_prompt)
+#     = 24        / (4          * 12                       / 24)
+#     = 12
+# Flow-Factory computes the same quantity as
+#   (unique_sample_num_per_epoch * group_size) / (world_size * per_device_batch_size)
+# so we keep `num_processes: 4` to preserve the authors' setup exactly.
+
+# Environment Configuration
+launcher: "accelerate"
+config_file: config/deepspeed/deepspeed_zero2.yaml
+num_processes: 4  # `pickscore_sd3_4gpu` assumes 4 ranks; adjust unique_sample_num_per_epoch if you change this.
+main_process_port: 29500
+mixed_precision: "bf16"  # base config: mixed_precision="bf16"
+
+log:
+  run_name: null
+  project: "Flow-Factory"
+  logging_backend: "wandb"
+  save_dir: "saves/"
+  save_freq: 60  # config.save_freq = 60 (epoch)
+  save_model_only: true
+
+# Data Configuration
+data:
+  dataset_dir: "dataset/pickscore"  # config.dataset = "dataset/pickscore"
+  preprocessing_batch_size: 16
+  dataloader_num_workers: 16
+  force_reprocess: false
+  cache_dir: "~/.cache/flow_factory/datasets"
+  sampler_type: "group_distributed"  # Required by DGPO; options: auto, distributed_k_repeat, group_contiguous, group_distributed
+
+# Model Configuration
+model:
+  finetune_type: 'lora'  # config.use_lora = True
+  lora_rank: 64           # LoraConfig(r=64)
+  lora_alpha: 128         # LoraConfig(lora_alpha=128)
+  target_modules: "default"
+  model_name_or_path: "stabilityai/stable-diffusion-3.5-medium"  # config.pretrained.model
+  model_type: "sd3-5"
+  resume_path: null
+  resume_type: null
+
+# Training Configuration
+train:
+  # Trainer settings
+  trainer_type: 'dgpo'
+  advantage_aggregation: 'sum'  # GRPO-style (reward - mean)/std, matches `per_prompt_stat_tracking=True` branch.
+
+  # ---------- DGPO core (compressibility base + pickscore override) ----------
+  dpo_beta: 10               # pickscore override: config.train.beta_dpo = 10
+  use_shared_noise: true     # compressibility base: config.use_shared_noise = True
+  clip_dsm: true             # compressibility base: config.clip_dsm = True
+  clip_kl: false             # compressibility base: config.clip_kl = False
+  switch_ema_ref: 200        # compressibility base: config.switch_ema_ref = 200
+  kl_cfg: 1.0                # base: config.kl_cfg = 1.0 (no CFG on the frozen ref)
+  use_ema_ref: false         # base: config.use_ema_ref = False (static pretrained ref)
+
+  # ---------- Sampling EMA (slow-tracking, for sampling/eval/save) ----------
+  # Original script: EMAModuleWrapper(decay=0.9, update_step_interval=8)
+  off_policy: false
+  ema_decay: 0.9
+  ema_decay_schedule: "constant"
+  ema_update_interval: 8
+  ema_device: "cuda"
+
+  # ---------- Old-policy EMA ref (fast-tracking, PPO-style clipping) ----------
+  # Original script: EMAModuleWrapper(decay=0.3, update_step_interval=1) with
+  # adaptive decay = min(0.3, 0.001 * global_step)
+  ema_ref_max_decay: 0.3
+  ema_ref_ramp_rate: 0.001
+  ema_ref_device: "cuda"
+
+  # ---------- Training Timestep distribution ----------
+  # Original: num_train_timesteps=4, trunc_steps=6 -> sampled from range(7)
+  # => train on 4 out of the 7 highest-noise timestep indices (skip the 3
+  # cleanest steps). Under `num_inference_steps=10`, indices [0..6] span
+  # timesteps with t >= 1000*(1-6/10) = 400, i.e. the top 60% of the 1000->0
+  # denoise axis. Flow-Factory's `timestep_range` is a closed interval
+  # [0, frac], so `timestep_range: 0.6` keeps timesteps in [400, 1000]:
+  num_train_timesteps: 4            # base: config.num_train_timesteps = 4
+  time_sampling_strategy: discrete  # integer-index broadcast semantics
+  time_shift: 3.0                   # base: config.flow_shift = 3
+  timestep_range: 0.6               # equivalent to trunc_steps=6 at num_inference_steps=10
+
+  # ---------- KL divergence ----------
+  kl_type: 'v-based'       # DGPO always uses v-based KL
+  kl_beta: 0.001           # pickscore override: config.train.beta = 0.001
+  ref_param_device: 'cuda'
+
+  # ---------- PPO-style Clipping ----------
+  clip_range: 5.0e-2       # compressibility base: config.clip_range = 5e-2
+  adv_clip_range: 5.0      # base: config.train.adv_clip_max = 5
+
+  # ---------- Sampling Settings ----------
+  resolution: 512          # pickscore override: config.resolution = 512
+  num_inference_steps: 10  # pickscore override: sample.num_steps = 10
+  guidance_scale: 4.5      # pickscore override: sample.guidance_scale = 4.5
+
+  # ---------- Batch and sampling geometry ----------
+  per_device_batch_size: 12         # pickscore override: sample.train_batch_size = 12
+  group_size: 24                    # pickscore override: sample.num_image_per_prompt = 24
+  global_std: true                  # pickscore override: sample.global_std = True
+  unique_sample_num_per_epoch: 24   # pickscore override: num_groups = 24 (author's recommended "better performance" setting; upstream baseline is 8)
+  gradient_step_per_epoch: 1        # => num_batches_per_epoch=12 gets all-accumulated once per epoch
+  num_inner_epochs: 1               # base: train.num_inner_epochs = 1
+
+  # ---------- Optimization (base config) ----------
+  learning_rate: 3.0e-4    # base: train.learning_rate = 3e-4
+  adam_weight_decay: 1.0e-4  # base: train.adam_weight_decay = 1e-4
+  adam_betas: [0.9, 0.999]   # base: train.adam_beta1/2
+  adam_epsilon: 1.0e-8       # base: train.adam_epsilon = 1e-8
+  max_grad_norm: 1.0         # base: train.max_grad_norm = 1.0
+
+  # ---------- Gradient Checkpointing ----------
+  enable_gradient_checkpointing: false
+
+  # Seed
+  seed: 42                 # base: config.seed = 42
+
+# Scheduler Configuration
+scheduler:
+  dynamics_type: "ODE"     # DGPO uses deterministic ODE (sample.noise_level=0)
+
+# Evaluation settings
+eval:
+  resolution: 512
+  per_device_batch_size: 16  # pickscore override: sample.test_batch_size = 16
+  guidance_scale: 4.5
+  num_inference_steps: 14    # pickscore override: sample.eval_num_steps = 14
+  eval_freq: 60              # config.eval_freq = 60
+  seed: 42
+
+# Reward Model Configuration
+rewards:
+  - name: "pickscore"        # config.reward_fn = {"pickscore": 1.0}
+    reward_model: "PickScore"
+    weight: 1.0
+    batch_size: 16
+    device: "cuda"
+    dtype: bfloat16
+
+# Optional Evaluation Reward Models
+eval_rewards:
+  - name: "pickscore"
+    reward_model: "PickScore"
+    batch_size: 32
+    device: "cuda"
+    dtype: bfloat16

--- a/examples/dgpo/lora/sd3_5_nocfg.yaml
+++ b/examples/dgpo/lora/sd3_5_nocfg.yaml
@@ -1,0 +1,150 @@
+# DGPO config for SD3.5-medium + PickScore — CFG-free variant.
+#
+# Identical to sd3_5.yaml (the official `pickscore_sd3_4gpu` reproduction)
+# except:
+#   train.guidance_scale: 4.5 → 1.0  (no classifier-free guidance during rollout)
+#   eval.guidance_scale:  4.5 → 1.0  (match training for consistent evaluation)
+#
+# Empirically converges faster than the CFG=4.5 baseline.
+
+# Environment Configuration
+launcher: "accelerate"
+config_file: config/deepspeed/deepspeed_zero2.yaml
+num_processes: 4  # `pickscore_sd3_4gpu` assumes 4 ranks; adjust unique_sample_num_per_epoch if you change this.
+main_process_port: 29500
+mixed_precision: "bf16"  # base config: mixed_precision="bf16"
+
+log:
+  run_name: null
+  project: "Flow-Factory"
+  logging_backend: "wandb"
+  save_dir: "saves/"
+  save_freq: 60  # config.save_freq = 60 (epoch)
+  save_model_only: true
+
+# Data Configuration
+data:
+  dataset_dir: "dataset/pickscore"  # config.dataset = "dataset/pickscore"
+  preprocessing_batch_size: 16
+  dataloader_num_workers: 16
+  force_reprocess: false
+  cache_dir: "~/.cache/flow_factory/datasets"
+  sampler_type: "group_distributed"  # Required by DGPO; options: auto, distributed_k_repeat, group_contiguous, group_distributed
+
+# Model Configuration
+model:
+  finetune_type: 'lora'  # config.use_lora = True
+  lora_rank: 64           # LoraConfig(r=64)
+  lora_alpha: 128         # LoraConfig(lora_alpha=128)
+  target_modules: "default"
+  model_name_or_path: "stabilityai/stable-diffusion-3.5-medium"  # config.pretrained.model
+  model_type: "sd3-5"
+  resume_path: null
+  resume_type: null
+
+# Training Configuration
+train:
+  # Trainer settings
+  trainer_type: 'dgpo'
+  advantage_aggregation: 'sum'  # GRPO-style (reward - mean)/std, matches `per_prompt_stat_tracking=True` branch.
+
+  # ---------- DGPO core (compressibility base + pickscore override) ----------
+  dpo_beta: 10               # pickscore override: config.train.beta_dpo = 10
+  use_shared_noise: true     # compressibility base: config.use_shared_noise = True
+  clip_dsm: true             # compressibility base: config.clip_dsm = True
+  clip_kl: false             # compressibility base: config.clip_kl = False
+  switch_ema_ref: 200        # compressibility base: config.switch_ema_ref = 200
+  kl_cfg: 1.0                # base: config.kl_cfg = 1.0 (no CFG on the frozen ref)
+  use_ema_ref: false         # base: config.use_ema_ref = False (static pretrained ref)
+
+  # ---------- Sampling EMA (slow-tracking, for sampling/eval/save) ----------
+  # Original script: EMAModuleWrapper(decay=0.9, update_step_interval=8)
+  off_policy: false
+  ema_decay: 0.9
+  ema_decay_schedule: "constant"
+  ema_update_interval: 8
+  ema_device: "cuda"
+
+  # ---------- Old-policy EMA ref (fast-tracking, PPO-style clipping) ----------
+  # Original script: EMAModuleWrapper(decay=0.3, update_step_interval=1) with
+  # adaptive decay = min(0.3, 0.001 * global_step)
+  ema_ref_max_decay: 0.3
+  ema_ref_ramp_rate: 0.001
+  ema_ref_device: "cuda"
+
+  # ---------- Training Timestep distribution ----------
+  # Original: num_train_timesteps=4, trunc_steps=6 -> sampled from range(7)
+  # => train on 4 out of the 7 highest-noise timestep indices (skip the 3
+  # cleanest steps). Under `num_inference_steps=10`, indices [0..6] span
+  # timesteps with t >= 1000*(1-6/10) = 400, i.e. the top 60% of the 1000->0
+  # denoise axis. Flow-Factory's `timestep_range` is a closed interval
+  # [0, frac], so `timestep_range: 0.6` keeps timesteps in [400, 1000]:
+  num_train_timesteps: 4            # base: config.num_train_timesteps = 4
+  time_sampling_strategy: discrete  # integer-index broadcast semantics
+  time_shift: 3.0                   # base: config.flow_shift = 3
+  timestep_range: 0.6               # equivalent to trunc_steps=6 at num_inference_steps=10
+
+  # ---------- KL divergence ----------
+  kl_type: 'v-based'       # DGPO always uses v-based KL
+  kl_beta: 0.001           # pickscore override: config.train.beta = 0.001
+  ref_param_device: 'cuda'
+
+  # ---------- PPO-style Clipping ----------
+  clip_range: 5.0e-2       # compressibility base: config.clip_range = 5e-2
+  adv_clip_range: 5.0      # base: config.train.adv_clip_max = 5
+
+  # ---------- Sampling Settings ----------
+  resolution: 512          # pickscore override: config.resolution = 512
+  num_inference_steps: 10  # pickscore override: sample.num_steps = 10
+  guidance_scale: 1.0      # CFG-free: faster convergence than the official 4.5
+
+  # ---------- Batch and sampling geometry ----------
+  per_device_batch_size: 12         # pickscore override: sample.train_batch_size = 12
+  group_size: 24                    # pickscore override: sample.num_image_per_prompt = 24
+  global_std: true                  # pickscore override: sample.global_std = True
+  unique_sample_num_per_epoch: 24   # pickscore override: num_groups = 24 (author's recommended "better performance" setting; upstream baseline is 8)
+  gradient_step_per_epoch: 1        # => num_batches_per_epoch=12 gets all-accumulated once per epoch
+  num_inner_epochs: 1               # base: train.num_inner_epochs = 1
+
+  # ---------- Optimization (base config) ----------
+  learning_rate: 3.0e-4    # base: train.learning_rate = 3e-4
+  adam_weight_decay: 1.0e-4  # base: train.adam_weight_decay = 1e-4
+  adam_betas: [0.9, 0.999]   # base: train.adam_beta1/2
+  adam_epsilon: 1.0e-8       # base: train.adam_epsilon = 1e-8
+  max_grad_norm: 1.0         # base: train.max_grad_norm = 1.0
+
+  # ---------- Gradient Checkpointing ----------
+  enable_gradient_checkpointing: false
+
+  # Seed
+  seed: 42                 # base: config.seed = 42
+
+# Scheduler Configuration
+scheduler:
+  dynamics_type: "ODE"     # DGPO uses deterministic ODE (sample.noise_level=0)
+
+# Evaluation settings
+eval:
+  resolution: 512
+  per_device_batch_size: 16  # pickscore override: sample.test_batch_size = 16
+  guidance_scale: 1.0        # match training (CFG-free)
+  num_inference_steps: 14    # pickscore override: sample.eval_num_steps = 14
+  eval_freq: 60              # config.eval_freq = 60
+  seed: 42
+
+# Reward Model Configuration
+rewards:
+  - name: "pickscore"        # config.reward_fn = {"pickscore": 1.0}
+    reward_model: "PickScore"
+    weight: 1.0
+    batch_size: 16
+    device: "cuda"
+    dtype: bfloat16
+
+# Optional Evaluation Reward Models
+eval_rewards:
+  - name: "pickscore"
+    reward_model: "PickScore"
+    batch_size: 32
+    device: "cuda"
+    dtype: bfloat16

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -13,7 +13,11 @@
      - [KL-loss](#kl-loss)
      - [GRPO-Guard](#grpo-guard)
 
+- [DPO](#dpo)
+
 - [DiffusionNFT](#diffusionnft)
+
+- [DGPO](#dgpo)
 
 - [AWM: Advantage Weighted Matching](#awm-advantage-weighted-matching)
 
@@ -26,7 +30,7 @@ Flow-Factory provides unified implementations of state-of-the-art RL algorithms 
 At a high level, the supported algorithms fall into two paradigms:
 
 - **Coupled paradigm (GRPO and variants)**: Training timesteps are coupled with the SDE-based sampling dynamics, requiring tractable log-probability computation for policy gradient optimization.
-- **Decoupled paradigm (DiffusionNFT, AWM)**: Training timesteps are decoupled from the actual sampling dynamics, making them inherently solver-agnostic — any ODE solver can be used for trajectory generation without modifying the training procedure.
+- **Decoupled paradigm (DPO, DiffusionNFT, AWM, DGPO)**: Training timesteps are decoupled from the actual sampling dynamics, making them inherently solver-agnostic — any ODE solver can be used for trajectory generation without modifying the training procedure.
 
 ## GRPO
 
@@ -73,7 +77,7 @@ train:
     dynamics_type: 'Flow-SDE' # Options are ['Flow-SDE', 'Dance-SDE', 'CPS', 'ODE'].
 ```
 
-> **Note**: `ODE` dynamics produce deterministic trajectories and cannot provide log-probability estimates. Therefore, `ODE` can only be used with decoupled algorithms such as `NFT` and `AWM`. See the [DiffusionNFT](#diffusionnft) and [AWM](#awm-advantage-weighted-matching) sections.
+> **Note**: `ODE` dynamics produce deterministic trajectories and cannot provide log-probability estimates. Therefore, `ODE` can only be used with decoupled algorithms such as `NFT`, `AWM`, and `DGPO`. See the [DiffusionNFT](#diffusionnft), [AWM](#awm-advantage-weighted-matching), and [DGPO](#dgpo) sections.
 
 
 ### Efficiency Strategies
@@ -149,6 +153,47 @@ train:
 ```
 > ‼️ **Note**: Currently, `grpo-guard` reweighting is only compatible with `Flow-GRPO` dynamics. Therefore, dynamics_type must be explicitly set to `Flow-SDE`.
 
+## DPO
+
+DPO (Direct Preference Optimization) [[11]](#ref11) is a **decoupled** algorithm that optimises a pairwise preference loss on flow-matching velocity targets. Instead of per-sample policy-gradient ratios, it forms chosen/rejected pairs within each group (based on per-sample advantages), then minimises a Bradley-Terry preference loss over the DSM errors of the two policies (current vs. frozen reference). To use this algorithm, set:
+
+```yaml
+train:
+    trainer_type: 'dpo'
+```
+
+### Core Parameters
+
+```yaml
+train:
+    beta: 2000.0              # DPO temperature; larger ⇒ sharper preference contrast.
+    ref_param_device: 'cuda'  # Device to store frozen reference parameters ('cpu' or 'cuda').
+```
+
+### Pair Formation & Advantage
+
+DPO forms chosen/rejected pairs at the **start** of `optimize()` after `prepare_feedback()` has stored per-sample advantages. The `advantage_aggregation` controls how multi-reward advantages are combined:
+
+```yaml
+train:
+    advantage_aggregation: 'gdpo'  # Options: 'sum', 'gdpo'. 'gdpo' normalizes each reward independently.
+    global_std: true               # Global std normalization across all samples (vs. per-prompt).
+```
+
+### Training Timestep Distribution
+
+```yaml
+train:
+    num_train_timesteps: 1              # Number of freshly sampled training timesteps per pair.
+    weighting_scheme: 'logit_normal'    # Options: 'logit_normal', 'uniform'.
+    logit_mean: 0.0                     # Mean for logit-normal sampling.
+    logit_std: 1.0                      # Std for logit-normal sampling.
+    time_shift: 1.0                     # Shift parameter (1.0 = no shift).
+    timestep_range: 0.99               # Float ⇒ (0, x); tuple ⇒ (lo, hi).
+```
+
+> **Note**: Like DiffusionNFT, AWM, and DGPO, DPO decouples training from sampling dynamics and is solver-agnostic — any ODE solver can be used for trajectory generation.
+
 ## DiffusionNFT
 
 This algorithm is introduced in [[7]](#ref7). Unlike GRPO, which couples sampling dynamics with training timesteps, **DiffusionNFT** decouples them entirely by optimizing a contrastive objective directly on the forward flow-matching process.
@@ -193,6 +238,85 @@ train:
 ```
 
 > **Tip**: The `piecewise_linear` schedule is recommended for DiffusionNFT. It starts with a lower decay rate to allow faster initial policy divergence and gradually increases the decay to stabilize later training. You can fine-tune this behavior with `flat_steps` and `ramp_rate`.
+
+## DGPO
+
+DGPO (Direct Group Preference Optimization) [[10]](#ref10) is a **decoupled** algorithm that optimises a group-level preference loss on flow-matching targets. Instead of per-sample PPO ratios, it aggregates each group's advantage-weighted DSM delta (current vs. reference) through a sigmoid and reweights every sample's DSM loss by the resulting per-group scalar. Training samples use `trajectory_indices=[-1]` and `compute_log_prob=False`; fresh timesteps are drawn from `TimeSampler` at each optimisation step. To use this algorithm, set:
+
+```yaml
+train:
+    trainer_type: 'dgpo'
+```
+
+Because the objective contrasts the current policy against a reference model, DGPO **always requires** a reference model (`requires_ref_model = True`).
+
+### Core Loss Coefficients
+
+```yaml
+train:
+    dpo_beta: 100.0           # DPO beta scaling for group preference; larger ⇒ sharper sigmoid weighting.
+    kl_type: 'v-based'        # DGPO only supports v-based KL (other values are auto-coerced with a warning).
+    kl_beta: 0.0              # KL penalty weight. 0 disables the KL term entirely.
+    kl_cfg: 1.0               # CFG scale applied to the frozen reference. >1 enables CFG on the KL reference branch.
+```
+
+### Shared RNG across Groups
+
+Cross-rank-deterministic sampling of both the training timesteps and the per-group noise (seeded from `(seed, epoch, inner_epoch, uid)`). The per-group noise is **timestep-invariant** — all training timesteps within an epoch share the same noise, matching the reference implementation. No `dist.broadcast` / RNG fork is used:
+
+```yaml
+train:
+    use_shared_noise: true    # Same noise for every sample within a group at each step.
+```
+
+### PPO-style Clipping and EMA Old Policy
+
+A fast-tracking EMA copy of the trainable parameters (`ema_ref`, distinct from the slow sampling EMA) acts as the "old policy" for PPO-style clipping on the DSM / KL losses:
+
+```yaml
+train:
+    clip_dsm: true            # Clip the DSM loss when the ratio exits clip_range.
+    clip_kl: false            # Optionally clip the KL loss using the same ratio mask.
+    clip_range: 1.0e-2        # PPO clip range (scalar is expanded to (-c, c)).
+    adv_clip_range: 5.0       # Advantage clipping range.
+    use_ema_ref: false        # If true, use ema_ref (not the frozen ref) as the DGPO loss reference (TDM-R1 dynamic ref).
+
+    ema_ref_max_decay: 0.3    # Cap of the adaptive decay.
+    ema_ref_ramp_rate: 1.0e-3 # Adaptive decay = min(ema_ref_max_decay, ema_ref_ramp_rate * step).
+    ema_ref_device: 'cuda'    # Where ema_ref parameters live.
+```
+
+`clip_dsm`, `clip_kl`, or `use_ema_ref` being enabled triggers the creation and per-step update of `ema_ref`; otherwise no fast EMA is maintained.
+
+### Sampling Policy Switch
+
+```yaml
+train:
+    off_policy: false         # If true, use the slow sampling EMA for trajectory generation from step 0.
+    switch_ema_ref: 200       # After this many optimizer steps, swap to ema_ref (fast EMA) for sampling.
+```
+
+### Training Timestep Distribution
+
+```yaml
+train:
+    num_train_timesteps: 0    # 0 ⇒ int(num_inference_steps * (timestep_range[1] - timestep_range[0])).
+    time_sampling_strategy: 'discrete'  # Options: discrete, discrete_with_init, discrete_wo_init, uniform, logit_normal.
+    time_shift: 3.0           # Shift for logit_normal / uniform strategies.
+    timestep_range: 0.6       # Float ⇒ (0, x); tuple ⇒ (lo, hi) along the 1000→0 denoise axis.
+```
+
+> **Note**: DGPO feeds scheduler-scale timesteps (`[0, 1000]`) into `flow_match_sigma` before constructing `x_t = (1 - σ) x_0 + σ ε`. Training directly on unscaled timesteps would drive reward downward — the σ-scaling is mandatory for correct flow-matching behaviour.
+
+### Group Completeness
+
+DGPO's group-level sigmoid reweighting is only meaningful if every optimizer step sees a **complete group** (all `K = group_size` copies of each prompt). Flow-Factory guarantees this by requiring `GroupDistributedSampler` for DGPO (auto-forced by `Arguments._resolve_sampler_type`).
+
+**How it works**: `GroupDistributedSampler` yields the same prompt-index sequence on every rank; each prompt appears `K / W` times per rank (`W` = `num_replicas`). Since all ranks see the same prompts, local `torch.unique` produces a cross-rank-consistent dense group-id space — no `gather_samples` or cross-rank id coordination is needed. The single `accelerator.reduce` inside `_compute_group_dgpo_loss` sums partial per-rank contributions to recover the full-group sigmoid weight.
+
+**Geometric constraint**: `(num_replicas × per_device_batch_size) % group_size == 0` must hold so that every global micro-batch packs an integer number of complete groups. `Arguments._align_for_group_distributed` auto-adjusts `group_size` (and then `unique_sample_num_per_epoch`) at init time to satisfy this, so no manual tuning is needed.
+
+For a complete runnable setup, see `examples/dgpo/lora/sd3_5.yaml`.
 
 ## AWM: Advantage Weighted Matching
 
@@ -263,3 +387,5 @@ Here $\varepsilon$ is a small constant for numerical stability and $p$ denotes `
 * <a name="ref7"></a>[7] [**DiffusionNFT**: Online Diffusion Reinforcement with Forward Process](https://arxiv.org/abs/2509.16117)
 * <a name="ref8"></a>[8] [**<u>C</u>oefficients-<u>P</u>reserving <u>S</u>ampling** for Reinforcement Learning with Flow Matching](https://arxiv.org/abs/2509.05952)
 * <a name="ref9"></a>[9] [**<u>A</u>dvantage <u>W</u>eighted <u>M</u>atching**: Aligning RL with Pretraining in Diffusion Models](https://arxiv.org/abs/2509.25050)
+* <a name="ref10"></a>[10] [**DGPO**: Reinforcing Diffusion Models by Direct Group Preference Optimization](https://arxiv.org/abs/2510.08425)
+* <a name="ref11"></a>[11] [**Diffusion-DPO**: Diffusion Model Alignment Using Direct Preference Optimization](https://arxiv.org/abs/2311.12908)

--- a/guidance/workflow.md
+++ b/guidance/workflow.md
@@ -217,12 +217,13 @@ BaseSample(
 | **GRPO** | `True` | Only train timesteps | Needs log-prob for policy ratio; selective storage saves memory. |
 | **DiffusionNFT** | `False` | `[-1]` (final only) | Only needs final clean latent $x_1$; log-prob not required |
 | **AWM** | `False` | `[-1]` (final only) | Same as NFT; log-prob computed later during optimization |
+| **DGPO** | `False` | `[-1]` (final only) | Same trajectory policy as NFT/AWM; optimization uses fresh `TimeSampler` timesteps |
 
 ### Key Points
 
 - **Selective trajectory recording**: `trajectory_indices` controls which denoising steps are stored. For GRPO, only steps corresponding to `train_timesteps` are kept to reduce memory.
-- **SDE dynamics for exploration**: GRPO injects noise during sampling via SDE formulation, enabling the log-probability computation required for policy gradients. NFT and AWM use standard ODE solvers.
-- **Off-policy sampling**: NFT optionally use EMA parameters for sampling (`off_policy: true`), while the current policy is optimized — stabilizing training.
+- **SDE dynamics for exploration**: GRPO injects noise during sampling via SDE formulation, enabling the log-probability computation required for policy gradients. NFT, AWM, and DGPO use decoupled sampling (typically ODE) with `compute_log_prob=False`.
+- **Off-policy sampling**: NFT optionally uses EMA parameters for sampling (`off_policy: true`), while the current policy is optimized — stabilizing training.
 
 
 ## Stage 4: Reward Computation
@@ -395,6 +396,7 @@ def optimize(self, samples):
 | **GRPO-Guard** | Same as GRPO but with timestep-dependent loss reweighting to mitigate ratio bias |
 | **DiffusionNFT** | Samples fresh timesteps; interpolates $x_t = (1-t)x_1 + t\epsilon$; contrastive objective with normalized rewards |
 | **AWM** | Samples fresh timesteps; weights velocity matching loss by advantage; PPO clipping + EMA-KL regularization |
+| **DGPO** | Samples fresh timesteps via `TimeSampler`; applies group-level preference objective with optional PPO clipping and EMA-reference KL |
 | **DPO** | Preference loss on chosen/rejected pairs; pairs formed at the start of `optimize` after advantages |
 
 ### Key Points
@@ -402,7 +404,7 @@ def optimize(self, samples):
 - **Inner epochs**: Samples can be reused for multiple optimization passes (`num_inner_epochs`), amortizing the cost of sampling.
 - **Gradient accumulation**: The `accelerator.accumulate()` context handles gradient accumulation across timesteps and micro-batches, with optimizer steps only at sync boundaries.
 - **KL regularization**: Optional penalty keeping the policy close to a reference model (or EMA model for AWM), preventing reward hacking.
-- **Per-timestep iteration**: GRPO iterates over each stored trajectory timestep, computing loss at each. NFT and AWM sample fresh timesteps independently of the sampling trajectory.
+- **Per-timestep iteration**: GRPO iterates over each stored trajectory timestep, computing loss at each. NFT, AWM, and DGPO sample fresh timesteps independently of the sampling trajectory.
 
 
 ## Putting It All Together

--- a/src/flow_factory/data_utils/sampler.py
+++ b/src/flow_factory/data_utils/sampler.py
@@ -14,13 +14,25 @@
 
 # src/flow_factory/data_utils/sampler.py
 import math
+from typing import Sized, cast
+
 import torch
-from torch.utils.data import Sampler, Dataset, DataLoader
-import logging
+from torch.utils.data import Dataset, Sampler
 
 from ..utils.logger_utils import setup_logger
 
 logger = setup_logger(__name__, rank_zero_only=True)
+
+
+def _dataset_size(dataset: Dataset) -> int:
+    if not hasattr(dataset, "__len__"):
+        raise TypeError(
+            "Sampler requires dataset with __len__, "
+            f"got {type(dataset).__name__}."
+        )
+    return len(cast(Sized, dataset))
+
+
 class DistributedKRepeatSampler(Sampler):
     """
     """
@@ -33,8 +45,11 @@ class DistributedKRepeatSampler(Sampler):
         self.seed = seed              # Random seed for synchronization
         self.m = unique_sample_num                    # `Least` number of unique sample per epoch
         
-        if unique_sample_num > len(self.dataset):
-            raise ValueError(f"`unique_sample_num` ({unique_sample_num}) must be <= dataset size ({len(self.dataset)}).")
+        dataset_size = _dataset_size(self.dataset)
+        if unique_sample_num > dataset_size:
+            raise ValueError(
+                f"`unique_sample_num` ({unique_sample_num}) must be <= dataset size ({dataset_size})."
+            )
         
         # Compute the number of samples for each batch iteration
         self.sample_num_per_iteration = self.num_replicas * self.batch_size
@@ -55,7 +70,7 @@ class DistributedKRepeatSampler(Sampler):
             g.manual_seed(self.seed + self.epoch)
             
             # Randomly select m unique samples, less if dataset is smaller than m
-            indices = torch.randperm(len(self.dataset), generator=g)[:self.m].tolist()
+            indices = torch.randperm(_dataset_size(self.dataset), generator=g)[:self.m].tolist()
 
             # Repeat each sample k times to generate m*k total samples.
             repeated_indices = [idx for idx in indices for _ in range(self.k)]
@@ -97,8 +112,11 @@ class GroupContiguousSampler(Sampler):
         self.seed = seed
         self.m = unique_sample_num
 
-        if unique_sample_num > len(self.dataset):
-            raise ValueError(f"`unique_sample_num` ({unique_sample_num}) must be <= dataset size ({len(self.dataset)}).")
+        dataset_size = _dataset_size(self.dataset)
+        if unique_sample_num > dataset_size:
+            raise ValueError(
+                f"`unique_sample_num` ({unique_sample_num}) must be <= dataset size ({dataset_size})."
+            )
 
         if self.m % self.num_replicas != 0:
             raise ValueError(
@@ -123,7 +141,7 @@ class GroupContiguousSampler(Sampler):
             g = torch.Generator()
             g.manual_seed(self.seed + self.epoch)
 
-            indices = torch.randperm(len(self.dataset), generator=g)[:self.m].tolist()
+            indices = torch.randperm(_dataset_size(self.dataset), generator=g)[:self.m].tolist()
 
             # Shuffle group order (all ranks see the same permutation)
             group_perm = torch.randperm(self.m, generator=g).tolist()
@@ -136,6 +154,123 @@ class GroupContiguousSampler(Sampler):
             # Expand: each group index repeated k times, groups stay contiguous
             my_samples = [gidx for gidx in my_groups for _ in range(self.k)]
 
+            for i in range(self.num_batches_per_epoch):
+                yield my_samples[i * self.batch_size : (i + 1) * self.batch_size]
+
+            self.epoch += 1
+
+    def set_epoch(self, epoch: int):
+        self.epoch = epoch
+
+
+class GroupDistributedSampler(Sampler):
+    """Distributed sampler that splits each group evenly across ranks.
+
+    Unlike :class:`GroupContiguousSampler` (all ``K`` copies on one rank),
+    this sampler assigns ``group_size / num_replicas`` copies of every
+    selected group to each rank, so the concatenation of one local
+    micro-batch from every rank is **group-complete**: every selected group
+    appears exactly ``K`` times across the ``W * B`` samples of the global
+    micro-batch.
+
+    Rank contract (public invariant — DGPO depends on this)
+    -------------------------------------------------------
+    Every rank yields the **same prompt-index sequence**: the per-rank
+    iterator does not stripe by ``rank``.  Each prompt id appears exactly
+    ``K / W`` times on each rank, so
+
+        local_uids (rank 0) == local_uids (rank 1) == ... == local_uids (rank W-1)
+
+    holds byte-for-byte on every micro-batch.  Rollout divergence between
+    ranks therefore comes from the **per-rank generation RNG** inside
+    ``adapter.inference`` (same prompt → different latent on each rank),
+    not from the dataset index itself.
+
+    Callers that rely on this (:class:`DGPOTrainer` in particular) use a
+    local ``torch.unique(local_uids, sorted=True)`` to derive a
+    cross-rank-consistent dense group-id space with **no collective**;
+    changing this sampler to stripe prompts across ranks would silently
+    break that invariant.
+
+    Constraints
+    -----------
+    - ``group_size % num_replicas == 0``: each rank gets an integer number
+      of copies per group.
+    - ``(num_replicas * batch_size) % group_size == 0``: exact global
+      micro-batch tiling.
+
+    Both are pre-aligned by
+    :meth:`flow_factory.hparams.Arguments._align_for_group_distributed` so
+    end users don't need to hand-tune them.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        batch_size: int,
+        group_size: int,
+        unique_sample_num: int,
+        num_replicas: int,
+        rank: int,
+        seed: int = 0,
+    ):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.k = group_size
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.seed = seed
+        self.m = unique_sample_num
+
+        dataset_size = _dataset_size(self.dataset)
+        if unique_sample_num > dataset_size:
+            raise ValueError(
+                f"`unique_sample_num` ({unique_sample_num}) must be <= dataset size ({dataset_size})."
+            )
+
+        # Geometric constraints — pre-aligned by
+        # ``Arguments._align_for_group_distributed``; assert here as
+        # belt-and-suspenders.
+        assert self.k % self.num_replicas == 0, (
+            "GroupDistributedSampler requires `group_size % num_replicas == 0`, "
+            f"got group_size={self.k}, num_replicas={self.num_replicas}. "
+            "Arguments._align_for_group_distributed should have enforced this."
+        )
+        sample_num_per_iteration = self.num_replicas * self.batch_size
+        assert sample_num_per_iteration % self.k == 0, (
+            "GroupDistributedSampler requires `(num_replicas * batch_size) % group_size == 0`, "
+            f"got {self.num_replicas} * {self.batch_size} = {sample_num_per_iteration}, "
+            f"group_size={self.k}. "
+            "Arguments._align_for_group_distributed should have enforced this."
+        )
+
+        self.copies_per_rank = self.k // self.num_replicas
+        samples_per_rank = self.m * self.copies_per_rank
+        assert samples_per_rank % self.batch_size == 0, (
+            "GroupDistributedSampler requires local samples per rank divisible by batch_size, "
+            f"got samples_per_rank={samples_per_rank}, batch_size={self.batch_size}. "
+            "Arguments._align_for_group_distributed should have enforced this."
+        )
+
+        self.num_batches_per_epoch = samples_per_rank // self.batch_size
+        self.epoch = 0
+
+    def __iter__(self):
+        while True:
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+
+            indices = torch.randperm(_dataset_size(self.dataset), generator=g)[:self.m].tolist()
+            group_perm = torch.randperm(self.m, generator=g).tolist()
+            shuffled_groups = [indices[i] for i in group_perm]
+
+            # Every rank sees the same group order; each rank takes an equal
+            # number of copies per group so global batches are group-complete.
+            my_samples = [
+                group_idx
+                for group_idx in shuffled_groups
+                for _ in range(self.copies_per_rank)
+            ]
             for i in range(self.num_batches_per_epoch):
                 yield my_samples[i * self.batch_size : (i + 1) * self.batch_size]
 

--- a/src/flow_factory/data_utils/sampler_loader.py
+++ b/src/flow_factory/data_utils/sampler_loader.py
@@ -16,8 +16,18 @@
 from torch.utils.data import Sampler, Dataset
 from accelerate import Accelerator
 
-from .sampler import DistributedKRepeatSampler, GroupContiguousSampler
+from .sampler import (
+    DistributedKRepeatSampler,
+    GroupContiguousSampler,
+    GroupDistributedSampler,
+)
 from ..hparams import Arguments
+
+SAMPLER_REGISTRY = {
+    "distributed_k_repeat": DistributedKRepeatSampler,
+    "group_contiguous": GroupContiguousSampler,
+    "group_distributed": GroupDistributedSampler,
+}
 
 
 def get_data_sampler(
@@ -35,15 +45,18 @@ def get_data_sampler(
     Returns:
         - GroupContiguousSampler when resolved type is ``"group_contiguous"``
           (keeps each group's samples on the same rank)
+        - GroupDistributedSampler when resolved type is ``"group_distributed"``
+          (split each group evenly across ranks)
         - DistributedKRepeatSampler when resolved type is ``"distributed_k_repeat"``
           (default behavior)
     """
     training_args = config.training_args
-    sampler_cls = (
-        GroupContiguousSampler
-        if config.data_args.sampler_type == "group_contiguous"
-        else DistributedKRepeatSampler
-    )
+    sampler_type = config.data_args.sampler_type
+    sampler_cls = SAMPLER_REGISTRY.get(sampler_type)
+    if sampler_cls is None:
+        raise ValueError(
+            f"Unknown sampler_type={sampler_type!r}. Expected one of {sorted(SAMPLER_REGISTRY)}."
+        )
     return sampler_cls(
         dataset=dataset,
         batch_size=training_args.per_device_batch_size,

--- a/src/flow_factory/hparams/__init__.py
+++ b/src/flow_factory/hparams/__init__.py
@@ -24,6 +24,7 @@ from .training_args import (
     GRPOTrainingArguments,
     NFTTrainingArguments,
     AWMTrainingArguments,
+    DGPOTrainingArguments,
     DPOTrainingArguments,
     get_training_args_class,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "GRPOTrainingArguments",
     "NFTTrainingArguments",
     "AWMTrainingArguments",
+    "DGPOTrainingArguments",
     "DPOTrainingArguments",
     "get_training_args_class",
     "RewardArguments",

--- a/src/flow_factory/hparams/args.py
+++ b/src/flow_factory/hparams/args.py
@@ -116,8 +116,10 @@ class Arguments(ArgABC):
         ``AdvantageProcessor``) read a concrete choice — never ``"auto"``.
 
         Rules:
-        - Explicit user choice is respected, unless ``distributed_k_repeat``
-          conflicts with async rewards (hard override to ``group_contiguous``).
+        - DGPO is always forced to ``group_distributed``.
+        - For non-DGPO trainers, explicit user choice is respected, unless
+          ``distributed_k_repeat`` / ``group_distributed`` conflicts with async
+          rewards (hard override to ``group_contiguous``).
         - ``"auto"`` prefers ``group_contiguous`` (minimal communication) and
           falls back to ``distributed_k_repeat`` only when the stricter
           geometric constraints cannot be satisfied without padding
@@ -135,18 +137,24 @@ class Arguments(ArgABC):
         ta = self.training_args
         user_choice = self.data_args.sampler_type
 
-        if user_choice == "distributed_k_repeat" and self._has_async_rewards:
+        trainer_type = str(ta.trainer_type).lower()
+
+        if (
+            user_choice in {"distributed_k_repeat", "group_distributed"}
+            and self._has_async_rewards
+            and trainer_type != "dgpo"
+        ):
             # Hard override to `group_contiguous` for async rewards
             # In fact, only group-wise async rewards require `group_contiguous` sampler
             # For pointwise async rewards, distributed_k_repeat is still valid
             # but for simplicity, we enforce `group_contiguous` for all async rewards
             logger.warning(
                 "Async rewards require 'group_contiguous' sampler. "
-                "Overriding 'distributed_k_repeat' → 'group_contiguous'."
+                f"Overriding '{user_choice}' → 'group_contiguous'."
             )
             self.data_args.sampler_type = "group_contiguous"
         
-        if user_choice == "auto":
+        if user_choice == "auto" and trainer_type != "dgpo":
             # auto: prefer `group_contiguous` (all K copies on same rank → no cross-rank all-gather for rewards/advantages),
             # fall back to `distributed_k_repeat` (all K copies scattered across ranks → cross-rank all-gather for rewards/advantages)
             # There are two geometric constraints:
@@ -166,100 +174,222 @@ class Arguments(ArgABC):
                 # and later `_align_batch_geometry()` will adjust `unique_sample_num_per_epoch` to satisfy the geometric constraints above.
                 self.data_args.sampler_type = "group_contiguous"
 
+        if trainer_type == "dgpo" and self.data_args.sampler_type != "group_distributed":
+            logger.warning(
+                "DGPO requires sampler_type='group_distributed'. "
+                f"Overriding '{self.data_args.sampler_type}' -> 'group_distributed'."
+            )
+            self.data_args.sampler_type = "group_distributed"
+
 
     def _align_batch_geometry(self) -> None:
-        """Align ``unique_sample_num_per_epoch`` to sampler constraints and
-        recompute derived batch quantities.
+        """Align ``unique_sample_num_per_epoch`` (and, for ``group_distributed``,
+        ``group_size``) to sampler constraints, then recompute derived batch
+        quantities.
 
         Must run after ``_resolve_sampler_type()`` so the sampler choice is
-        finalised.  Overwrites the placeholder values set in
+        finalised.  Overwrites placeholder values set in
         ``TrainingArguments.__post_init__``.
 
-        Alignment strategy
-        ------------------
-        - ``distributed_k_repeat``: GCD-based rounding so
-          ``unique_sample_num_per_epoch * group_size ≡ 0
-          (mod num_replicas * per_device_batch_size [* gradient_step_per_epoch])``.
-        - ``group_contiguous``: LCM-based rounding so
-          ``unique_sample_num_per_epoch ≡ 0 (mod num_replicas)`` **and** the
-          base constraint above.
+        Each sampler enforces slightly different divisibility constraints on
+        ``unique_sample_num_per_epoch * group_size`` vs.
+        ``num_replicas * per_device_batch_size`` (and, optionally,
+        ``gradient_step_per_epoch``); the actual logic lives in the
+        per-sampler helpers below.  This method only dispatches to the right
+        one and then updates derived quantities (``num_batches_per_epoch`` +
+        ``gradient_accumulation_steps``).
+        """
+        sampler_type = self.data_args.sampler_type
+        if sampler_type == "distributed_k_repeat":
+            self._align_for_distributed_k_repeat()
+        elif sampler_type == "group_contiguous":
+            self._align_for_group_contiguous()
+        elif sampler_type == "group_distributed":
+            self._align_for_group_distributed()
+        else:
+            raise ValueError(
+                f"Unknown sampler_type={sampler_type!r}; "
+                "expected one of {'distributed_k_repeat', 'group_contiguous', 'group_distributed'}."
+            )
+        self._recompute_derived_batch_quantities()
 
-        When ``gradient_accumulation_steps`` is manually set (not ``"auto"``),
-        ``gradient_step_per_epoch`` is excluded from the alignment divisor
-        because only the sampler constraint (``M*K % (W*B) == 0``) matters.
+    # ---------------------------------------------------------------------
+    # Shared alignment primitives (used by the three per-sampler helpers).
+    # ---------------------------------------------------------------------
+    @staticmethod
+    def _round_up_to_step(value: int, step: int) -> int:
+        """Smallest multiple of ``step`` that is ``>= value``."""
+        return ((value + step - 1) // step) * step
 
-        Derived quantities
-        ------------------
-        - ``num_batches_per_epoch = unique_sample_num_per_epoch * group_size
-          / (num_replicas * per_device_batch_size)``
-        - ``gradient_accumulation_steps`` (auto mode only) =
-          ``compute_gradient_accumulation_steps(num_batches_per_epoch)``
+    def _base_unique_sample_step(self) -> int:
+        """Minimum alignment step for ``unique_sample_num_per_epoch``.
+
+        Ensures::
+
+            unique_sample_num_per_epoch * group_size
+                ≡ 0  (mod  num_replicas * per_device_batch_size [* gradient_step_per_epoch])
+
+        i.e. ``unique_sample_num_per_epoch`` must be a multiple of::
+
+            (num_replicas * per_device_batch_size [* gradient_step_per_epoch])
+            / gcd(group_size, num_replicas * per_device_batch_size)
+
+        This same base step powers all three samplers; ``group_contiguous``
+        further ``lcm``-s it with ``num_replicas``.
+        """
+        ta = self.training_args
+        sample_num_per_iteration = get_world_size() * ta.per_device_batch_size
+        base = sample_num_per_iteration // math.gcd(ta.group_size, sample_num_per_iteration)
+        if not ta._manual_gradient_accumulation_steps:
+            base *= ta.gradient_step_per_epoch
+        return base
+
+    def _warn_and_assign_unique_sample_num(
+        self,
+        new_unique_sample_num: int,
+        sampler_name: str,
+        extra_line: str = "",
+    ) -> None:
+        """Emit a standardised "adjusted unique_sample_num_per_epoch" warning
+        and assign the new value.
+
+        ``extra_line`` lets a caller prepend a sampler-specific constraint line
+        (e.g. ``group_contiguous``'s ``unique_sample_num_per_epoch %
+        num_replicas == 0`` requirement) above the shared constraint
+        description.
         """
         ta = self.training_args
         world_size = get_world_size()
-        sample_num_per_iteration = world_size * ta.per_device_batch_size
-        manual = ta._manual_gradient_accumulation_steps
+        constraint_suffix = (
+            f" * gradient_step_per_epoch({ta.gradient_step_per_epoch}))"
+            if not ta._manual_gradient_accumulation_steps
+            else ")"
+        )
+        prefix = f"{extra_line}\n  " if extra_line else "  "
+        logger.warning(
+            f"{sampler_name}: adjusted `unique_sample_num_per_epoch` "
+            f"from {ta.unique_sample_num_per_epoch} to {new_unique_sample_num} to satisfy:\n"
+            f"{prefix}unique_sample_num_per_epoch({new_unique_sample_num}) "
+            f"* group_size({ta.group_size}) "
+            f"% (num_replicas({world_size}) "
+            f"* per_device_batch_size({ta.per_device_batch_size})"
+            + constraint_suffix
+            + " == 0"
+        )
+        ta.unique_sample_num_per_epoch = new_unique_sample_num
 
-        # ---- Compute alignment step ----
-        if manual:
-            # Only sampler constraint: M*K ≡ 0 (mod W*B)
-            base_step = sample_num_per_iteration // math.gcd(
-                ta.group_size, sample_num_per_iteration
-            )
-        else:
-            # Full constraint: M*K ≡ 0 (mod W*B*G)
-            base_step = (
-                sample_num_per_iteration * ta.gradient_step_per_epoch
-            ) // math.gcd(ta.group_size, sample_num_per_iteration)
+    def _recompute_derived_batch_quantities(self) -> None:
+        """Recompute ``num_batches_per_epoch`` and (in ``auto`` grad-accum
+        mode) ``gradient_accumulation_steps`` from the now-aligned
+        ``(unique_sample_num_per_epoch, group_size)`` pair.
 
-        if self.data_args.sampler_type == "group_contiguous":
-            step = math.lcm(base_step, world_size)
-        else:
-            step = base_step
-
-        # ---- Adjust M ----
-        new_m = (ta.unique_sample_num_per_epoch + step - 1) // step * step
-        if new_m != ta.unique_sample_num_per_epoch:
-            constraint_suffix = (
-                f" * gradient_step_per_epoch({ta.gradient_step_per_epoch}))"
-                if not manual
-                else ")"
-            )
-            if self.data_args.sampler_type == "group_contiguous":
-                logger.warning(
-                    f"GroupContiguousSampler: adjusted `unique_sample_num_per_epoch` "
-                    f"from {ta.unique_sample_num_per_epoch} to {new_m} to satisfy:\n"
-                    f"  1) unique_sample_num_per_epoch({new_m}) "
-                    f"% num_replicas({world_size}) == 0\n"
-                    f"  2) unique_sample_num_per_epoch({new_m}) "
-                    f"* group_size({ta.group_size}) "
-                    f"% (num_replicas({world_size}) "
-                    f"* per_device_batch_size({ta.per_device_batch_size})"
-                    + constraint_suffix
-                    + " == 0"
-                )
-            else:
-                logger.warning(
-                    f"DistributedKRepeatSampler: adjusted `unique_sample_num_per_epoch` "
-                    f"from {ta.unique_sample_num_per_epoch} to {new_m} to satisfy:\n"
-                    f"  unique_sample_num_per_epoch({new_m}) "
-                    f"* group_size({ta.group_size}) "
-                    f"% (num_replicas({world_size}) "
-                    f"* per_device_batch_size({ta.per_device_batch_size})"
-                    + constraint_suffix
-                    + " == 0"
-                )
-            ta.unique_sample_num_per_epoch = new_m
-
-        # ---- Update derived quantities ----
+        Called by the dispatcher after any per-sampler alignment; each of
+        the three helpers thus only needs to adjust the inputs, not the
+        outputs.
+        """
+        ta = self.training_args
+        sample_num_per_iteration = get_world_size() * ta.per_device_batch_size
         ta.num_batches_per_epoch = (
             (ta.unique_sample_num_per_epoch * ta.group_size)
             // sample_num_per_iteration
         )
-        if not manual:
+        if not ta._manual_gradient_accumulation_steps:
             ta.gradient_accumulation_steps = ta.compute_gradient_accumulation_steps(
                 ta.num_batches_per_epoch,
             )
+
+    # ---------------------------------------------------------------------
+    # Per-sampler alignment (identical shape: adjust inputs, then unique_sample_num).
+    # ---------------------------------------------------------------------
+    def _align_for_distributed_k_repeat(self) -> None:
+        """``DistributedKRepeatSampler``: only the base
+        ``unique_sample_num_per_epoch * group_size`` divisibility constraint.
+        """
+        ta = self.training_args
+        step = self._base_unique_sample_step()
+        new_unique_sample_num = self._round_up_to_step(ta.unique_sample_num_per_epoch, step)
+        if new_unique_sample_num != ta.unique_sample_num_per_epoch:
+            self._warn_and_assign_unique_sample_num(new_unique_sample_num, "DistributedKRepeatSampler")
+
+    def _align_for_group_contiguous(self) -> None:
+        """``GroupContiguousSampler``: base constraint + ``unique_sample_num_per_epoch % num_replicas == 0``."""
+        ta = self.training_args
+        world_size = get_world_size()
+        step = math.lcm(self._base_unique_sample_step(), world_size)
+        new_unique_sample_num = self._round_up_to_step(ta.unique_sample_num_per_epoch, step)
+        if new_unique_sample_num != ta.unique_sample_num_per_epoch:
+            extra_line = (
+                f"  1) unique_sample_num_per_epoch({new_unique_sample_num}) "
+                f"% num_replicas({world_size}) == 0\n  2)"
+            )
+            self._warn_and_assign_unique_sample_num(
+                new_unique_sample_num, "GroupContiguousSampler", extra_line,
+            )
+
+    def _align_for_group_distributed(self) -> None:
+        """``GroupDistributedSampler``: first align ``group_size`` so that
+        ``group_size % num_replicas == 0`` **and**
+        ``(num_replicas * per_device_batch_size) % group_size == 0``; then
+        do the base ``unique_sample_num_per_epoch`` alignment with the
+        (possibly bumped) ``group_size``.
+
+        **group_size alignment** — any valid ``group_size`` has the form
+        ``num_replicas * d`` where ``d`` is a divisor of
+        ``per_device_batch_size``, so we enumerate divisors of
+        ``per_device_batch_size`` in O(√per_device_batch_size) and pick the
+        smallest ``d`` with ``d >= ceil(group_size / num_replicas)``.
+        When ``group_size > num_replicas * per_device_batch_size`` no
+        solution exists.
+        """
+        ta = self.training_args
+        if ta.group_size <= 0:
+            raise ValueError(f"group_size must be positive, got {ta.group_size}.")
+
+        world_size = get_world_size()
+        per_device_batch_size = ta.per_device_batch_size
+        sample_num_per_iteration = world_size * per_device_batch_size
+        original_group_size = ta.group_size
+
+        if original_group_size > sample_num_per_iteration:
+            raise ValueError(
+                "sampler_type='group_distributed' requires "
+                "`group_size <= num_replicas * per_device_batch_size`; "
+                f"got group_size={original_group_size}, "
+                f"num_replicas * per_device_batch_size={sample_num_per_iteration}."
+            )
+
+        # Smallest new group_size = num_replicas * d  where
+        # d divides per_device_batch_size  and  d >= ceil(group_size / num_replicas).
+        min_copies_per_rank = -(-original_group_size // world_size)  # ceil division
+        best_copies_per_rank = per_device_batch_size                 # fallback (always valid)
+        i = 1
+        while i * i <= per_device_batch_size:
+            if per_device_batch_size % i == 0:
+                for d in (i, per_device_batch_size // i):
+                    if min_copies_per_rank <= d < best_copies_per_rank:
+                        best_copies_per_rank = d
+            i += 1
+        new_group_size = world_size * best_copies_per_rank
+
+        if new_group_size != original_group_size:
+            logger.warning(
+                "sampler_type='group_distributed' requires `group_size %% num_replicas == 0` "
+                "and `(num_replicas * per_device_batch_size) %% group_size == 0`; "
+                "auto-adjusting group_size from %d to %d "
+                "(num_replicas=%d, per_device_batch_size=%d).",
+                original_group_size,
+                new_group_size,
+                world_size,
+                per_device_batch_size,
+            )
+            ta.group_size = new_group_size
+
+        # Now do the shared unique_sample_num_per_epoch alignment with the aligned group_size.
+        step = self._base_unique_sample_step()
+        new_unique_sample_num = self._round_up_to_step(ta.unique_sample_num_per_epoch, step)
+        if new_unique_sample_num != ta.unique_sample_num_per_epoch:
+            self._warn_and_assign_unique_sample_num(new_unique_sample_num, "GroupDistributedSampler")
+
 
     def _adjust_gradient_accumulation(self) -> None:
         """Adjust gradient accumulation for per-timestep losses.

--- a/src/flow_factory/hparams/data_args.py
+++ b/src/flow_factory/hparams/data_args.py
@@ -73,7 +73,12 @@ class DataArguments(ArgABC):
             )
         },
     )
-    sampler_type: Literal["auto", "distributed_k_repeat", "group_contiguous"] = field(
+    sampler_type: Literal[
+        "auto",
+        "distributed_k_repeat",
+        "group_contiguous",
+        "group_distributed",
+    ] = field(
         default="auto",
         metadata={
             "help": (
@@ -84,7 +89,10 @@ class DataArguments(ArgABC):
                 "'distributed_k_repeat': shuffle K copies globally across ranks "
                 "(fewer constraints, extra all-gather communication). "
                 "'group_contiguous': keep all K copies of each group on the same rank "
-                "(requires unique_sample_num divisible by world_size)."
+                "(requires unique_sample_num divisible by world_size). "
+                "'group_distributed': split each group evenly across ranks "
+                "(requires group_size divisible by world_size and exact global batch tiling). "
+                "For DGPO trainer, sampler_type is always resolved to 'group_distributed'."
             )
         },
     )

--- a/src/flow_factory/hparams/training_args.py
+++ b/src/flow_factory/hparams/training_args.py
@@ -687,6 +687,96 @@ class DPOTrainingArguments(TrainingArguments):
         return self.num_train_timesteps
 
 
+@dataclass
+class DGPOTrainingArguments(GRPOTrainingArguments):
+    r"""Training arguments for DGPO (Direct Group Preference Optimization).
+
+    Extends GRPO with group-level DPO loss, shared noise, DSM clipping,
+    and per-timestep training controls.
+    """
+
+    # DGPO core
+    dpo_beta: float = field(
+        default=100.0,
+        metadata={"help": "DPO beta for group preference scaling."},
+    )
+    use_shared_noise: bool = field(
+        default=True,
+        metadata={"help": "Whether to share noise across samples within the same group."},
+    )
+    clip_dsm: bool = field(
+        default=True,
+        metadata={"help": "Whether to apply PPO-style DSM clipping using EMA old-policy predictions."},
+    )
+    clip_kl: bool = field(
+        default=False,
+        metadata={"help": "Whether to apply PPO-style clipping to the KL loss using the same ratio-based mask."},
+    )
+    switch_ema_ref: int = field(
+        default=200,
+        metadata={"help": "After this many optimizer steps, use EMA parameters for sampling instead of current params."},
+    )
+    off_policy: bool = field(
+        default=False,
+        metadata={"help": "Whether to use EMA parameters for sampling from the start (off-policy)."},
+    )
+    kl_cfg: float = field(
+        default=1.0,
+        metadata={"help": "CFG scale for reference model predictions. >1.0 enables CFG on the frozen ref model."},
+    )
+    use_ema_ref: bool = field(
+        default=False,
+        metadata={"help": "Use EMA (old policy) as DGPO loss reference instead of frozen pretrained. Dynamic ref from TDM-R1."},
+    )
+
+    # Old-policy EMA ref (ema_ref) — a fast-tracking EMA separate from the sampling EMA
+    ema_ref_max_decay: float = field(
+        default=0.3,
+        metadata={"help": "Maximum decay for old-policy EMA ref. Actual decay is min(ema_ref_max_decay, ema_ref_ramp_rate * step)."},
+    )
+    ema_ref_ramp_rate: float = field(
+        default=0.001,
+        metadata={"help": "Linear ramp rate for old-policy EMA ref decay. decay(step) = min(max_decay, ramp_rate * step)."},
+    )
+    ema_ref_device: Literal["cpu", "cuda"] = field(
+        default='cuda',
+        metadata={"help": "Device for old-policy EMA ref parameters ('cuda' or 'cpu')."},
+    )
+
+    # Timestep control
+    num_train_timesteps: int = field(
+        default=0,
+        metadata={"help": "Number of training timesteps per sample. 0 defaults to `int(num_inference_steps * (timestep_range[1] - timestep_range[0]))`."},
+    )
+    time_sampling_strategy: Literal['uniform', 'logit_normal', 'discrete', 'discrete_with_init', 'discrete_wo_init'] = field(
+        default='discrete',
+        metadata={"help": "Strategy for sampling training timesteps."},
+    )
+    time_shift: float = field(
+        default=3.0,
+        metadata={"help": "Shift parameter for logit-normal timestep sampling."},
+    )
+    timestep_range: Union[float, Tuple[float, float]] = field(
+        default=0.6,
+        metadata={"help": "Timestep range for discrete sampling. Float for [0, value], tuple for [start, end]."},
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.timestep_range = _standardize_timestep_range(self.timestep_range)
+        if not self.num_train_timesteps or self.num_train_timesteps <= 0:
+            self.num_train_timesteps = max(1, int(self.num_inference_steps * (self.timestep_range[1] - self.timestep_range[0])))
+
+    def get_num_train_timesteps(self, args: Any) -> int:
+        assert self.num_train_timesteps is not None
+        return self.num_train_timesteps
+
+    @property
+    def requires_ref_model(self) -> bool:
+        """DGPO always requires a reference model for the group DPO loss."""
+        return True
+
+
 # ============================================================================
 # Training Arguments Registry
 # ============================================================================
@@ -696,6 +786,7 @@ _TRAINING_ARGS_REGISTRY: Dict[str, Type[TrainingArguments]] = {
     'grpo-guard': GRPOTrainingArguments,
     'nft': NFTTrainingArguments,
     'awm': AWMTrainingArguments,
+    'dgpo': DGPOTrainingArguments,
     'dpo': DPOTrainingArguments,
 }
 

--- a/src/flow_factory/trainers/dgpo.py
+++ b/src/flow_factory/trainers/dgpo.py
@@ -1,0 +1,1024 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# src/flow_factory/trainers/dgpo.py
+"""
+DGPO (Direct Group Preference Optimization) Trainer.
+
+Reference:
+[1] DGPO: Reinforcing Diffusion Models by Direct Group Preference Optimization
+    - ICLR 2026
+"""
+
+import os
+from collections import defaultdict
+from contextlib import contextmanager
+from functools import partial
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, TypedDict, Union
+
+import numpy as np
+import torch
+import tqdm as tqdm_
+
+from diffusers.utils.torch_utils import randn_tensor
+
+tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
+
+from ..hparams import DGPOTrainingArguments
+from ..samples import BaseSample
+from ..utils.base import (
+    create_generator,
+    create_generator_by_prompt,
+    filter_kwargs,
+    to_broadcast_tensor,
+)
+from ..utils.dist import reduce_loss_info
+from ..utils.logger_utils import setup_logger
+from ..utils.noise_schedule import TimeSampler, flow_match_sigma
+from .abc import BaseTrainer
+
+logger = setup_logger(__name__)
+
+# Seed-namespace tags — appended to ``create_generator(...)`` integer keys so
+# independent RNG streams (shared timesteps / shared per-group noise) never
+# collide even if the other keys happen to coincide.  Independent (non-shared)
+# training noise uses the global default RNG and is not seeded.
+_SEED_TAG_SHARED_TIMESTEPS = 1
+_SEED_TAG_SHARED_NOISE = 2
+
+
+class DGPOGroupInfo(TypedDict):
+    """Per-minibatch group labels for scatter-add in :meth:`_compute_group_dgpo_loss`."""
+
+    local_group_indices: torch.Tensor
+    num_groups: int
+
+
+class _PreppedBatch(TypedDict):
+    """Unpacked view of one entry from ``training_batches``.
+
+    Created once per ``tb`` by :meth:`DGPOTrainer._prep_training_batch` to
+    avoid repeating the same six-field unpack on every timestep inside
+    :meth:`DGPOTrainer._optimize_step`.
+    """
+
+    batch: Dict[str, Any]
+    clean_latents: torch.Tensor
+    adv: torch.Tensor
+    group_info: DGPOGroupInfo
+    timesteps: torch.Tensor
+    samples_slice: List[BaseSample]
+    inner_epoch: int
+
+
+class _NoisedInputs(TypedDict):
+    """``(t_flat, noised, target_v)`` for a single ``(prepped_batch, t_idx)`` pair."""
+
+    t_flat: torch.Tensor
+    noised: torch.Tensor
+    target_v: torch.Tensor
+
+
+class _VelocityPredictions(TypedDict):
+    """Output bundle of :meth:`DGPOTrainer._forward_velocities`.
+
+    ``model_v`` carries autograd; ``old_v`` / ``ref_v`` / ``ref_dgpo_v`` are
+    detached.  ``old_v`` and ``ref_v`` are computed on demand (``None`` when
+    the corresponding feature — clipping / KL / ``use_ema_ref`` — is off);
+    ``ref_dgpo_v`` is always set (aliased to ``old_v`` if
+    ``use_ema_ref=True`` and to ``ref_v`` otherwise).
+    """
+
+    model_v: torch.Tensor
+    old_v: Optional[torch.Tensor]
+    ref_v: Optional[torch.Tensor]
+    ref_dgpo_v: torch.Tensor
+
+
+class DGPOTrainer(BaseTrainer):
+    """DGPO Trainer: Direct Group Preference Optimization for diffusion models.
+
+    Uses a group-level DPO loss instead of per-sample PPO ratio loss.
+    Partitions samples into groups by prompt, computes DSM losses vs a frozen
+    reference model, aggregates group-level preference signals via sigmoid,
+    and applies PPO-style DSM clipping using an EMA "old policy".
+
+    Cross-rank determinism is achieved via ``create_generator`` (``utils.base``)
+    — every random draw is seeded from an explicit integer tuple so all ranks
+    produce byte-identical shared timesteps and per-group noise without any
+    ``dist.broadcast``/``torch.random.fork_rng`` side effects.
+
+    Reference: [1] DGPO: Reinforcing Diffusion Models by Direct Group Preference Optimization (ICLR 2026).
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        ta: DGPOTrainingArguments = self.training_args  # type: ignore[assignment]
+        self.training_args = ta
+
+        # DGPO is only valid under GroupDistributedSampler — `hparams.Arguments.
+        # _resolve_sampler_type` hard-forces this.  This assert is a
+        # belt-and-suspenders guard against future code paths bypassing hparams.
+        assert self.config.data_args.sampler_type == "group_distributed", (
+            "DGPOTrainer requires sampler_type='group_distributed'; "
+            "hparams.Arguments._resolve_sampler_type should have enforced this, "
+            f"got sampler_type={self.config.data_args.sampler_type!r}."
+        )
+
+        # DGPO core
+        self.dpo_beta = ta.dpo_beta
+        self.use_shared_noise = ta.use_shared_noise
+        self.clip_dsm = ta.clip_dsm
+        self.clip_kl = ta.clip_kl
+        self.switch_ema_ref = ta.switch_ema_ref
+        self.kl_cfg = ta.kl_cfg
+        self.use_ema_ref = ta.use_ema_ref
+
+        # Timestep sampling
+        self.off_policy = ta.off_policy
+        self.time_sampling_strategy = ta.time_sampling_strategy
+        self.time_shift = ta.time_shift
+        self.num_train_timesteps = ta.num_train_timesteps
+        self.timestep_range = ta.timestep_range
+
+        # KL regularisation
+        self.kl_beta = ta.kl_beta
+        self.kl_type = ta.kl_type
+        if self.kl_type != "v-based":
+            logger.warning(
+                f"DGPOTrainer only supports 'v-based' KL loss (got {self.kl_type!r}); "
+                "switching to 'v-based'."
+            )
+            self.kl_type = "v-based"
+
+        # Old-policy EMA ref (fast-tracking EMA separate from sampling EMA)
+        self.ema_ref_max_decay = ta.ema_ref_max_decay
+        self.ema_ref_ramp_rate = ta.ema_ref_ramp_rate
+        self._requires_ema_ref = self.clip_dsm or self.clip_kl or self.use_ema_ref
+        if self._requires_ema_ref:
+            ema_ref_device = (
+                self.accelerator.device if ta.ema_ref_device == "cuda" else torch.device("cpu")
+            )
+            self.adapter.add_named_parameters(
+                "ema_ref",
+                device=ema_ref_device,
+                overwrite=True,
+            )
+            logger.info(
+                f"Initialized old-policy EMA ref on {ema_ref_device} "
+                f"(max_decay={self.ema_ref_max_decay}, ramp_rate={self.ema_ref_ramp_rate})."
+            )
+
+    # =========================== Properties ============================
+    @property
+    def enable_kl_loss(self) -> bool:
+        """Whether the v-based KL penalty is active."""
+        return self.kl_beta > 0.0
+
+    # =========================== Parameter-swap Contexts ============================
+    @contextmanager
+    def sampling_context(self):
+        """Swap to the appropriate parameters during sampling.
+
+        Mirrors the reference DGPO (``global_step > switch_ema_ref``): once
+        warmup is done we sample under the fast-tracking ``ema_ref``; before
+        that either keep current parameters or use the slow sampling EMA if
+        ``off_policy=True``.
+        """
+        if self.step > self.switch_ema_ref and self._requires_ema_ref:
+            with self.adapter.use_named_parameters("ema_ref"):
+                yield
+        elif self.off_policy:
+            with self.adapter.use_ema_parameters():
+                yield
+        else:
+            yield
+
+    @contextmanager
+    def _ema_ref_forward_context(self):
+        """Swap to ``ema_ref`` for the old-policy forward pass.
+
+        Only called when :attr:`_requires_ema_ref` is ``True``; there is no
+        fallback — the caller must gate the call itself.
+        """
+        with self.adapter.use_named_parameters("ema_ref"):
+            yield
+
+    # =========================== EMA-ref Update ============================
+    def _update_ema_ref(self, step: int) -> None:
+        """Update the old-policy EMA ref with adaptive decay.
+
+        Reproduces the reference DGPO per-step update::
+
+            decay       = min(max_decay, ramp_rate * step)
+            ema_ref_new = decay * ema_ref_old + (1 - decay) * current
+        """
+        if not self._requires_ema_ref:
+            return
+
+        decay = min(self.ema_ref_max_decay, self.ema_ref_ramp_rate * step)
+        one_minus_decay = 1.0 - decay
+
+        ema_params = self.adapter.get_named_parameters("ema_ref")
+        current_params = self.adapter.get_trainable_parameters()
+
+        with torch.no_grad():
+            for ema_p, cur_p in zip(ema_params, current_params, strict=True):
+                ema_p.mul_(decay).add_(cur_p.detach().to(ema_p.device), alpha=one_minus_decay)
+
+    # =========================== Timestep Sampling ============================
+    def _sample_timesteps(
+        self,
+        batch_size: int,
+        generator: Optional[torch.Generator] = None,
+    ) -> torch.Tensor:
+        """Sample scheduler-scale training timesteps ``[0, 1000]``.
+
+        Args:
+            batch_size: Size of the broadcast batch dimension.
+            generator: Optional ``torch.Generator``. When supplied, the draw is
+                deterministic and cross-rank-reproducible for any strategy;
+                threaded straight through to :class:`TimeSampler`.
+
+        Returns:
+            Tensor of shape ``(num_train_timesteps, batch_size)``.
+        """
+        device = self.accelerator.device
+        strategy = self.time_sampling_strategy.lower()
+        available = [
+            "logit_normal",
+            "uniform",
+            "discrete",
+            "discrete_with_init",
+            "discrete_wo_init",
+        ]
+
+        if strategy == "logit_normal":
+            return TimeSampler.logit_normal_shifted(
+                batch_size=batch_size,
+                num_timesteps=self.num_train_timesteps,
+                timestep_range=self.timestep_range,
+                time_shift=self.time_shift,
+                device=device,
+                stratified=True,
+                generator=generator,
+            )
+        if strategy == "uniform":
+            return TimeSampler.uniform(
+                batch_size=batch_size,
+                num_timesteps=self.num_train_timesteps,
+                timestep_range=self.timestep_range,
+                time_shift=self.time_shift,
+                device=device,
+                generator=generator,
+            )
+        if strategy.startswith("discrete"):
+            discrete_config = {
+                "discrete": (True, False),
+                "discrete_with_init": (True, True),
+                "discrete_wo_init": (False, False),
+            }
+            if strategy not in discrete_config:
+                raise ValueError(
+                    f"Unknown time_sampling_strategy: {strategy!r}. Available: {available}"
+                )
+            include_init, force_init = discrete_config[strategy]
+            return TimeSampler.discrete(
+                batch_size=batch_size,
+                num_train_timesteps=self.num_train_timesteps,
+                scheduler_timesteps=self.adapter.scheduler.timesteps,
+                timestep_range=self.timestep_range,
+                include_init=include_init,
+                force_init=force_init,
+                generator=generator,
+            )
+
+        raise ValueError(f"Unknown time_sampling_strategy: {strategy!r}. Available: {available}")
+
+    def _sample_shared_timesteps(self, inner_epoch: int) -> torch.Tensor:
+        """Sample ``num_train_timesteps`` scheduler-scale timesteps, identical on all ranks.
+
+        All ranks call :func:`create_generator` with the same integer tuple
+        ``(seed, epoch, inner_epoch, tag)`` and hand the resulting generator
+        to :class:`TimeSampler` — no broadcast, no global-RNG fork, and any
+        configured ``time_sampling_strategy`` (continuous or discrete) works.
+
+        Returns:
+            Tensor of shape ``(num_train_timesteps,)`` in scheduler scale
+            ``[0, 1000]``.
+        """
+        gen = create_generator(
+            self.training_args.seed,
+            self.epoch,
+            inner_epoch,
+            _SEED_TAG_SHARED_TIMESTEPS,
+        )
+        return self._sample_timesteps(batch_size=1, generator=gen).squeeze(-1)
+
+    # =========================== Forward Pass ============================
+    def _compute_dgpo_output(
+        self,
+        batch: Dict[str, Any],
+        timestep: torch.Tensor,
+        noised_latents: torch.Tensor,
+        guidance_scale: float,
+    ) -> torch.Tensor:
+        """Run the adapter for DGPO at a single timestep.
+
+        Args:
+            batch: Stacked batch dict (must contain at least prompt embeddings).
+            timestep: ``(B,)`` timestep in scheduler scale ``[0, 1000]``.
+            noised_latents: ``x_t`` for the current sample.
+            guidance_scale: CFG scale; use ``1.0`` for the uncond branch.
+
+        Returns:
+            Tensor ``(B, C, ...)``: the velocity prediction ``noise_pred``.
+        """
+        t = timestep.view(-1)
+        forward_kwargs = {
+            **self.training_args,
+            "t": t,
+            "t_next": torch.zeros_like(t),
+            "latents": noised_latents,
+            "compute_log_prob": False,
+            "return_kwargs": ["noise_pred"],
+            "noise_level": 0.0,
+            "guidance_scale": guidance_scale,
+            **{
+                k: v for k, v in batch.items() if k not in ("all_latents", "timesteps", "advantage")
+            },
+        }
+        forward_kwargs = filter_kwargs(self.adapter.forward, **forward_kwargs)
+        noise_pred = self.adapter.forward(**forward_kwargs).noise_pred
+        assert noise_pred is not None, (
+            "adapter.forward must return `noise_pred` for DGPO "
+            "(ensure 'noise_pred' is in `return_kwargs`)"
+        )
+        return noise_pred
+
+    # =========================== Group Bookkeeping ============================
+    def _precompute_group_info(
+        self,
+        samples: List[BaseSample],
+    ) -> DGPOGroupInfo:
+        """Return ``local_group_indices`` + ``num_groups`` for a micro-batch.
+
+        Derives a dense group id space from ``torch.unique`` on the
+        micro-batch's ``unique_id`` values.
+
+        Cross-rank consistency relies on the
+        :class:`GroupDistributedSampler` contract: every rank yields the
+        same prompt-index sequence per micro-batch, so ``local_uids`` is
+        byte-identical on every rank and ``torch.unique(sorted=True)``
+        produces the same dense ``0..L-1`` mapping.  That in turn makes
+        the ``scatter_add`` + ``accelerator.reduce`` in
+        :meth:`_compute_group_dgpo_loss` operate on a consistent group-id
+        space without any cross-rank coordination on the id assignment.
+        """
+        device = self.accelerator.device
+        local_uids = torch.as_tensor(
+            [int(s.unique_id) for s in samples],
+            dtype=torch.int64,
+            device=device,
+        )
+        _, inverse = torch.unique(local_uids, return_inverse=True)
+        return {
+            "local_group_indices": inverse,
+            "num_groups": int(inverse.max().item()) + 1,
+        }
+
+    # =========================== Noise Construction ============================
+    def _make_shared_noise(
+        self,
+        x0: torch.Tensor,
+        samples: List[BaseSample],
+        inner_epoch: int,
+    ) -> torch.Tensor:
+        """Per-``unique_id`` shared noise on the same device as ``x0``.
+
+        Uses one ``torch.Generator`` per unique group; because the generator
+        is seeded deterministically from ``(seed, epoch, inner_epoch, uid)``
+        and lives on ``x0.device``, we avoid any CPU→GPU copy and produce
+        byte-identical noise across ranks for the same ``unique_id``.
+
+        The noise is **timestep-invariant** — all training timesteps within
+        an epoch share the same per-group noise, matching the reference
+        DGPO implementation.
+        """
+        device, dtype = x0.device, x0.dtype
+        per_sample_shape = x0.shape[1:]
+
+        group_cache: Dict[int, torch.Tensor] = {}
+        noises: List[torch.Tensor] = []
+        for sample in samples:
+            uid = int(sample.unique_id)
+            noise = group_cache.get(uid)
+            if noise is None:
+                gen = create_generator(
+                    self.training_args.seed,
+                    self.epoch,
+                    inner_epoch,
+                    int(uid),
+                    _SEED_TAG_SHARED_NOISE,
+                    device=device,
+                )
+                noise = randn_tensor(
+                    per_sample_shape,
+                    generator=gen,
+                    device=device,
+                    dtype=dtype,
+                )
+                group_cache[uid] = noise
+            noises.append(noise)
+        return torch.stack(noises, dim=0)
+
+    # =========================== Group DGPO Loss ============================
+    def _compute_per_sample_preference(
+        self,
+        dsm_loss: torch.Tensor,
+        ref_dgpo_v: torch.Tensor,
+        target_v: torch.Tensor,
+        advantages: torch.Tensor,
+    ) -> torch.Tensor:
+        """Per-sample contribution to a group's sigmoid argument.
+
+        ``per_sample = advantage * dpo_beta * (dsm - ref_dsm) / group_size``
+
+        We always detach ``dsm_loss`` internally because the sigmoid arm
+        must be a constant w.r.t. the loss gradient — otherwise the
+        reweighting is no longer a DGPO group preference but a
+        second-order correction on ``dsm_loss`` itself.
+        """
+        batch_size = ref_dgpo_v.shape[0]
+        with torch.no_grad():
+            ref_dsm = (target_v - ref_dgpo_v).square().reshape(batch_size, -1).mean(dim=1)
+        delta = dsm_loss.detach() - ref_dsm
+        return advantages * self.dpo_beta * delta / self.training_args.group_size
+
+    def _reduce_group_sums(
+        self,
+        local_sums: torch.Tensor,
+    ) -> torch.Tensor:
+        """Cross-rank-sum partial per-group contributions.
+
+        ``local_sums[g]`` is **this** rank's partial sum for group ``g``;
+        after reduction every rank holds the full per-group sum, indexed
+        by the same dense ``0..L-1`` id space that every rank derived
+        locally via :meth:`_precompute_group_info` under the
+        :class:`GroupDistributedSampler` contract.
+
+        Wraps :meth:`accelerator.reduce`; a no-op in single-process /
+        uninitialised-dist contexts.  Always ``.detach()`` the input so
+        autograd does not try to flow through the collective.
+        """
+        if self.accelerator.num_processes > 1:
+            return self.accelerator.reduce(local_sums.detach(), reduction="sum")  # type: ignore[return-value]
+        return local_sums.detach()
+
+    def _compute_group_dgpo_loss(
+        self,
+        ref_v: torch.Tensor,
+        target_v: torch.Tensor,
+        advantages: torch.Tensor,
+        group_info: DGPOGroupInfo,
+        dsm_loss: torch.Tensor,
+    ) -> torch.Tensor:
+        """Group-level DGPO loss.
+
+        Under the :class:`GroupDistributedSampler` contract every global
+        micro-batch (``num_processes * per_device_batch_size`` samples, seen
+        by all ranks in lockstep) holds an integer number of complete groups
+        and every rank sees the same ``local_group_indices`` (via
+        :meth:`_precompute_group_info`'s local ``torch.unique``).  A
+        single complete group's ``group_size`` copies are split across
+        ranks — one ``group_size / num_processes`` chunk per rank — so we
+        ``scatter_add`` the local
+        per-sample contributions, ``accelerator.reduce`` across ranks
+        to recover the full-group sum, then apply ``sigmoid``.  This is
+        the only group-level collective in the entire DGPO optimize
+        loop.
+        """
+        device = dsm_loss.device
+        num_groups = int(group_info["num_groups"])
+        local_group_indices = group_info["local_group_indices"]
+
+        per_sample = self._compute_per_sample_preference(
+            dsm_loss=dsm_loss,
+            ref_dgpo_v=ref_v,
+            target_v=target_v,
+            advantages=advantages,
+        )
+
+        local_sums = torch.zeros(num_groups, device=device, dtype=per_sample.dtype)
+        local_sums.scatter_add_(0, local_group_indices, per_sample)
+        global_sums = self._reduce_group_sums(local_sums)
+        group_weights = torch.sigmoid(global_sums)[local_group_indices].detach()
+        return (group_weights * advantages * dsm_loss).mean()
+
+    # =========================== Per-Micro-batch Helpers ============================
+    def _prep_training_batch(self, tb: Dict[str, Any]) -> _PreppedBatch:
+        """Unpack one ``training_batches`` entry once.
+
+        Avoids repeating the same six-field unpack and the
+        ``adv_clip_range`` + ``clean_latents`` derivation on every
+        timestep of :meth:`_optimize_step`.
+        """
+        batch = tb["batch"]
+        all_latents: torch.Tensor = batch["all_latents"]
+        clean_latents = all_latents[:, -1]
+        adv_clip_range = self.training_args.adv_clip_range
+        adv = torch.clamp(batch["advantage"], adv_clip_range[0], adv_clip_range[1])
+        return {
+            "batch": batch,
+            "clean_latents": clean_latents,
+            "adv": adv,
+            "group_info": tb["group_info"],
+            "timesteps": tb["timesteps"],
+            "samples_slice": tb["samples_slice"],
+            "inner_epoch": tb["inner_epoch"],
+        }
+
+    def _build_noised_inputs(
+        self, p: _PreppedBatch, t_idx: int,
+    ) -> _NoisedInputs:
+        """Compute ``(t_flat, noised_latents, target_velocity)`` for a
+        ``(prepped_batch, t_idx)`` pair.
+
+        The per-group shared noise is **timestep-invariant** — all timesteps
+        within an epoch receive the same noise for a given ``unique_id``,
+        matching the reference DGPO implementation.
+        """
+        clean_latents = p["clean_latents"]
+        t_flat = p["timesteps"][t_idx]
+        sigma_bcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
+        if self.use_shared_noise:
+            noise = self._make_shared_noise(
+                clean_latents, p["samples_slice"], p["inner_epoch"],
+            )
+        else:
+            noise = randn_tensor(clean_latents.shape, device=clean_latents.device, dtype=clean_latents.dtype)
+        noised = (1 - sigma_bcast) * clean_latents + sigma_bcast * noise
+        target_v = noise - clean_latents
+        return {"t_flat": t_flat, "noised": noised, "target_v": target_v}
+
+    def _forward_velocities(
+        self,
+        batch: Dict[str, Any],
+        t_flat: torch.Tensor,
+        noised: torch.Tensor,
+    ) -> _VelocityPredictions:
+        """Run the per-optimizer-step velocity forwards.
+
+        - ``model_v`` — **always** computed with gradient (this is the forward
+          that backprop flows through).
+        - ``old_v`` (``ema_ref``) — computed only when needed for DSM/KL
+          clipping **or** as the DGPO reference under ``use_ema_ref=True``.
+          Always detached.
+        - ``ref_v`` (frozen pretrained) — computed only when needed for the
+          KL penalty **or** as the DGPO reference when ``use_ema_ref=False``.
+          Always detached.
+        - ``ref_dgpo_v`` — alias of ``old_v`` if ``use_ema_ref=True``,
+          otherwise ``ref_v``.
+
+        This "compute on demand" pattern avoids unconditional extra forwards
+        (two per step) when the corresponding feature is disabled.
+        """
+        need_old_v_for_clip = self._requires_ema_ref and (self.clip_dsm or self.clip_kl)
+        need_old_v_for_dgpo_ref = self._requires_ema_ref and self.use_ema_ref
+        compute_old_v = need_old_v_for_clip or need_old_v_for_dgpo_ref
+
+        old_v: Optional[torch.Tensor] = None
+        if compute_old_v:
+            with torch.no_grad(), self._ema_ref_forward_context():
+                old_v = self._compute_dgpo_output(
+                    batch, t_flat, noised, guidance_scale=1.0
+                ).detach()
+
+        model_v = self._compute_dgpo_output(batch, t_flat, noised, guidance_scale=1.0)
+
+        ref_v: Optional[torch.Tensor] = None
+        if self.enable_kl_loss or (not self.use_ema_ref):
+            ref_cfg = self.kl_cfg if self.kl_cfg > 1.0 else 1.0
+            with torch.no_grad(), self.adapter.use_ref_parameters():
+                ref_v = self._compute_dgpo_output(batch, t_flat, noised, guidance_scale=ref_cfg)
+
+        if self.use_ema_ref:
+            # Guaranteed non-None: use_ema_ref → compute_old_v → old_v assigned.
+            assert old_v is not None
+            ref_dgpo_v = old_v
+        else:
+            # Guaranteed non-None: not use_ema_ref → ref_v branch taken.
+            assert ref_v is not None
+            ref_dgpo_v = ref_v
+
+        return {
+            "model_v": model_v,
+            "old_v": old_v,
+            "ref_v": ref_v,
+            "ref_dgpo_v": ref_dgpo_v,
+        }
+
+    def _compute_dsm_loss(
+        self,
+        target_v: torch.Tensor,
+        pred_v: torch.Tensor,
+    ) -> torch.Tensor:
+        """Per-sample DSM MSE reduced over non-batch dimensions."""
+        batch_size = target_v.shape[0]
+        return (target_v - pred_v).square().reshape(batch_size, -1).mean(dim=1)
+
+    def _maybe_clip_dsm(
+        self,
+        dsm_loss: torch.Tensor,
+        old_v: Optional[torch.Tensor],
+        target_v: torch.Tensor,
+        adv: torch.Tensor,
+        loss_info: Dict[str, List[torch.Tensor]],
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+        """Return ``(should_clip_mask, possibly_clipped_dsm_loss)``.
+
+        PPO-ratio clip on the DSM loss against the old policy (``ema_ref``).
+        ``should_clip`` is reused by the KL-clip path when ``clip_kl`` is
+        set, hence its return.
+        """
+        if not (self.clip_dsm or self.clip_kl) or old_v is None:
+            return None, dsm_loss
+
+        batch_size = old_v.shape[0]
+        clip_range = self.training_args.clip_range
+        old_dsm = (target_v - old_v).square().reshape(batch_size, -1).mean(dim=1)
+        ratio = torch.exp(-dsm_loss.detach() + old_dsm)
+        should_clip = torch.where(
+            adv > 0,
+            ratio > 1.0 + clip_range[1],
+            ratio < 1.0 + clip_range[0],
+        )
+        if self.clip_dsm:
+            dsm_loss = torch.where(should_clip, dsm_loss.detach(), dsm_loss)
+        loss_info["clip_ratio"].append(should_clip.float().mean().detach())
+        return should_clip, dsm_loss
+
+    def _apply_total_loss_and_backward(
+        self,
+        *,
+        dgpo_loss: torch.Tensor,
+        model_v: torch.Tensor,
+        ref_v: Optional[torch.Tensor],
+        should_clip: Optional[torch.Tensor],
+        loss_info: Dict[str, List[torch.Tensor]],
+    ) -> Dict[str, List[torch.Tensor]]:
+        """Assemble ``dgpo_loss + optional kl``, log components, backward,
+        and optionally finalize the optimizer step.
+
+        Returns the (possibly-reset) ``loss_info`` dict so the caller can
+        keep accumulating into the same handle across micro-batches.
+        """
+        loss = dgpo_loss
+        if self.enable_kl_loss:
+            if ref_v is None:
+                raise RuntimeError(
+                    "DGPOTrainer._apply_total_loss_and_backward expected ref_v when KL is "
+                    "enabled, but got None."
+                )
+            batch_size = model_v.shape[0]
+            kl_div = (model_v - ref_v).square().reshape(batch_size, -1).mean(dim=1)
+            if self.clip_kl and should_clip is not None:
+                kl_div = torch.where(should_clip, kl_div.detach(), kl_div)
+            kl_loss = self.kl_beta * kl_div.mean()
+            loss = loss + kl_loss
+            loss_info["kl_div"].append(kl_div.mean().detach())
+            loss_info["kl_loss"].append(kl_loss.detach())
+
+        loss_info["dgpo_loss"].append(dgpo_loss.detach())
+        loss_info["loss"].append(loss.detach())
+
+        self.accelerator.backward(loss)
+        if self.accelerator.sync_gradients:
+            loss_info = self._finalize_step(loss_info)
+        return loss_info
+
+    # =========================== Advantage Processor Dispatch ============================
+    def compute_advantages(
+        self,
+        samples: List[BaseSample],
+        rewards: Dict[str, torch.Tensor],
+        store_to_samples: bool = True,
+        aggregation_func: Optional[Union[Literal["sum", "gdpo"], Callable]] = None,
+    ) -> torch.Tensor:
+        """Compute advantages via the shared ``AdvantageProcessor``."""
+        aggregation_func = aggregation_func or self.training_args.advantage_aggregation
+        return self.advantage_processor.compute_advantages(
+            samples=samples,
+            rewards=rewards,
+            store_to_samples=store_to_samples,
+            aggregation_func=aggregation_func,
+        )
+
+    # =========================== Training Batch Builder ============================
+    def _build_training_batches(
+        self,
+        sample_slices: List[List[BaseSample]],
+        shared_timesteps: torch.Tensor,
+        inner_epoch: int,
+    ) -> List[Dict[str, Any]]:
+        """Materialise per-micro-batch inputs for the training loop.
+
+        Noise is **not** pre-allocated: each timestep tensor is created
+        inside the optimize loop to cap peak memory (``T`` × latent
+        tensors).
+
+        ``local_group_indices`` are derived per-micro-batch by
+        :meth:`_precompute_group_info` via local ``torch.unique`` —
+        cross-rank consistency is guaranteed by the
+        :class:`GroupDistributedSampler` contract (identical prompt
+        sequence on every rank).
+        """
+        training_batches: List[Dict[str, Any]] = []
+        self.adapter.rollout()
+
+        with torch.no_grad(), self.autocast():
+            for samples_slice in tqdm(
+                sample_slices,
+                desc=f"Epoch {self.epoch} Pre-computing",
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                batch = BaseSample.stack(samples_slice)
+                all_latents: torch.Tensor = batch["all_latents"]  # type: ignore[assignment]
+                clean_latents = all_latents[:, -1]
+                batch_size = clean_latents.shape[0]
+
+                group_info = self._precompute_group_info(samples_slice)
+                timesteps = shared_timesteps.unsqueeze(1).expand(-1, batch_size)  # (T, B)
+
+                training_batches.append(
+                    {
+                        "batch": batch,
+                        "group_info": group_info,
+                        "timesteps": timesteps,
+                        "samples_slice": samples_slice,
+                        "inner_epoch": inner_epoch,
+                    }
+                )
+
+        return training_batches
+
+    # =========================== Main Loop ============================
+    def start(self):
+        """Main training loop."""
+        while self.should_continue_training():
+            self.adapter.scheduler.set_seed(self.epoch + self.training_args.seed)
+
+            if (
+                self.log_args.save_freq > 0
+                and self.epoch % self.log_args.save_freq == 0
+                and self.log_args.save_dir
+            ):
+                save_dir = os.path.join(
+                    self.log_args.save_dir,
+                    str(self.log_args.run_name),
+                    "checkpoints",
+                )
+                self.save_checkpoint(save_dir, epoch=self.epoch)
+
+            if self.eval_args.eval_freq > 0 and self.epoch % self.eval_args.eval_freq == 0:
+                self.evaluate()
+
+            with self.sampling_context():
+                samples = self.sample()
+
+            self.prepare_feedback(samples)
+            self.optimize(samples)
+            self.adapter.ema_step(step=self.epoch)
+            self.epoch += 1
+
+    # =========================== Evaluation ============================
+    def evaluate(self) -> None:
+        """Evaluation loop (kept GRPO-equivalent: always use sampling EMA)."""
+        if self.test_dataloader is None:
+            return
+
+        self.adapter.eval()
+        self.eval_reward_buffer.clear()
+
+        with torch.no_grad(), self.autocast(), self.adapter.use_ema_parameters():
+            all_samples: List[BaseSample] = []
+
+            for batch in tqdm(
+                self.test_dataloader,
+                desc="Evaluating",
+                disable=not self.show_progress_bar,
+            ):
+                generator = create_generator_by_prompt(batch["prompt"], self.training_args.seed)
+                inference_kwargs = {
+                    "compute_log_prob": False,
+                    "generator": generator,
+                    "trajectory_indices": None,
+                    **self.eval_args,
+                }
+                inference_kwargs.update(**batch)
+                inference_kwargs = filter_kwargs(self.adapter.inference, **inference_kwargs)
+                samples = self.adapter.inference(**inference_kwargs)
+                all_samples.extend(samples)
+                self.eval_reward_buffer.add_samples(samples)
+
+            rewards = self.eval_reward_buffer.finalize(store_to_samples=True, split="pointwise")
+            rewards = {
+                key: torch.as_tensor(value).to(self.accelerator.device)
+                for key, value in rewards.items()
+            }
+            gathered_rewards: Dict[str, np.ndarray] = {}
+            for key, value in rewards.items():
+                gathered: torch.Tensor = self.accelerator.gather(value)  # type: ignore[assignment]
+                gathered_rewards[key] = gathered.cpu().numpy()
+
+            if self.accelerator.is_main_process:
+                log_data: Dict[str, Any] = {
+                    f"eval/reward_{key}_mean": np.mean(value)
+                    for key, value in gathered_rewards.items()
+                }
+                log_data.update(
+                    {
+                        f"eval/reward_{key}_std": np.std(value)
+                        for key, value in gathered_rewards.items()
+                    }
+                )
+                log_data["eval_samples"] = all_samples
+                self.log_data(log_data, step=self.step)
+            self.accelerator.wait_for_everyone()
+
+    # =========================== Sampling (Stages 2-3) ============================
+    def sample(self) -> List[BaseSample]:
+        """Generate rollouts for DGPO (ODE sampling, final latents only)."""
+        self.adapter.rollout()
+        self.reward_buffer.clear()
+        samples = []
+        data_iter = iter(self.dataloader)
+
+        with torch.no_grad(), self.autocast():
+            for _ in tqdm(
+                range(self.training_args.num_batches_per_epoch),
+                desc=f"Epoch {self.epoch} Sampling",
+                disable=not self.show_progress_bar,
+            ):
+                batch = next(data_iter)
+                sample_kwargs = {
+                    **self.training_args,
+                    "compute_log_prob": False,
+                    "trajectory_indices": [-1],
+                    **batch,
+                }
+                sample_kwargs = filter_kwargs(self.adapter.inference, **sample_kwargs)
+                sample_batch = self.adapter.inference(**sample_kwargs)
+                samples.extend(sample_batch)
+                self.reward_buffer.add_samples(sample_batch)
+
+        return samples
+
+    # =========================== Reward / Advantage (Stages 4-5) ============================
+    def prepare_feedback(self, samples: List[BaseSample]) -> None:
+        """Finalise rewards, compute advantages, and log advantage metrics."""
+        rewards = self.reward_buffer.finalize(store_to_samples=True, split="all")
+        self.compute_advantages(samples, rewards, store_to_samples=True)
+        adv_metrics = self.advantage_processor.pop_advantage_metrics()
+        if adv_metrics:
+            self.log_data(adv_metrics, step=self.step)
+
+    # =========================== Optimization (Stage 6) ============================
+    def optimize(self, samples: List[BaseSample]) -> None:
+        """Policy optimisation (Stage 6): group DGPO loss + optional PPO clip + KL.
+
+        Rewards and advantages are finalised in :meth:`prepare_feedback`; this
+        method performs policy gradients and the per-step ``ema_ref`` update.
+
+        Under the :class:`GroupDistributedSampler` contract (enforced by
+        ``hparams._resolve_sampler_type`` + ``_align_for_group_distributed``),
+        every local micro-batch holds the same prompt sequence on every rank
+        and a whole number of complete groups is present in every global
+        micro-batch (``(num_processes * per_device_batch_size) % group_size == 0``).  This means we never need to
+        gather full samples across ranks — the single ``accelerator.reduce``
+        inside :meth:`_compute_group_dgpo_loss` is the only group-level
+        collective required to recover the full-group sigmoid weights.
+        """
+        bsz = self.training_args.per_device_batch_size
+        assert len(samples) % bsz == 0, (
+            "DGPOTrainer.optimize expects len(samples) to be a multiple of "
+            f"per_device_batch_size, got len(samples)={len(samples)} and bsz={bsz}."
+        )
+
+        for inner_epoch in range(self.training_args.num_inner_epochs):
+            sample_slices = [
+                samples[i : i + bsz] for i in range(0, len(samples), bsz)
+            ]
+            shared_timesteps = self._sample_shared_timesteps(inner_epoch)  # (T,)
+            training_batches = self._build_training_batches(
+                sample_slices,
+                shared_timesteps,
+                inner_epoch,
+            )
+
+            self.adapter.train()
+            self._optimize_step(training_batches)
+
+    def _optimize_step(
+        self,
+        training_batches: List[Dict[str, Any]],
+    ) -> None:
+        """Per-optimizer-step DGPO loss over every timestep of every micro-batch.
+
+        ``(num_processes * per_device_batch_size) % group_size == 0`` holds
+        by the sampler contract, so each global micro-batch is
+        group-complete and a single forward per ``(micro_batch, t_idx)``
+        pair is sufficient.  ``accelerator.reduce`` inside
+        :meth:`_compute_group_dgpo_loss` aggregates partial per-rank
+        per-group sums into the full-group sum before the sigmoid.
+        """
+        loss_info: Dict[str, List[torch.Tensor]] = defaultdict(list)
+
+        with self.autocast():
+            for tb in tqdm(
+                training_batches,
+                desc=f"Epoch {self.epoch} Training",
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                p = self._prep_training_batch(tb)
+                batch = p["batch"]
+                adv = p["adv"]
+                group_info = p["group_info"]
+
+                for t_idx in tqdm(
+                    range(self.num_train_timesteps),
+                    desc=f"Epoch {self.epoch} Timestep",
+                    position=1,
+                    leave=False,
+                    disable=not self.show_progress_bar,
+                ):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        noised = self._build_noised_inputs(p, t_idx)
+                        vels = self._forward_velocities(
+                            batch, noised["t_flat"], noised["noised"]
+                        )
+                        dsm_loss = self._compute_dsm_loss(noised["target_v"], vels["model_v"])
+                        should_clip, dsm_loss = self._maybe_clip_dsm(
+                            dsm_loss=dsm_loss,
+                            old_v=vels["old_v"],
+                            target_v=noised["target_v"],
+                            adv=adv,
+                            loss_info=loss_info,
+                        )
+                        ref_dgpo_v = vels["ref_dgpo_v"]
+                        dgpo_loss = self._compute_group_dgpo_loss(
+                            ref_v=ref_dgpo_v,
+                            target_v=noised["target_v"],
+                            advantages=adv,
+                            group_info=group_info,
+                            dsm_loss=dsm_loss,
+                        )
+                        loss_info["dsm_loss"].append(dsm_loss.mean().detach())
+                        loss_info = self._apply_total_loss_and_backward(
+                            dgpo_loss=dgpo_loss,
+                            model_v=vels["model_v"],
+                            ref_v=vels["ref_v"],
+                            should_clip=should_clip,
+                            loss_info=loss_info,
+                        )
+
+    # =========================== Optimizer Step Finalization ============================
+    def _finalize_step(
+        self,
+        loss_info: Dict[str, List[torch.Tensor]],
+    ) -> Dict[str, List[torch.Tensor]]:
+        """Optimizer step + ema_ref update + loss reduction/logging."""
+        grad_norm = self.accelerator.clip_grad_norm_(
+            self.adapter.get_trainable_parameters(),
+            self.training_args.max_grad_norm,
+        )
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+
+        # ema_ref advances once per optimiser step (reference DGPO);
+        # sampling EMA advances once per epoch in ``start()``.
+        self._update_ema_ref(step=self.step)
+
+        reduced = reduce_loss_info(self.accelerator, loss_info)
+        reduced["grad_norm"] = grad_norm
+        self.log_data(
+            {f"train/{k}": v for k, v in reduced.items()},
+            step=self.step,
+        )
+        self.step += 1
+        return defaultdict(list)
+

--- a/src/flow_factory/trainers/registry.py
+++ b/src/flow_factory/trainers/registry.py
@@ -31,6 +31,7 @@ _TRAINER_REGISTRY: Dict[str, str] = {
     'grpo-guard': 'flow_factory.trainers.grpo.GRPOGuardTrainer',
     'nft': 'flow_factory.trainers.nft.DiffusionNFTTrainer',
     'awm': 'flow_factory.trainers.awm.AWMTrainer',
+    'dgpo': 'flow_factory.trainers.dgpo.DGPOTrainer',
     'dpo': 'flow_factory.trainers.dpo.DPOTrainer',
 }
 

--- a/src/flow_factory/utils/base.py
+++ b/src/flow_factory/utils/base.py
@@ -92,18 +92,30 @@ def split_kwargs(funcs: list[Callable], **kwargs: Any) -> list[dict[str, Any]]:
     return results
 
 # ------------------------------------Random Utils---------------------------------------
-def create_generator(*args: int) -> torch.Generator:
-    """
-    Create a reproducible torch Generator seeded by combining arbitrary integers.
-    
+def create_generator(
+    *args: int,
+    device: Optional[Union[torch.device, str]] = None,
+) -> torch.Generator:
+    """Create a reproducible torch Generator seeded by combining integer keys.
+
+    The seed is derived from ``hash(args) % 2**32``; tuples of ints have a
+    stable hash in CPython (unlike tuples containing strings, which depend on
+    ``PYTHONHASHSEED``), so the same integer keys reliably produce the same
+    generator within and across runs.
+
     Args:
-        *args: Any number of integers (e.g., epoch, rank, base_seed).
-    
+        *args: Any number of integers (e.g., base_seed, epoch, rank). Order
+            matters — different orderings seed different generators.
+        device: Target device for the generator. ``None`` (default) creates a
+            CPU generator; pass ``accelerator.device`` / ``'cuda'`` to sample
+            directly on GPU when feeding ``torch.rand`` / ``torch.randn`` /
+            ``randn_tensor`` without a CPU↔GPU copy.
+
     Returns:
-        A seeded torch.Generator instance.
+        A seeded ``torch.Generator`` on the requested device.
     """
     seed = hash(args) % (2**32)
-    generator = torch.Generator()
+    generator = torch.Generator(device=device) if device is not None else torch.Generator()
     generator.manual_seed(seed)
     return generator
 

--- a/src/flow_factory/utils/noise_schedule.py
+++ b/src/flow_factory/utils/noise_schedule.py
@@ -26,9 +26,19 @@ when TIMESTEP_MAX=1000). All samplers return **scheduler-scale** timesteps in
 ``[0, TIMESTEP_MAX]``; trainers pass them to ``adapter.forward(t=...)`` without
 extra scaling. Use ``flow_match_sigma(t) = t / TIMESTEP_MAX`` for linear
 flow interpolation ``x_t = (1-σ) x_0 + σ ε``.
+
+All samplers accept an optional ``generator`` argument for reproducible /
+cross-rank-deterministic draws:
+
+* ``generator=None`` (default): use the global default RNG on ``device``.
+* ``generator is not None``: every internal random op runs on
+  ``generator.device``; the final tensor is moved to ``device`` before return.
+  This lets callers seed with a CPU generator while the output lives on GPU,
+  guaranteeing that two ranks with the same seed produce byte-identical
+  timesteps regardless of their device placement.
 """
 import torch
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 TIMESTEP_MAX = 1000.0
 
@@ -45,6 +55,27 @@ def fraction_range_to_t_bounds(frac_lo: float, frac_hi: float) -> Tuple[float, f
     return t_min, t_max
 
 
+def _rng_device(
+    generator: Optional[torch.Generator],
+    fallback: torch.device,
+) -> torch.device:
+    """Choose the device random ops must run on.
+
+    When ``generator`` is supplied, every random op MUST execute on
+    ``generator.device`` (PyTorch constraint); otherwise use ``fallback``.
+    """
+    return generator.device if generator is not None else fallback
+
+
+def _normalize_timestep_range(
+    timestep_range: Union[float, Tuple[float, float]],
+) -> Tuple[float, float]:
+    """Coerce ``timestep_range`` to a ``(frac_lo, frac_hi)`` pair."""
+    if isinstance(timestep_range, (list, tuple)):
+        return float(timestep_range[0]), float(timestep_range[1])
+    return 0.0, float(timestep_range)
+
+
 class TimeSampler:
     """Continuous and discrete time sampler for flow matching training."""
 
@@ -56,20 +87,33 @@ class TimeSampler:
         logit_mean: float,
         logit_std: float,
         time_shift: float,
+        generator: Optional[torch.Generator] = None,
     ) -> torch.Tensor:
-        """Samples ``raw`` in (0, 1) with logit-normal + optional shift warp (legacy shape)."""
+        """Samples ``raw`` in (0, 1) with logit-normal + optional shift warp (legacy shape).
+
+        Args:
+            generator: If given, all ``torch.rand / randn / randperm`` calls are
+                routed through it on ``generator.device``; the final tensor is
+                then moved to ``device``.
+        """
+        rng_device = _rng_device(generator, device)
+
         if stratified:
-            base = (torch.arange(num_rows, device=device) + torch.rand(num_rows, device=device)) / num_rows
+            u_base = torch.rand(num_rows, generator=generator, device=rng_device)
+            base = (torch.arange(num_rows, device=rng_device) + u_base) / num_rows
             normal_dist = torch.distributions.Normal(loc=0.0, scale=1.0)
             u_standard = normal_dist.icdf(torch.clamp(base, 1e-7, 1 - 1e-7))
-            u_standard = u_standard[torch.randperm(num_rows, device=device)]
+            perm = torch.randperm(num_rows, generator=generator, device=rng_device)
+            u_standard = u_standard[perm]
         else:
-            u_standard = torch.randn(num_rows, device=device)
+            # ``torch.randn`` accepts ``generator``; stays on ``rng_device``.
+            u_standard = torch.randn(num_rows, generator=generator, device=rng_device)
 
         u = u_standard * logit_std + logit_mean
         raw = torch.sigmoid(u)
         raw = time_shift * raw / (1 + (time_shift - 1) * raw)
-        return torch.clamp(raw, min=0.01, max=1.0 - 1e-6)
+        raw = torch.clamp(raw, min=0.01, max=1.0 - 1e-6)
+        return raw.to(device)
 
     @staticmethod
     def logit_normal_shifted(
@@ -81,20 +125,30 @@ class TimeSampler:
         time_shift: float = 3.0,
         device: torch.device = torch.device("cpu"),
         stratified: bool = True,
+        generator: Optional[torch.Generator] = None,
     ) -> torch.Tensor:
-        """
-        Logit-normal time sampling; returns scheduler-scale timesteps in ``[0, TIMESTEP_MAX]``.
+        """Logit-normal time sampling; returns scheduler-scale timesteps in ``[0, TIMESTEP_MAX]``.
 
         ``timestep_range`` is interpreted as ``(frac_lo, frac_hi)`` (fraction along 1000→0).
         A unit interval sample ``raw`` is mapped to ``frac = frac_lo + raw * (frac_hi - frac_lo)``,
         then ``t = TIMESTEP_MAX * (1 - frac)``.
-        """
-        if isinstance(timestep_range, (list, tuple)):
-            frac_lo, frac_hi = float(timestep_range[0]), float(timestep_range[1])
-        else:
-            frac_lo, frac_hi = 0.0, float(timestep_range)
 
-        raw = TimeSampler._raw_logit_normal_unit(num_timesteps, device, stratified, logit_mean, logit_std, time_shift)
+        Args:
+            generator: Optional ``torch.Generator`` for deterministic draws.
+                When supplied, the same ``generator.initial_seed()`` produces
+                byte-identical output on any rank.
+        """
+        frac_lo, frac_hi = _normalize_timestep_range(timestep_range)
+
+        raw = TimeSampler._raw_logit_normal_unit(
+            num_timesteps,
+            device,
+            stratified,
+            logit_mean,
+            logit_std,
+            time_shift,
+            generator=generator,
+        )
         frac = frac_lo + raw * (frac_hi - frac_lo)
         t = TIMESTEP_MAX * (1.0 - frac)
         return t.unsqueeze(1).expand(num_timesteps, batch_size)
@@ -106,24 +160,26 @@ class TimeSampler:
         timestep_range: Union[float, Tuple[float, float]],
         time_shift: float = 1.0,
         device: torch.device = torch.device("cpu"),
+        generator: Optional[torch.Generator] = None,
     ) -> torch.Tensor:
-        """
-        Uniform sampling over fraction interval, then map to ``[0, TIMESTEP_MAX]`` scheduler times.
-        Optional ``time_shift`` warps the fraction before mapping (same as legacy uniform).
-        """
-        if isinstance(timestep_range, (list, tuple)):
-            frac_lo, frac_hi = float(timestep_range[0]), float(timestep_range[1])
-        else:
-            frac_lo, frac_hi = 0.0, float(timestep_range)
+        """Uniform sampling over fraction interval, mapped to ``[0, TIMESTEP_MAX]``.
 
-        rand_u = torch.rand(num_timesteps, device=device)
-        normalized = (torch.arange(num_timesteps, device=device) + rand_u) / num_timesteps
+        Optional ``time_shift`` warps the fraction before mapping (same as
+        legacy uniform). ``generator`` semantics are identical to
+        :meth:`logit_normal_shifted`.
+        """
+        frac_lo, frac_hi = _normalize_timestep_range(timestep_range)
+        rng_device = _rng_device(generator, device)
+
+        rand_u = torch.rand(num_timesteps, generator=generator, device=rng_device)
+        normalized = (torch.arange(num_timesteps, device=rng_device) + rand_u) / num_timesteps
         f = frac_lo + normalized * (frac_hi - frac_lo)
-        f = f[torch.randperm(num_timesteps, device=device)]
+        perm = torch.randperm(num_timesteps, generator=generator, device=rng_device)
+        f = f[perm]
         if abs(time_shift - 1.0) > 1e-6:
             f = time_shift * f / (1 + (time_shift - 1) * f)
         t = TIMESTEP_MAX * (1.0 - f)
-        return t.unsqueeze(1).expand(-1, batch_size)
+        return t.to(device).unsqueeze(1).expand(-1, batch_size)
 
     @staticmethod
     def discrete(
@@ -133,23 +189,27 @@ class TimeSampler:
         timestep_range: Union[float, Tuple[float, float]] = 1.0,
         include_init: bool = True,
         force_init: bool = False,
+        generator: Optional[torch.Generator] = None,
     ) -> torch.Tensor:
-        """
-        Discrete stratified sampling from ``scheduler_timesteps`` (scheduler scale, e.g. 0–1000).
+        """Discrete stratified sampling from ``scheduler_timesteps`` (scheduler scale, e.g. 0–1000).
 
-        ``timestep_range=(frac_lo, frac_hi)`` keeps indices ``i`` whose ``ts[i]`` lies in
-        ``[TIMESTEP_MAX*(1-frac_hi), TIMESTEP_MAX*(1-frac_lo)]``, then stratifies over
-        the contiguous index span ``[min_i, max_i]`` among those matches.
+        ``timestep_range=(frac_lo, frac_hi)`` keeps indices ``i`` whose ``ts[i]``
+        lies in ``[TIMESTEP_MAX*(1-frac_hi), TIMESTEP_MAX*(1-frac_lo)]``, then
+        stratifies over the contiguous index span ``[min_i, max_i]`` among
+        those matches.
+
+        Args:
+            generator: Optional ``torch.Generator`` for deterministic draws.
+                Index computation stays on ``scheduler_timesteps.device`` since
+                ``scheduler_timesteps`` is typically tiny (≤50 elements) and
+                the bookkeeping is cheap; only the final stratified ``rand``
+                draw uses ``generator``.
         """
         device = scheduler_timesteps.device
         ts = scheduler_timesteps.float()
         num_steps = len(ts)
 
-        if isinstance(timestep_range, (list, tuple)):
-            frac_start, frac_end = float(timestep_range[0]), float(timestep_range[1])
-        else:
-            frac_start, frac_end = 0.0, float(timestep_range)
-
+        frac_start, frac_end = _normalize_timestep_range(timestep_range)
         t_min, t_max = fraction_range_to_t_bounds(frac_start, frac_end)
         mask = (ts >= t_min - 1e-3) & (ts <= t_max + 1e-3)
         valid_indices = torch.where(mask)[0]
@@ -162,15 +222,17 @@ class TimeSampler:
                 t_indices = torch.tensor([min_idx], device=device, dtype=torch.long)
             else:
                 start_idx = min_idx + 1
+                rest = TimeSampler._stratified_sample(
+                    num_train_timesteps - 1, start_idx, max_idx, device, generator=generator
+                )
                 t_indices = torch.cat(
-                    [
-                        torch.tensor([min_idx], device=device, dtype=torch.long),
-                        TimeSampler._stratified_sample(num_train_timesteps - 1, start_idx, max_idx, device),
-                    ]
+                    [torch.tensor([min_idx], device=device, dtype=torch.long), rest]
                 )
         else:
             start_idx = min_idx if include_init else min_idx + 1
-            t_indices = TimeSampler._stratified_sample(num_train_timesteps, start_idx, max_idx, device)
+            t_indices = TimeSampler._stratified_sample(
+                num_train_timesteps, start_idx, max_idx, device, generator=generator
+            )
 
         t_indices = t_indices.clamp(min=0, max=num_steps - 1)
         timesteps = ts[t_indices].unsqueeze(1).expand(-1, batch_size)
@@ -182,9 +244,16 @@ class TimeSampler:
         start_idx: int,
         end_idx: int,
         device: torch.device,
+        generator: Optional[torch.Generator] = None,
     ) -> torch.Tensor:
-        """Stratified sampling of indices from [start_idx, end_idx]."""
+        """Stratified sampling of indices from ``[start_idx, end_idx]``.
+
+        ``boundaries`` is always built on ``device``; only the uniform
+        perturbation draw uses ``generator`` (on ``generator.device``) and is
+        then moved to ``device`` for the index arithmetic.
+        """
+        rng_device = _rng_device(generator, device)
         boundaries = torch.linspace(start_idx, end_idx, num_samples + 1, device=device)
         lower, upper = boundaries[:-1].long(), boundaries[1:].long()
-        rand_u = torch.rand(num_samples, device=device)
+        rand_u = torch.rand(num_samples, generator=generator, device=rng_device).to(device)
         return lower + (rand_u * (upper - lower)).long()


### PR DESCRIPTION
## Summary

Adds DGPO ([Direct Group Preference Optimization](https://arxiv.org/abs/2510.08425), ICLR 2026) and supporting infrastructure to Flow-Factory. Split into **3 commits** for clean review:

1. `[utils] feat: optional device/generator kwargs for reproducible cross-rank RNG` — backward-compatible additions to `create_generator` and `TimeSampler`; no existing call site is touched.
2. `[data_utils,hparams] feat: GroupDistributedSampler + per-sampler alignment split` — new sampler, sampler registry, `sampler_type='group_distributed'` literal, and `_align_batch_geometry` refactored into 3 per-sampler helpers with shared primitives.
3. `[trainer,hparams,examples,docs] feat: add DGPO trainer` — the trainer, hparams, registry entry, example config, and documentation (algorithms.md DPO + DGPO sections, README, AGENTS.md, workflow.md).

### Algorithm highlights

- **Group-level DPO loss**: scatter-add + sigmoid reweighting on per-group advantage-weighted DSM deltas against a frozen reference (or the fast EMA old policy when `use_ema_ref=True`).
- **Optional PPO-style clipping** on DSM / KL loss, using a fast-tracking EMA (`ema_ref`, distinct from the slow sampling EMA) with adaptive decay `min(ema_ref_max_decay, ema_ref_ramp_rate * step)`.
- **Cross-rank-deterministic shared timesteps / per-group shared noise** via seeded `create_generator` keys — no `dist.broadcast` / RNG fork needed.
- **Timestep-invariant shared noise**: per-group noise is seeded from `(seed, epoch, inner_epoch, uid)` — all training timesteps within an epoch share the same noise, matching the reference implementation.
- **`v`-based KL regularisation** and CFG-enabled frozen reference (`kl_cfg > 1`).
- Flow-matching interpolation `x_t = (1 - σ) x_0 + σ ε` correctly scales scheduler-scale timesteps through `flow_match_sigma(t)` (σ = t / 1000).

### GroupDistributedSampler

DGPO requires `GroupDistributedSampler` (auto-forced by `Arguments._resolve_sampler_type`). Every rank yields the **same prompt-index sequence** — each prompt appears `group_size / num_replicas` times per rank. Rollout divergence comes from per-rank generation RNG, not dataset stripe. This means:

- Local `torch.unique(sorted=True)` produces cross-rank-consistent dense group ids — **no `gather_samples` or cross-rank id coordination** needed.
- The single `accelerator.reduce` inside `_compute_group_dgpo_loss` is the **only group-level collective** in the entire optimize loop.
- Geometric constraint `(W × B) % K == 0` is auto-aligned by `_align_for_group_distributed` via O(√B) divisor search on `per_device_batch_size`.

### hparams refactor

`_align_batch_geometry` split into 3 per-sampler helpers sharing `_base_unique_sample_step` / `_round_up_to_step` / `_warn_and_assign_unique_sample_num` / `_recompute_derived_batch_quantities`. Each helper is ~10 lines. Non-DGPO samplers (`distributed_k_repeat`, `group_contiguous`) produce **identical outputs** to the old monolithic function (verified via 4000-case randomized equivalence test).

### Wiring

- `DGPOTrainingArguments` (extends `GRPOTrainingArguments`) exports all DGPO hyper-parameters; registered under `'dgpo'` in the hparams registry.
- `DGPOTrainer` registered under `'dgpo'` in `trainers/registry.py`.
- Example config `examples/dgpo/lora/sd3_5.yaml` — direct port of the reference `pickscore_sd3_4gpu` preset (`num_processes: 4`, `group_size = 24`).
- Docs: DPO + DGPO sections in `guidance/algorithms.md`; DPO and DGPO added to README algorithm table; light touch-ups in AGENTS.md, architecture.md, workflow.md.

## Test plan

- [x] **Reward trends upward.** Training on SD3.5-medium + PickScore with `examples/dgpo/lora/sd3_5.yaml` shows positive reward trajectory.
- [x] **Sibling trainers unaffected.** No existing call site passes `device=` / `generator=`, so GRPO / DPO / NFT / AWM behavior is bit-identical to `origin/main`.
- [x] **hparams equivalence.** 4000-case randomized test confirms `_align_for_distributed_k_repeat` and `_align_for_group_contiguous` produce identical `(M, K, num_batches_per_epoch)` as the original monolithic `_align_batch_geometry`.
- [x] **Registry wiring.** `DGPOTrainingArguments` exported from `flow_factory.hparams`; `_TRAINER_REGISTRY['dgpo']` resolves to `DGPOTrainer`.
- [x] **σ-scaling contract.** `flow_match_sigma(t_flat)` applied before constructing `x_t`, matching `trainers/nft.py`, `trainers/awm.py`, `trainers/dpo.py`.
- [x] **Reference implementation audit.** Line-by-line comparison with [Luo-Yihong/DGPO](https://github.com/Luo-Yihong/DGPO/blob/main/scripts/train_sd3_dgpo.py): all 12 dimensions verified equivalent (σ-scaling, loss, clipping, KL, EMA timing, grad accumulation, forward ordering, group info, shared noise, sampling switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)