### PR TITLE
[docs] chore: enforce scratch file constraint in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 AGENTS.md
+
+# Hard Rules (always enforced, including sub-agents)
+
+- **Scratch files only** — All temporary/intermediate files (analysis reports, investigation notes, checklists, diagrams) MUST go under `.scratch/` (git-ignored). NEVER write to the project root or any tracked directory.


### PR DESCRIPTION
## Summary
- Add scratch file rule directly to `CLAUDE.md` so sub-agents (which cannot see `AGENTS.md` or `constraints.md`) are also bound by it

## Context
Sub-agents spawned via the Agent tool start fresh sessions without access to project-level `AGENTS.md` or `.agents/knowledge/constraints.md`. This caused repeated violations where intermediate analysis files were written to the project root instead of `.scratch/`. Since `CLAUDE.md` is force-loaded at session level for all agents, placing the rule there closes the gap.

## Test plan
- [x] Verify `CLAUDE.md` still correctly references `AGENTS.md`
- [x] Confirm `.scratch/` is in `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)