### PR TITLE
[docs] readme: CRD algorithm row + table alignment (follow-up to #152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ This experimental feature leverages `diffusers`'s `transformer.set_attention_bac
 | AWM            | awm            | [Advantage Weighted Matching](https://arxiv.org/abs/2509.25050) |
 | DGPO           | dgpo           | [DGPO](https://arxiv.org/abs/2510.08425) |
 | GRPO-Guard     | grpo-guard     | [GRPO-Guard](https://arxiv.org/abs/2510.22319) |
+| CRD            | crd            | [Centered Reward Distillation](https://arxiv.org/abs/2603.14128) |
 
 See [`Algorithm Guidance`](guidance/algorithms.md) for more information.
 
 > Model and algorithm are fully decoupled in Flow-Factory, enabling all listed model–algorithm combinations to work out of the box. The configurations under `examples/` have been verified to yield measurable performance gains. For unlisted combinations, find the closest (task, algorithm) config and swap in the desired model or algorithm parameters.
 
-# 💾 Hardward Requirements
+# 💾 Hardware Requirements
 
 # 🚀 Get Started
 


### PR DESCRIPTION
Restores the README CRD row reverted in #153, with review-style fixes:

- Align the CRD row columns with the other algorithm table rows.
- Fix heading typo: Hardward → Hardware.

Refs #152
Closes follow-up from revert #153

Made with [Cursor](https://cursor.com)