### PR TITLE
[examples] Add LTX2.3 + pickscore example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,8 @@ If you've tested a model–algorithm combination and confirmed reward improvemen
 - The config YAML following the directory structure above
 - A brief note in the PR description about hardware used and observed reward trend
 
+> **Example**: [#145 — LTX-2.3 + PickScore](https://github.com/X-GenGroup/Flow-Factory/pull/145) added a GRPO + LoRA config for text-to-audio-video, with a training curve (8×H200, 18h) confirming reward improvement.
+
 ### Custom Reward Models
 
 New reward models are welcome — add the implementation under `src/flow_factory/rewards/` and include an example config that uses it. Please ensure your reward model's dependencies are compatible with the existing environment (check `pyproject.toml`).

--- a/examples/grpo/lora/ltx2/t2av_pickscore.yaml
+++ b/examples/grpo/lora/ltx2/t2av_pickscore.yaml
@@ -1,0 +1,131 @@
+# Environment Configuration
+launcher: "accelerate"  # Options: accelerate
+config_file: config/deepspeed/deepspeed_zero2.yaml  # Switch to fsdp_full_shard.yaml to shard both transformer + audio components
+num_processes: 8  # Number of processes to launch (overrides config file)
+main_process_port: 29500
+mixed_precision: "bf16"  # Options: no, fp16, bf16
+
+# Data Configuration
+# Prompt-only dataset: 50K VidProM-filtered prompts, split by scripts/data/split_prompts.py
+data:
+  dataset_dir: "dataset/vid_prompt"  # Contains train.txt / test.txt (one prompt per line)
+  preprocessing_batch_size: 4  # Batch size for preprocessing
+  dataloader_num_workers: 8  # Number of workers for DataLoader
+  force_reprocess: true  # Force reprocessing of the dataset
+  cache_dir: "~/.cache/flow_factory/datasets"  # Cache directory for preprocessed datasets
+  max_dataset_size: 1024  # Limit the maximum number of samples in the dataset
+  sampler_type: "auto"  # Options: auto, distributed_k_repeat, group_contiguous
+
+# Model Configuration
+model:
+  finetune_type: 'lora'  # Options: full, lora
+  lora_rank: 64
+  lora_alpha: 128
+  target_components: 'transformer'  # LTX2 has a single unified transformer for both video and audio
+  target_modules: "default"  # 28 Linear layers per block (video/audio attn + cross-modal attn + FFN)
+  model_name_or_path: "dg845/LTX-2.3-Diffusers"  # Options: Lightricks/LTX-2, dg845/LTX-2.3-Diffusers
+  model_type: "ltx2_t2av"
+  resume_path: null  # Path to load previous checkpoint/lora adapter
+  resume_type: null  # Options: lora, full, state. Null to auto-detect based on `finetune_type`
+  # attn_backend: '_flash_3_hub'  # Attention backend.
+
+log:
+  run_name: null  # Run name (auto: {model_type}_{finetune_type}_{trainer_type}_{timestamp})
+  project: "Flow-Factory"  # Project name for logging
+  logging_backend: "wandb"  # Options: wandb, swanlab, tensorboard, none
+  save_dir: "saves/"  # Directory to save model checkpoints and logs
+  save_freq: 60  # Save frequency in epochs (0 to disable)
+  save_model_only: true  # Save only the model weights (not optimizer, scheduler, etc.)
+
+# Training Configuration
+train:
+  # Trainer settings
+  trainer_type: 'grpo'  # Options: 'grpo', 'nft', 'awm'
+  advantage_aggregation: 'gdpo'  # Options: 'sum', 'gdpo'
+  # Clipping
+  clip_range: 1.0e-4  # PPO/GRPO clipping range
+  adv_clip_range: 5.0  # Advantage clipping range
+  # KL div
+  kl_type: 'v-based'  # Options: 'x-based', 'v-based'
+  kl_beta: 0  # KL divergence coefficient. Set ~1e-2 for 'x-based' and ~1e-3 for 'v-based'.
+  ref_param_device: 'cuda'  # Options: cpu, cuda
+
+  # Video settings (LTX2: 768x512, 121 frames at 24fps = ~5s)
+  resolution: [512, 768]  # Can be int or [height, width]
+  num_frames: 121 # (num_frames - 1) % 8 == 0 for VAE temporal compression
+  frame_rate: 24.0  # Frame rate for video generation
+  num_inference_steps: 24  # Number of denoising timesteps
+  guidance_scale: 1.0  # Classifier-free guidance scale
+  stg_scale: 0.0  # Spatio-temporal guidance scale
+  modality_scale: 1.0  # Modality isolation scale
+  guidance_rescale: 0.0  # Guidance rescale
+  audio_guidance_scale: null  # Audio guidance scale, defaults to guidance_scale
+  audio_stg_scale: null  # Audio spatio-temporal guidance scale, defaults to stg_scale
+  audio_modality_scale: null  # Audio modality isolation scale, defaults to modality_scale
+  audio_guidance_rescale: null  # Audio guidance rescale, defaults to guidance_rescale
+
+  # Prompt enhancement (null = disabled; "default" = a predefined prompt; or custom string)
+  system_prompt: null
+  prompt_enhancement_seed: 10
+
+  # Batch and sampling
+  per_device_batch_size: 1  # Batch size per device
+  group_size: 16  # Group size for GRPO sampling
+  global_std: true  # Use global std for advantage normalization
+  unique_sample_num_per_epoch: 48  # Unique samples per epoch
+  gradient_step_per_epoch: 2  # Gradient steps per epoch
+  gradient_accumulation_steps: auto  # Options: auto, or positive integer. When set, `gradient_step_per_epoch` is ignored.
+
+  # Optimization
+  seed: 42  # Random seed
+  learning_rate: 3.0e-4  # Initial learning rate
+  adam_weight_decay: 1.0e-4  # AdamW weight decay
+  adam_betas: [0.9, 0.999]  # AdamW betas
+  adam_epsilon: 1.0e-8  # AdamW epsilon
+  max_grad_norm: 1.0  # Max gradient norm for clipping
+
+  # EMA
+  ema_decay: 0.9  # EMA decay rate (0 to disable)
+  ema_update_interval: 4  # EMA update interval (in epochs)
+  ema_device: "cuda"  # Device to store EMA model (options: cpu, cuda)
+
+  # Gradient checkpointing
+  enable_gradient_checkpointing: true  # Enable gradient checkpointing to save memory with extra compute
+  offload_samples_to_cpu: true  # Required for video models: per-sample tensors are GB-scale; without offload, sample()/optimize() OOMs at num_batches_per_epoch > 1.
+
+# Scheduler Configuration
+scheduler:
+  dynamics_type: "CPS"  # Options: Flow-SDE, Dance-SDE, CPS, ODE
+  noise_level: 0.8  # Noise level for sampling
+  num_sde_steps: 3  # Number of noise steps
+  sde_steps: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]  # Custom noise window, noise steps are randomly selected from this list during training
+  seed: 42  # Scheduler seed (for noise step selection)
+
+# Evaluation settings
+eval:
+  eval_freq: 60  # Eval frequency in epochs (0 to disable)
+  seed: 42  # Eval seed (defaults to training seed)
+  resolution: [512, 768]  # Evaluation resolution [height, width]
+  num_frames: 121  # Evaluation frames
+  frame_rate: 24.0  # Evaluation frame rate
+  per_device_batch_size: 1  # Eval batch size
+  guidance_scale: 4.0  # Guidance scale for sampling
+  stg_scale: 0.0  # Spatio-temporal guidance scale
+  modality_scale: 1.0  # Modality isolation scale
+  guidance_rescale: 0.0  # Guidance rescale
+  audio_guidance_scale: null  # Audio guidance scale, defaults to guidance_scale
+  audio_stg_scale: null  # Audio spatio-temporal guidance scale, defaults to stg_scale
+  audio_modality_scale: null  # Audio modality isolation scale, defaults to modality_scale
+  audio_guidance_rescale: null  # Audio guidance rescale, defaults to guidance_rescale
+  num_inference_steps: 50  # Number of eval timesteps
+  system_prompt: null  # null = disabled; "default" = a predefined prompt; or custom string
+  prompt_enhancement_seed: 10
+
+# Reward Model Configuration
+rewards:
+  - name: "pick_score"
+    reward_model: "PickScore"
+    weight: 1.0  # Weight of this reward model
+    batch_size: 32
+    device: "cuda"
+    dtype: bfloat16


### PR DESCRIPTION
## Summary
- Add a verified GRPO + LoRA training config for **LTX-2.3** (text-to-audio-video) with PickScore reward
- Config: `examples/grpo/lora/ltx2/t2av_pickscore.yaml`
- Key settings: CPS dynamics, LoRA rank 64, GDPO advantage aggregation, 512×768 resolution, 121 frames @ 24fps (~5s video), DeepSpeed ZeRO-2

## Hardware & Results
- **Hardware**: 8× H200, ~18 hours of training (~40 epochs)
- **Reward trend**: PickScore shows a steady upward trend over 40 epochs. Due to the large model size and limited compute budget, training was stopped early — but the curve indicates the config is effective and reward is improving.

## Test plan
- [x] Config is self-contained and runnable with `ff-train`
- [x] Follows `examples/{algorithm}/{finetune_type}/{model_type}/{variant}.yaml` convention
- [x] Verified on 8× H200 with reward improvement observed