### PR TITLE
[adapter] refactor: tidy _resolve_checkpoint_path call sites

### DIFF
--- a/src/flow_factory/models/abc.py
+++ b/src/flow_factory/models/abc.py
@@ -1494,14 +1494,14 @@ class BaseAdapter(ABC):
         # Normalize leading ``~`` for local-path inputs; no-op for HF specs since
         # ``expanduser`` only acts on a leading ``~``.
         path = os.path.expanduser(path)
-
         force_hf = path.startswith(HF_PATH_PREFIX)
-        spec = path[len(HF_PATH_PREFIX):] if force_hf else path
 
-        if not force_hf and os.path.exists(spec):
-            return spec
+        # Local path wins unless an explicit ``hf://`` prefix forces remote.
+        if not force_hf and os.path.exists(path):
+            return path
 
-        repo_id, subfolder, revision = parse_hf_checkpoint_path(spec)
+        # ``parse_hf_checkpoint_path`` handles the ``hf://`` prefix internally.
+        repo_id, subfolder, revision = parse_hf_checkpoint_path(path)
 
         try:
             local_path = download_hf_checkpoint(repo_id, subfolder, revision)
@@ -1746,10 +1746,6 @@ class BaseAdapter(ABC):
                 - None: Auto-detect based on checkpoint directory contents
         """
         path = self._resolve_checkpoint_path(path)
-        if not os.path.exists(path):
-            raise FileNotFoundError(
-                f"Checkpoint path not found locally or on Hugging Face Hub: {path!r}"
-            )
 
         # Auto-detect if not specified
         if resume_type is None:

--- a/src/flow_factory/models/abc.py
+++ b/src/flow_factory/models/abc.py
@@ -1491,6 +1491,10 @@ class BaseAdapter(ABC):
         Raises:
             FileNotFoundError: When the spec is neither a local path nor a reachable HF repo.
         """
+        # Normalize leading ``~`` for local-path inputs; no-op for HF specs since
+        # ``expanduser`` only acts on a leading ``~``.
+        path = os.path.expanduser(path)
+
         force_hf = path.startswith(HF_PATH_PREFIX)
         spec = path[len(HF_PATH_PREFIX):] if force_hf else path
 
@@ -1741,7 +1745,6 @@ class BaseAdapter(ABC):
                 - 'state': Load full training state (model + optimizer + scheduler + RNG)
                 - None: Auto-detect based on checkpoint directory contents
         """
-        path = os.path.expanduser(path)
         path = self._resolve_checkpoint_path(path)
         if not os.path.exists(path):
             raise FileNotFoundError(


### PR DESCRIPTION
## Summary

Two small follow-up refactors to `BaseAdapter._resolve_checkpoint_path` and `BaseAdapter.load_checkpoint`, both prompted by re-reading the code after PR #160 was merged. No behavior change.

## What changes

**A. Hoist `os.path.expanduser` into `_resolve_checkpoint_path`** (commit 1)

Currently `load_checkpoint` does:

```python
path = os.path.expanduser(path)
path = self._resolve_checkpoint_path(path)
```

The two normalization steps belong together. `_resolve_checkpoint_path` is the one entry point that takes a raw user-provided spec (local path OR HF repo spec, with or without `hf://`) and returns a usable local directory; making it own `expanduser` too means callers no longer have to remember to normalize `~` separately.

Safe across all three input branches:
- Local path with `~`: expanded correctly (unchanged behavior).
- Local path without `~`: no-op.
- HF spec (`owner/repo` or `hf://...`): no-op since `expanduser` only acts on a leading `~`.

`ModelArguments.__post_init__` still calls `expanduser(resume_path)` defensively at config-parse time, so other code that displays/logs `model_args.resume_path` keeps seeing the normalized form. The double call is idempotent.

**B. Drop dead `os.path.exists` guard + collapse `spec` local** (commit 2)

After the un-gating in PR #160, `_resolve_checkpoint_path` has these exit paths:
1. Returns a local path it has just confirmed with `os.path.exists`.
2. Returns a downloaded path that `download_hf_checkpoint` has verified with `os.path.isdir`.
3. Raises `FileNotFoundError` with the actual root cause.

So the post-resolve check in `load_checkpoint` was unreachable AND its error message lied about the failure mode (it said "not found locally or on HF Hub", but `_resolve_checkpoint_path` would already have raised the real reason). Removed:

```python
path = self._resolve_checkpoint_path(path)
if not os.path.exists(path):
    raise FileNotFoundError(...)   # unreachable; misleading message
```

Same commit also collapses the redundant `spec` local in `_resolve_checkpoint_path`. `parse_hf_checkpoint_path` already strips the `hf://` prefix internally, and the local-path `os.path.exists` check is gated on `not force_hf`, so passing `path` directly (with the prefix still attached on the HF branch) is safe. One fewer variable for the reader to track.

## Diff

Net: `-9/+8` in `src/flow_factory/models/abc.py`. No other files touched.

## Test plan

- [x] Pre-existing parser unit cases (8 happy + 5 error + 6 path-traversal) still pass — these refactors don't touch the parser.
- [x] No new imports, no public API change, no config change.
- [ ] Single-GPU smoke: load LoRA from `resume_path: "owner/repo"` (will exercise the cleaned-up flow).

## Out of scope

- `ModelArguments.__post_init__`'s `expanduser` call — kept; defensive normalization at config-parse time, idempotent with the resolver, removing it could surprise other readers of `model_args.resume_path`.

Made with [Cursor](https://cursor.com)