### PR TITLE
[docker] add CUDA 12.9 training image with user docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Build context is the repo root. Keep `diffusers/` and `README.md` (setuptools).
+.git
+**/__pycache__
+**/*.py[cod]
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/.tox
+.cursor
+.gitignore
+# Local promo tree with node_modules/artifacts; not required for the training image
+xiaohongshu
+# Submodule metadata; source still copied from `diffusers/` working tree
+diffusers/.git

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ pip install -e .[deepspeed]
 > pip install -e ./diffusers
 > ```
 
+A CUDA training image (Python 3.12, **uv**-based install, PyTorch 2.8 + `cu129`, `deepspeed`, `wandb`, bundled `diffusers`) is defined under [`docker/docker-cuda/`](docker/docker-cuda/Dockerfile). See [`docker/README.md`](docker/README.md) for build and run instructions (including `linux/amd64` on Apple Silicon).
+
 ## Experiment Trackers
 
 To use [Weights & Biases](https://wandb.ai/site/) or [SwanLab](https://github.com/SwanHubX/SwanLab) to log experimental results, install extra dependencies via `pip install -e .[wandb]` or `pip install -e .[swanlab]`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,135 @@
+# Docker (CUDA) — Flow-Factory Training Image
+
+Pre-built GPU training image for Flow-Factory: CUDA 12.9, Python 3.12, PyTorch 2.8, DeepSpeed, and W&B — ready to run `ff-train` out of the box.
+
+## Prerequisites
+
+| Requirement | Minimum |
+|---|---|
+| **OS** | Linux (x86_64) |
+| **GPU** | NVIDIA with Compute Capability ≥ 7.0 |
+| **NVIDIA Driver** | ≥ 535 |
+| **Docker** | ≥ 24.0 |
+| **NVIDIA Container Toolkit** | [Install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) |
+
+> **Apple Silicon (M1–M4):** The image is `linux/amd64` only. You can use it for smoke tests and CLI checks via Docker Desktop's QEMU emulation, but there is no CUDA-capable GPU on macOS — real training requires a Linux + NVIDIA host.
+
+## Quick start
+
+### A. Pull a prebuilt image (recommended)
+
+```bash
+docker pull ghcr.io/x-gengroup/flow-factory:0.1.0
+# or: docker pull ghcr.io/x-gengroup/flow-factory:latest
+```
+
+Run:
+
+```bash
+docker run --rm -it --gpus all ghcr.io/x-gengroup/flow-factory:0.1.0
+```
+
+### B. Build locally
+
+Clone with the `diffusers` submodule (required):
+
+```bash
+git clone --recursive https://github.com/X-GenGroup/Flow-Factory.git
+cd Flow-Factory
+# or, if already cloned: git submodule update --init --recursive
+```
+
+Build from the **repository root**:
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -f docker/docker-cuda/Dockerfile \
+  -t flow-factory:local --load .
+```
+
+Run:
+
+```bash
+docker run --rm -it --gpus all flow-factory:local
+```
+
+## Running a training job
+
+### Single-GPU example
+
+```bash
+docker run --rm -it --gpus all \
+  ghcr.io/x-gengroup/flow-factory:0.1.0 \
+  ff-train examples/grpo/lora/flux1/default.yaml
+```
+
+### With custom configs and output directory
+
+```bash
+docker run --rm -it --gpus all \
+  -v /path/to/my-configs:/app/configs:ro \
+  -v /path/to/outputs:/app/outputs \
+  ghcr.io/x-gengroup/flow-factory:0.1.0 \
+  ff-train /app/configs/my_experiment.yaml
+```
+
+### Multi-GPU with DeepSpeed
+
+```bash
+docker run --rm -it --gpus all --ipc=host --shm-size=16g \
+  ghcr.io/x-gengroup/flow-factory:0.1.0 \
+  ff-train examples/grpo/lora/flux1/default.yaml
+```
+
+> **Note:** `--ipc=host` (or `--shm-size=16g`) is required for DeepSpeed / NCCL multi-GPU communication.
+
+## Configuration
+
+| Option | Example |
+|---|---|
+| **W&B tracking** | `-e WANDB_API_KEY=your_key` |
+| **Mount data** | `-v /host/data:/app/data:ro` |
+| **Mount outputs** | `-v /host/outputs:/app/outputs` |
+| **Shared memory** | `--ipc=host` or `--shm-size=16g` |
+| **PyTorch mirror** (build-time) | `--build-arg PYTORCH_INDEX_URL=https://your-mirror/whl/cu129` |
+
+The working directory inside the image is `/app` (a copy of the repo at build time). For live-editing, mount a bind volume over `/app` or a subdirectory.
+
+Do not commit secrets; use environment variables or your orchestrator's secret store.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `nvidia-smi` not found in container | NVIDIA Container Toolkit not installed | [Install the toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) and restart Docker |
+| `CUDA out of memory` | Batch size too large for GPU VRAM | Reduce batch size, enable DeepSpeed ZeRO-3, or use FSDP |
+| Build fails on `diffusers` install | Submodule not initialized | Run `git submodule update --init --recursive` |
+| Every source change triggers full rebuild | Expected with `COPY . /app` | The Dockerfile uses two-phase COPY for layer caching; ensure `pyproject.toml` is unchanged for cache hits |
+
+## Building tips
+
+- **Layer caching**: The Dockerfile copies `pyproject.toml` first and installs dependencies, then copies the full source. As long as `pyproject.toml` doesn't change, PyTorch/DeepSpeed layers are cached.
+- **Fast iteration**: For development, mount your source as a volume (`-v $(pwd):/app`) instead of rebuilding the image.
+- **PyTorch index override**: Pass `--build-arg PYTORCH_INDEX_URL=...` to use a mirror or different CUDA version.
+- **Apple Silicon**: Always pass `--platform linux/amd64` when building or running on Mac.
+
+---
+
+<details>
+<summary><strong>For maintainers: publishing to GHCR</strong></summary>
+
+After building locally (e.g. as `flow-factory:local`), tag and push:
+
+```bash
+docker tag flow-factory:local ghcr.io/x-gengroup/flow-factory:0.1.0
+docker tag flow-factory:local ghcr.io/x-gengroup/flow-factory:latest
+echo $GITHUB_PAT | docker login ghcr.io -u $GITHUB_USER --password-stdin
+docker push ghcr.io/x-gengroup/flow-factory:0.1.0
+docker push ghcr.io/x-gengroup/flow-factory:latest
+```
+
+Requires a GitHub PAT with **`write:packages`** scope and appropriate org access. Prefer CI (e.g. GitHub Actions) for repeatable releases.
+
+Users who need reproducible deploys should pin by **digest** rather than moving tags.
+
+</details>

--- a/docker/docker-cuda/Dockerfile
+++ b/docker/docker-cuda/Dockerfile
@@ -1,0 +1,65 @@
+# Build from repository root (includes diffusers submodule):
+#   docker buildx build --platform linux/amd64 -f docker/docker-cuda/Dockerfile -t flow-factory:local --load .
+#
+# Apple Silicon: always pass --platform linux/amd64 for this training image.
+# Python 3.12 + uv: dependency installs use `uv pip` (same resolution model as pip, faster).
+FROM nvidia/cuda:12.9.1-devel-ubuntu22.04
+
+LABEL org.opencontainers.image.source="https://github.com/X-GenGroup/Flow-Factory"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.description="Flow-Factory GPU training image (CUDA 12.9 + Python 3.12)"
+
+# Pin uv version; see https://docs.astral.sh/uv/guides/docker/
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /uvx /usr/local/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
+# No pip cache inside image layers
+ENV UV_NO_CACHE=1
+ENV UV_LINK_MODE=copy
+# Skip .pyc generation: smaller layers; both uv and Python runtime agree
+ENV UV_COMPILE_BYTECODE=0
+ENV PYTHONDONTWRITEBYTECODE=1
+
+SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    ffmpeg \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN uv venv /opt/ff-venv --python 3.12
+ENV PATH="/opt/ff-venv/bin:$PATH"
+ENV VIRTUAL_ENV=/opt/ff-venv
+ENV UV_PROJECT_ENVIRONMENT=/opt/ff-venv
+
+WORKDIR /app
+
+# --- Phase 1: install dependencies (cached unless pyproject.toml changes) ---
+COPY pyproject.toml README.md /app/
+# Stub src dir so setuptools find_packages can resolve without full source
+RUN mkdir -p /app/src/flow_factory && touch /app/src/flow_factory/__init__.py
+
+ARG PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu129
+RUN uv pip install \
+    torch==2.8.0 \
+    torchvision==0.23.0 \
+    torchaudio==2.8.0 \
+    --index-url "${PYTORCH_INDEX_URL}"
+
+RUN uv pip install ".[deepspeed,wandb]"
+
+# --- Phase 2: copy full source and re-link editable installs ---
+COPY . /app
+RUN uv pip install --no-deps -e .
+RUN uv pip install -e ./diffusers
+
+# Fail fast if any layer is broken
+RUN python -c "import deepspeed, torch, wandb; print('torch', torch.__version__)" && ff-train --help >/dev/null
+
+# Intentionally root: DeepSpeed / NCCL may need elevated IPC access.
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

- Add `docker/docker-cuda/Dockerfile`: GPU training image based on `nvidia/cuda:12.9.1-devel-ubuntu22.04` with Python 3.12, uv, PyTorch 2.8 (cu129), DeepSpeed, and W&B
- Add `docker/README.md`: user-facing docs covering prerequisites, quick start (pull / build), training examples, configuration, troubleshooting, and building tips
- Add `.dockerignore` to keep the build context clean
- Add a Docker reference line in the root `README.md` under the installation section

## Key design decisions

- **Two-phase COPY** for Docker layer caching: `pyproject.toml` is copied first to install dependencies, then full source is copied — source-only changes skip the ~10min PyTorch/DeepSpeed reinstall
- **`UV_NO_CACHE=1`** globally instead of per-command `--no-cache` flags
- **OCI labels** for registry discoverability
- **Editable installs** of both `flow-factory` and the `diffusers` submodule so in-repo pipeline code is always in sync
- README focuses on **user workflows** (pull → run → train); maintainer publishing instructions are collapsed in a `<details>` block

## Test plan

- [ ] Build image from repo root: `docker buildx build --platform linux/amd64 -f docker/docker-cuda/Dockerfile -t flow-factory:test --load .`
- [ ] Verify build validation passes (import check + `ff-train --help`)
- [ ] Verify layer caching: modify a `.py` file and rebuild — PyTorch/DeepSpeed layers should be cached
- [ ] Run container with GPU: `docker run --rm -it --gpus all flow-factory:test`
- [ ] Review `docker/README.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)