### PR TITLE
[trainer,hparams,scheduler] feat: DiffusionOPD on-policy distillation trainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,135 +1,90 @@
 # Changelog
 
-## Unreleased — `feat/diffusion-opd`
+## Unreleased — `feat/diffusion-opd` (merge to `main`)
 
-**Branch:** `feat/diffusion-opd` (off `main` @ `#168`)
+**Full range:** `652f7315..e4496c6` (2026-05-26 … 2026-06-02)
 **Repo:** [X-GenGroup/Flow-Factory](https://github.com/X-GenGroup/Flow-Factory)
+**Branch:** `feat/diffusion-opd`
 
-Adds **DiffusionOPD** ([paper](https://arxiv.org/abs/2605.15055)), a multi-teacher
-on-policy distillation trainer built on the multi-dataset infrastructure from
-#168. One LoRA teacher per training source is distilled into a single student
-along the student's own rollout trajectories via a closed-form per-step KL
-(pathwise mean-matching), supporting **both ODE and SDE** dynamics.
+This branch stacks two features onto `main` (at `652f7315`):
 
-### Added
+| Part | Range on branch | PR / feature |
+|------|-----------------|--------------|
+| A — Multi-dataset training & eval | `652f7315..02c581a` | [#168](https://github.com/X-GenGroup/Flow-Factory/pull/168) (squash commit `02c581a`) |
+| B — DiffusionOPD | `02c581a..e4496c6` | On-policy multi-teacher distillation (this branch) |
 
-- **`trainer_type: diffusion-opd`** — `DiffusionOPDTrainer`
-  (`trainers/opd/trainer.py`), registered in `trainers/registry.py`. Uses a
-  2-pass `optimize()`: PASS 1 (`no_grad`) caches each teacher's per-step
-  transition mean `mu_T` on its routed samples with **one weight swap per
-  teacher**; PASS 2 runs a student-only gradient loop matching each sample's
-  `mu_S` to its own cached `mu_T` (per-step loss `kl_div_j`). Reuses the GRPO
-  trajectory-replay primitives and the `sample() → optimize()` lifecycle.
-  Rewards are used only for eval monitoring.
-- **`DiffusionOPDTrainingArguments` + `TeacherConfig`**
-  (`hparams/training_args/opd.py`): `teachers` (list of
-  `{path, name, applicable_datasets, guidance_scale}`) and
-  `teacher_param_device`. Registered under key `diffusion-opd`; exported from
-  `hparams`. Overrides `get_preprocess_guidance_scale()` to cover the max of the
-  student and any per-teacher CFG. The schema permits several teachers to share
-  a dataset (for a future multi-teacher/ensemble trainer); the current
-  `DiffusionOPDTrainer` enforces one teacher per dataset.
-- **`SDESchedulerMixin.get_kl_divergence_denominator(std_dev_t, dt)`**
-  (`scheduler/abc.py`): centralizes the per-dynamics transition variance so the
-  distillation loss is dynamics-agnostic — `1.0` for ODE,
-  `std_dev_t²·(-dt)` for Flow-SDE/Dance-SDE, `std_dev_t²` for CPS (clamped to
-  `>= eps`).
-- **`trainers/opd/common.py`** — `load_teachers`: loads each teacher LoRA into a
-  named-parameter snapshot (snapshot student → `_load_lora` → `add_named_parameters`
-  → restore student) with a clear LoRA-architecture compatibility error. LoRA
-  teachers only; full-parameter teachers deferred.
-- **`Arguments._validate_teacher_sources`** (`hparams/args.py`): fail-fast config
-  validation that every teacher `applicable_datasets` entry is a declared training
-  dataset. The one-teacher-per-dataset rule is enforced in `DiffusionOPDTrainer`
-  (not here), keeping the schema reusable. No-op for non-OPD trainers.
-- **Examples** under `examples/opd/lora/sd3_5/`: `DiffusionOPD_aligned.yaml`
-  (3 Hugging Face teachers — GenEval/OCR/Aes — aligned to the upstream `mopd`
-  recipe: `group_size=1`, `per_device_batch_size=3`, the Aes teacher distilled
-  on the `pickscore` dataset, per-teacher CFG 4.5/4.5/1.0) and
-  `geneval_pickscore_ocr.yaml` (3 local-checkpoint teachers). Both default to
-  `dynamics_type: ODE`; switch to `Flow-SDE` + `noise_level > 0` for SDE
-  distillation.
+Part B requires Part A (`data.datasets`, multi-source train loaders, per-dataset eval).
 
-### Docs
+---
 
-- `guidance/algorithms.md`: new "DiffusionOPD: On-Policy Distillation" section +
-  reference [14].
-- `README.md` / `examples/README.md`: list the `diffusion-opd` trainer and the
-  new `opd` examples.
+## Part A — Multi-dataset training & eval (#168)
 
-## Unreleased — `feat/multi-eval-dataset`
-
-**Range:** `652f7315..HEAD` (2026-05-26 … 2026-05-31)
-**Repo:** [X-GenGroup/Flow-Factory](https://github.com/X-GenGroup/Flow-Factory)
-**Branch:** `feat/multi-eval-dataset`
+**Range:** `652f7315..02c581a` (2026-05-26 … 2026-05-31)
+**Squash commit on branch:** `02c581a`
 **PR:** [#168](https://github.com/X-GenGroup/Flow-Factory/pull/168)
 
-> Note: the commit table below covers the original `f2b2100..15c3943` stack.
-> A later review round (see "Post-review hardening" at the end) removed the
-> `_canonicalize_legacy_dataset_dir` shim, migrated all examples to
-> `data.datasets`, renamed `RewardArguments.datasets` →
-> `applicable_datasets`, and added per-dataset reward weights — so some
-> paragraphs below describing the legacy-canonicalization behavior are
-> superseded by that section.
+Unified configuration and runtime support for **multiple named datasets** in one
+training run: weighted multi-source training, per-dataset eval with independent
+reward routing, and source-aware reward gating with NaN-padded cross-rank transport.
 
-### Commit ranges by phase
+> The commit table below documents **PR #168 development history** (individual
+> commits before squash). On `feat/diffusion-opd` the entire feature lands as a
+> single squash commit `02c581a`. A post-merge review round (still within `02c581a`)
+> removed legacy `data.dataset_dir` canonicalization, renamed reward routing fields,
+> and migrated all example YAMLs — see [Post-review hardening](#post-review-hardening-after-15c3943).
+
+### Commit ranges by phase (PR #168 development)
 
 | Phase | Range | Date | What |
 |-------|-------|------|------|
-| Pre-existing multi-eval foundation (merged before this stack) | `8e573cc..33d678b` | 2026-05-26 | Initial multi-eval support + per-dataset reward routing + per-dataset overrides |
-| Plan steps 1–12 (multi-training-dataset infra) | `f2b2100..cf3a3f7` | 2026-05-30 | Unified `data.datasets` schema, exact partitioning, source-aware gate, NaN-pad transport, multi_source.yaml example |
-| Review items 1, 4, 5, 6, 7, 8, 9 (post-implementation tightening) | `56c1b67..3d1d098` | 2026-05-30 | Naming / ordering / typed source fields / integer weights / eager resolution / cleanup |
-| Eval-path unification (merge steps 1, 3, 4, 5, 6) | `5a00d9b..15c3943` | 2026-05-30 | Single eval implementation; rename `get_dataloader` → `get_train_dataloader` |
+| Pre-existing multi-eval foundation | `8e573cc..33d678b` | 2026-05-26 | Initial multi-eval + per-dataset reward routing + per-dataset eval overrides |
+| Plan steps 1–12 (multi-training-dataset infra) | `f2b2100..cf3a3f7` | 2026-05-30 | Unified `data.datasets` schema, exact partitioning, source-aware gate, NaN-pad transport, `multi_source.yaml` |
+| Review items 1–9 | `56c1b67..3d1d098` | 2026-05-30 | Naming, typed `source`/`source_id`, integer weights, eager reward resolution, cleanup |
+| Eval-path unification | `5a00d9b..15c3943` | 2026-05-30 | Single `evaluate()`; `get_dataloader` → `get_train_dataloader` + `get_eval_dataloaders` |
 
-### Commit list
+### Commit list (PR #168 development)
 
 | Hash | Date | Subject |
 |------|------|---------|
 | `15c3943` | 2026-05-30 | `[review,merge-6]` CHANGELOG.md: document eval-merge breaking changes |
-| `9e38246` | 2026-05-30 | `[review,merge-5]` drop self.test_dataloader and self.eval_reward_buffer |
-| `b4717f4` | 2026-05-30 | `[review,merge-4]` delete _evaluate_single_dataset; unify into evaluate() |
-| `b360984` | 2026-05-30 | `[review,merge-3]` route legacy test through get_eval_dataloaders; drop _build_legacy_test_dataloader |
-| `5a00d9b` | 2026-05-30 | `[review,merge-1]` rename: get_dataloader -> get_train_dataloader; train-only return |
+| `9e38246` | 2026-05-30 | `[review,merge-5]` drop `self.test_dataloader` and `self.eval_reward_buffer` |
+| `b4717f4` | 2026-05-30 | `[review,merge-4]` delete `_evaluate_single_dataset`; unify into `evaluate()` |
+| `b360984` | 2026-05-30 | `[review,merge-3]` route legacy test through `get_eval_dataloaders`; drop `_build_legacy_test_dataloader` |
+| `5a00d9b` | 2026-05-30 | `[review,merge-1]` rename: `get_dataloader` → `get_train_dataloader`; train-only return |
 | `3d1d098` | 2026-05-30 | `[review,item-8]` cleanups: explicit batch_size, deepcopy shim, inverse routing check |
 | `94f28ba` | 2026-05-30 | `[review,items-2+3]` feat: per-source spec fields + unified single/multi path |
 | `933beae` | 2026-05-30 | `[review,item-7]` feat: integer weights + exact-divisibility partition |
-| `0a612bb` | 2026-05-30 | `[review,item-6]` feat: promote source/source_id to first-class BaseSample fields |
-| `6be080f` | 2026-05-30 | `[review,item-9]` feat: eager `RewardArguments.datasets` resolution |
+| `0a612bb` | 2026-05-30 | `[review,item-6]` feat: promote `source`/`source_id` to first-class `BaseSample` fields |
+| `6be080f` | 2026-05-30 | `[review,item-9]` feat: eager `RewardArguments.applicable_datasets` resolution |
 | `fd2e2bd` | 2026-05-30 | `[review,item-4]` reorder: training-before-eval parameters and accessors |
-| `521a9bb` | 2026-05-30 | `[review,item-1]` rename: dl -> loader (consistent with project naming) |
-| `56c1b67` | 2026-05-30 | `[review,item-5]` cleanup: drop object.__getattribute__ paranoia in gate/aggregation |
-| `cf3a3f7` | 2026-05-30 | `[examples]` feat: multi_source.yaml smoke config (step 12) |
-| `610a80f` | 2026-05-30 | `[trainers]` feat: BaseTrainer __source__ injection + set_epoch propagation (step 11) |
-| `da62f47` | 2026-05-30 | `[advantage]` feat: applicability-aware aggregation (step 10) |
-| `993d144` | 2026-05-30 | `[rewards,samples]` feat: source-aware reward gate with NaN-padded transport (step 9) |
-| `de40eec` | 2026-05-30 | `[rewards,trainers]` feat: MultiRewardLoader training_dataset_names plumbing (step 8) |
-| `b3e74c7` | 2026-05-30 | `[data_utils,trainers]` feat: multi-source train dataloader infra (step 7) |
-| `4662279` | 2026-05-30 | `[data_utils]` feat: get_data_sampler unique_sample_num override (step 6, later removed by review-2+3) |
-| `e072d1c` | 2026-05-30 | `[hparams]` feat: shared `_align_unique_sample_num` + multi-source partition (step 5) |
-| `33a9349` | 2026-05-30 | `[hparams,trainers,data_utils]` feat: switch eval consumers to data.datasets (step 4) |
-| `5f84e05` | 2026-05-30 | `[hparams]` feat: top-level eval_datasets deprecation shim (step 3) |
-| `c01909e` | 2026-05-30 | `[hparams]` feat: data.datasets field + per-split properties + validators (step 2) |
-| `f2b2100` | 2026-05-30 | `[hparams]` feat: unified DatasetArguments schema (step 1) |
+| `521a9bb` | 2026-05-30 | `[review,item-1]` rename: `dl` → `loader` |
+| `56c1b67` | 2026-05-30 | `[review,item-5]` cleanup: drop `object.__getattribute__` paranoia in gate/aggregation |
+| `cf3a3f7` | 2026-05-30 | `[examples]` feat: `multi_source.yaml` smoke config |
+| `610a80f` | 2026-05-30 | `[trainers]` feat: `BaseTrainer` `__source__` injection + `set_epoch` propagation |
+| `da62f47` | 2026-05-30 | `[advantage]` feat: applicability-aware aggregation |
+| `993d144` | 2026-05-30 | `[rewards,samples]` feat: source-aware reward gate with NaN-padded transport |
+| `de40eec` | 2026-05-30 | `[rewards,trainers]` feat: `MultiRewardLoader` `training_dataset_names` plumbing |
+| `b3e74c7` | 2026-05-30 | `[data_utils,trainers]` feat: multi-source train dataloader infra |
+| `4662279` | 2026-05-30 | `[data_utils]` feat: `get_data_sampler` `unique_sample_num` override (later removed) |
+| `e072d1c` | 2026-05-30 | `[hparams]` feat: shared `_align_unique_sample_num` + multi-source partition |
+| `33a9349` | 2026-05-30 | `[hparams,trainers,data_utils]` feat: switch eval consumers to `data.datasets` |
+| `5f84e05` | 2026-05-30 | `[hparams]` feat: top-level `eval_datasets` deprecation shim |
+| `c01909e` | 2026-05-30 | `[hparams]` feat: `data.datasets` field + per-split properties + validators |
+| `f2b2100` | 2026-05-30 | `[hparams]` feat: unified `DatasetArguments` schema |
 | `33d678b` | 2026-05-26 | refactor: simplify multi-eval implementation after code review |
 | `cb3c434` | 2026-05-26 | feat: add per-dataset eval generation overrides |
 | `8e573cc` | 2026-05-26 | feat: support multiple eval datasets with per-dataset reward routing |
+| `02c581a` | 2026-05-31 | **Squash merge** of #168 onto branch (includes post-review hardening) |
 
----
-
-### Breaking changes
+### Breaking changes (#168)
 
 #### Eval metric key rename
 
-All eval now flows through the unified per-dataset `evaluate()`. Configs
-declare datasets explicitly via `data.datasets` (each entry named, e.g.
-`default`); the eval metric keys are namespaced by that dataset name.
-(Earlier on this branch a `_canonicalize_legacy_dataset_dir` shim
-auto-promoted a bare `data.dataset_dir`; that shim was later removed —
-see "Post-review hardening" — and bare `data.dataset_dir` is now
-rejected, so the `default` namespace simply reflects the dataset entry's
-name.)
+All eval flows through the unified per-dataset `evaluate()`. Configs declare
+datasets via `data.datasets` (each entry has a `name`, e.g. `default`); eval
+metric keys are namespaced by that name.
 
-Consequence — eval metric keys move from:
+Keys move from:
 
 ```
 eval/reward_<name>_mean
@@ -140,46 +95,41 @@ eval_samples
 to:
 
 ```
-eval/default/reward_<name>_mean
-eval/default/reward_<name>_std
-eval/default/samples
+eval/<dataset_name>/reward_<name>_mean
+eval/<dataset_name>/reward_<name>_std
+eval/<dataset_name>/samples
 ```
 
-W&B / TensorBoard dashboards / alerts / aggregations targeting the old
-keys must be updated (find-and-replace `eval/reward_` →
+W&B / TensorBoard dashboards must update (e.g. `eval/reward_` →
 `eval/default/reward_`; `eval_samples` → `eval/default/samples`).
 
-Landed in: `b4717f4` (step 4 of eval merge).
+Landed in: `b4717f4` (eval merge).
 
 #### Eval cache one-time reprocess
 
-The unified eval path adds an `eval_<name>` token (here `eval_default`)
-to the preprocessing-cache fingerprint. Existing
-`~/.cache/flow_factory/datasets/...` entries from the old code path
-do not match the new fingerprint, so the test split is reprocessed
-once on the next run. Training caches are unaffected.
+The unified eval path adds an `eval_<name>` token to the preprocessing-cache
+fingerprint. Existing `~/.cache/flow_factory/datasets/...` entries from the old
+path do not match, so the test split is reprocessed once on the next run.
+Training caches are unaffected.
 
-Landed in: `b360984` (step 3 of eval merge).
+Landed in: `b360984` (eval merge).
 
 #### Removed `BaseTrainer` attributes
 
-These were used only by the deleted legacy single-eval path; subclasses
-(GRPO / CRD / DGPO / NFT / AWM / DPO) never referenced them. Forks
-that did need to migrate to the per-dataset shape:
+Used only by the deleted legacy single-eval path:
 
 - `self.test_dataloader` → `self.eval_dataloaders` (`Dict[str, DataLoader]`).
 - `self.eval_reward_buffer` → `self.eval_dataset_reward_buffers[name]`.
 - `self.eval_reward_processor` → `self.eval_dataset_reward_processors[name]`.
-- Private methods `_evaluate_single_dataset` / `_evaluate_multi_dataset`
-  are gone; `evaluate()` is the single eval entry point.
+- `_evaluate_single_dataset` / `_evaluate_multi_dataset` removed; `evaluate()`
+  is the single entry point.
 
-Landed in: `9e38246` (step 5 of eval merge).
+Landed in: `9e38246` (eval merge).
 
 #### Renamed `data_utils.get_dataloader` → `get_train_dataloader`
 
-The function now returns a 2-tuple `(train_loader, train_loaders_by_source)`
-— the test-loader return slot has moved to `get_eval_dataloaders`.
-The eval / test path is fully owned by `get_eval_dataloaders`.
+Returns `(train_loader, train_loaders_by_source)`; eval is owned by
+`get_eval_dataloaders`.
 
 ```python
 # Before
@@ -189,141 +139,162 @@ train, test, by_source = get_dataloader(config, accelerator, ...)
 # After
 from flow_factory.data_utils.loader import get_train_dataloader, get_eval_dataloaders
 train, by_source = get_train_dataloader(config, accelerator, ...)
-eval_dict = get_eval_dataloaders(config.data_args.eval_datasets, ...)
+eval_dict = get_eval_dataloaders(config.data_args.eval_datasets, config, accelerator, ...)
 ```
 
-Landed in: `5a00d9b` (step 1 of eval merge).
+Landed in: `5a00d9b` (eval merge).
 
 #### Top-level `eval_datasets:` YAML key deprecated
 
-YAMLs using the brief-lived top-level `eval_datasets:` field (introduced
-on this same branch in `8e573cc..33d678b`) are auto-migrated to
-`data.datasets[*].eval` with a single `DeprecationWarning` per config
-load. The shim is scheduled for removal one release after this PR
-ships.
+YAMLs using the brief-lived top-level `eval_datasets:` field are auto-migrated
+to `data.datasets[*].eval` with a `DeprecationWarning` per config load. Scheduled
+for removal one release after #168 ships.
 
-Landed in: `5f84e05` (step 3 of plan).
+Landed in: `5f84e05` (plan step 3); migration shim: `_migrate_legacy_eval_datasets`.
 
 #### `RewardArguments.applicable_datasets` semantic change
 
-The reward-routing field (named `datasets` when first introduced, later
-renamed to `applicable_datasets`) is eagerly resolved at config load
-time: `None` (the user-supplied default) becomes the explicit list of
-applicable side names — so `print(config)` shows a concrete `List[str]`
-instead of `null`. Empty list `[]` is honored as "this reward never
-fires" with a warning.
+The routing field (named `datasets` when first introduced, renamed to
+`applicable_datasets` in post-review hardening) is eagerly resolved at config
+load: `None` becomes the explicit list of applicable dataset names. Empty list
+`[]` is honored as "never fires" with a warning.
 
-Landed in: `6be080f` (review item 9); renamed to `applicable_datasets`
-in the post-review hardening round.
+Landed in: `6be080f` (review item 9); rename in post-review hardening.
 
 #### Integer `train.weight` required
 
-`DatasetTrainSpec.weight` must be a positive integer (float values that
-are integer-valued, e.g. `1.0`, are silently coerced; non-integer
-floats raise). Combined with `num_batches_per_epoch %
-sum(weights) == 0` enforcement, this geometrically guarantees every
-batch comes from a single source.
+`DatasetTrainSpec.weight` must be a positive integer (integer-valued floats like
+`1.0` are coerced; non-integer floats raise). With `num_batches_per_epoch %
+sum(weights) == 0`, every batch is guaranteed to come from a single source.
 
 Landed in: `933beae` (review item 7).
 
----
+#### Legacy `data.dataset_dir` rejected (post-review)
 
-### Non-breaking additive features
+After post-review hardening, **bare `data.dataset_dir` without `data.datasets` is
+rejected** (mutual exclusion when both are set). All example YAMLs use
+`data.datasets` with per-entry `dataset_dir`. The earlier
+`_canonicalize_legacy_dataset_dir` shim was removed.
 
-Everything in the rest of this branch lands as additive features — no
-existing code paths regress, and the legacy single-source training
-flow is byte-identical for configs that don't opt into multi-source:
+### Added (#168)
 
-- **Unified `data.datasets:` schema** with per-entry `train:` / `eval:`
-  sub-blocks (legacy `data.dataset_dir` and top-level `eval_datasets:`
-  are auto-canonicalized with deprecation warnings).
-- **Multi-source training:** weight-based interleaving with exact
-  per-batch source homogeneity, weighted scheduler, per-source
-  DataLoaders.
-- **Source-aware reward routing:** `RewardArguments.applicable_datasets`
-  extends to training rewards (was eval-only before this branch).
-- **Source bookkeeping on samples:** `BaseSample.source: Optional[str]`
-  + `BaseSample.source_id: Optional[int]` first-class typed fields;
-  `_datasets_resolved: frozenset[int]` cache on `RewardArguments` for
-  hot-path comparison.
-- **NaN-padded reward transport:** every reward call yields a
-  full-length tensor with NaN at non-applicable positions, so
-  cross-rank `accelerator.gather` participants are uniform regardless
-  of which sources each rank processed (no deadlock).
-- **Applicability-aware aggregation:** `AdvantageProcessor` reads
-  `sample.applicable_rewards` as the source of truth (not
-  `np.isnan`), so an in-model NaN at an applicable position raises
-  loudly instead of silently masking. Samples with no applicable
-  reward also raise at config-load time
-  (`Arguments._validate_every_source_has_a_reward`).
-- **Future OPD readiness:** `self.train_dataloaders_by_source: Dict[str,
-  DataLoader]` is exposed on every trainer for the upcoming
-  DiffusionOPD trainer to drive its own balanced per-teacher sampling
-  without re-deriving the partition.
+- **Unified `data.datasets:` schema** — each entry has `name`, `dataset_dir`,
+  optional media roots, and optional `train:` / `eval:` sub-blocks.
+- **Multi-source training** — integer `train.weight`, exact batch partitioning,
+  `WeightedSourceBatchScheduler`, per-source DataLoaders, homogeneous batches.
+- **Per-dataset eval** — `get_eval_dataloaders`, `DatasetEvalSpec` overrides
+  (`resolution`, `num_inference_steps`, `guidance_scale`), namespaced metrics.
+- **Source-aware reward routing** — `RewardArguments.applicable_datasets` on
+  training and eval rewards; `_datasets_resolved: frozenset[int]` for hot-path gate.
+- **Sample bookkeeping** — `BaseSample.source` / `BaseSample.source_id`;
+  `MultiSourceTrainDataLoader` injects `__source__` / `__source_id__`.
+- **NaN-padded reward transport** — full-length tensors with NaN at non-applicable
+  positions for deadlock-free `accelerator.gather`.
+- **Applicability-aware aggregation** — `AdvantageProcessor` uses
+  `sample.applicable_rewards`; `_validate_every_source_has_a_reward` at config load.
+- **`train_dataloaders_by_source`** — exposed on every trainer (consumed by
+  DiffusionOPD for per-teacher rollout routing).
 
----
+### Notable internal refactors (#168)
 
-### Notable internal refactors
+- Single `evaluate()` implementation; legacy eval helpers deleted (`b4717f4`).
+- `get_train_dataloader` + `get_eval_dataloaders`; legacy test loader deleted
+  (`b360984`).
+- Config validation in `Arguments.__post_init__` (`_validate_dataset_routing` +
+  resolvers).
+- **Latent bug fix:** `_evaluate_multi_dataset` called `get_merged_eval_kwargs` on
+  the parent `DatasetArguments` instead of `DatasetEvalSpec`; fixed in eval merge
+  (`b4717f4`). (A related eval-preprocess gap — per-dataset `guidance_scale` not
+  merged at dataset-cache time — was fixed on the OPD branch; see Part B.)
 
-- **One eval implementation** (`evaluate()`); `_evaluate_single_dataset`
-  / `_evaluate_multi_dataset` deleted (`b4717f4`).
-- **One train data factory** (`get_train_dataloader`) + one eval data
-  factory (`get_eval_dataloaders`); legacy single-test path
-  (`_build_legacy_test_dataloader`) deleted (`b360984`).
-- **Single config validation pass** (`Arguments._validate_dataset_routing`
-  + resolvers) in `__post_init__` so every downstream consumer sees only
-  the unified `data.datasets` schema (`94f28ba`). (An earlier
-  `_canonicalize_legacy_dataset_dir` shim was removed in the post-review
-  hardening round; the only remaining config migration is
-  `_migrate_legacy_eval_datasets()` for the top-level `eval_datasets:`
-  key.)
-- **Latent bug fix**: `_evaluate_multi_dataset` was calling
-  `get_merged_eval_kwargs` on the parent `DatasetArguments` (carrying
-  over from the legacy eval-dataset shape where the method
-  lived on the parent). Method actually lives on `DatasetEvalSpec`
-  (the inner sub-block) — so per-dataset eval overrides would have
-  raised `AttributeError`. Fixed during the eval-merge unification
-  (`b4717f4`).
-- **Pre-PR latent-cache compatibility** (superseded): the per-source
-  loader originally skipped the `train_source:{name}` token in
-  `extra_hash_strs` when `len(training_datasets) == 1`. The post-review
-  hardening round removed that skip (the token is now always included),
-  since the legacy `data.dataset_dir` path no longer exists.
+### Post-review hardening (after `15c3943`, included in squash `02c581a`)
 
----
-
-### Post-review hardening (after `15c3943`)
-
-A second review round (PR #168) tightened the implementation. Net effect:
-the legacy single-source path is gone entirely and all configs use
-`data.datasets`.
-
-- **Legacy `data.dataset_dir` removed**: `_canonicalize_legacy_dataset_dir`
-  deleted; bare `data.dataset_dir` (without `data.datasets`) is now
-  rejected with a clear error. All 60 example YAMLs migrated to the
-  `data.datasets` schema with inline parameter docs.
-- **`RewardArguments.datasets` → `applicable_datasets`**: field renamed
-  for clarity (the reward gate, loader, and advantage routing follow).
-- **Per-dataset reward weights**: `RewardArguments.weight` accepts a
-  scalar or a `{dataset: weight}` dict, so the same reward can contribute
-  differently per source (e.g. PickScore 0.2 on GenEval/OCR, 1.0 on its
-  own dataset). Resolved to a fully-expanded dict at config load.
-- **Metadata transport**: per-sample JSONL metadata is carried as a single
-  JSON string (`sample.metadata`) instead of flattened keys, so
-  heterogeneous metadata across sources no longer breaks
-  `BaseSample.stack`. Reward models parse via `json.loads` (GenEval
-  updated; `required_fields` now `("image", "prompt", "metadata")`).
-- **Communication optimizations**: the three advantage-stage gathers were
-  merged into one (`source_id` piggybacks on the rewards+`unique_id`
-  gather; applicability mask and per-source weight matrix are derived
-  locally from config); M groupwise reward reductions packed into one
-  NCCL `reduce`; group normalization (GRPO + GDPO) and post-reduce NaN
-  fill vectorized with `np.bincount` / fancy indexing.
-- **`get_data_sampler`** refactored to a pure factory (no `Arguments`
-  dependency); `_init_dataloader` returns `(train, eval)` and eval
-  dataloaders are prepared in the single `accelerator.prepare()` call.
-- **Dead code removed**: `eval_dataset_args.py` (the unused
-  `EvalDatasetArguments` class), `_partition_unique_sample_num`,
+- **`_canonicalize_legacy_dataset_dir` removed** — bare `data.dataset_dir` rejected;
+  all example YAMLs migrated to `data.datasets`.
+- **`RewardArguments.datasets` → `applicable_datasets`** — renamed across gate,
+  loader, and advantage routing.
+- **Per-dataset reward weights** — `RewardArguments.weight` as scalar or
+  `{dataset: weight}` dict, expanded at config load.
+- **Metadata transport** — per-sample JSONL metadata as `sample.metadata` (JSON
+  string); GenEval `required_fields` updated to `("image", "prompt", "metadata")`.
+- **Communication optimizations** — merged advantage-stage gathers; packed M
+  groupwise reductions; vectorized group normalization.
+- **Dead code removed** — `eval_dataset_args.py`, `_partition_unique_sample_num`,
   `_per_source_unique_sample_num`, `_encode_prompts`.
-- **Eval-only guard**: `generate_samples()` now raises a clear error if no
-  training dataloader exists (eval-only `data.datasets`).
+- **Eval-only guard** — `generate_samples()` raises if no training dataloader.
+
+---
+
+## Part B — DiffusionOPD
+
+**Range:** `02c581a..e4496c6` (2026-05-31 … 2026-06-02)
+**Builds on:** Part A (#168)
+**Paper:** [On-Policy Distillation of Diffusion Models](https://arxiv.org/abs/2605.15055)
+
+Multi-teacher on-policy distillation: each **training dataset** is distilled by
+**exactly one** LoRA teacher; a single teacher may cover **multiple** datasets
+(teachers must not overlap on the same dataset). Distillation runs along the
+student's rollout trajectories via per-step mean-matching KL, supporting **ODE
+and SDE** dynamics.
+
+### Commit list (Part B)
+
+| Hash | Date | Subject |
+|------|------|---------|
+| `aa9b639` | 2026-05-31 | `[trainer,hparams,scheduler]` feat: add DiffusionOPD on-policy distillation trainer |
+| `34a043f` | 2026-05-31 | `[examples]` feat: add DiffusionOPD SD3.5 example configs |
+| `51ec3c4` | 2026-06-01 | Update teacher path to HF |
+| `fc97e83` | 2026-06-01 | `[examples,docs]` fix: point teachers at `quanhaol/DiffusionOPD` subfolders |
+| `0fbbc59` | 2026-06-01 | `[trainer,hparams,examples]` fix: distillation steps via `timestep_range` |
+| `a6f8dab` | 2026-06-01 | `[trainer,hparams,examples]` feat: per-teacher KL logging + gradient accumulation fix |
+| `33519e6` | 2026-06-01 | `[hparams]` fix: gate `_validate_teacher_sources` on `isinstance` (PR #170) |
+| `425b443` | 2026-06-01 | Refactor `data_utils` |
+| `e7544fc` | 2026-06-01 | Fix eval preprocessing kwargs (per-dataset `guidance_scale`) |
+| `28afc90` | 2026-06-01 | `[data,hparams]` chore: black/isort on new OPD files |
+| `ed91b21` | 2026-06-02 | Update readme |
+| `e4496c6` | 2026-06-02 | Teacher coverage validation in `Arguments._validate_teacher_sources` |
+
+### Added (Part B)
+
+- **`trainer_type: diffusion-opd`** — `DiffusionOPDTrainer`
+  (`trainers/opd/trainer.py`), registered in `trainers/registry.py`. Two-pass
+  `optimize()`: PASS 1 (`no_grad`) caches each teacher's `mu_T` with one weight
+  swap per teacher; PASS 2 student-only gradient loop matching `mu_S` to cached
+  `mu_T`. Rewards used only for eval monitoring. Logs `train/kl_div_{teacher_name}`
+  and overall `train/kl_div`.
+- **`DiffusionOPDTrainingArguments` + `TeacherConfig`**
+  (`hparams/training_args/opd.py`): `teachers` (`path`, `name`,
+  `applicable_datasets`, `guidance_scale`), `teacher_param_device`, `timestep_range`.
+  Overrides `get_preprocess_guidance_scale()` (max of student and per-teacher CFG)
+  and `get_num_train_timesteps()` (one backward per distilled step). Routing:
+  one teacher may list several datasets; `DiffusionOPDTrainer` rejects overlap.
+- **`SDESchedulerMixin.get_kl_divergence_denominator(std_dev_t, dt)`**
+  (`scheduler/abc.py`): dynamics-agnostic transition variance for the KL denominator.
+- **`trainers/opd/common.py`** — `load_teachers`: named-parameter snapshots for
+  teacher LoRAs (architecture must match student LoRA slot).
+- **`Arguments._validate_teacher_sources`** (`hparams/args.py`, OPD-only):
+  (1) every teacher `applicable_datasets` entry is a declared training dataset;
+  (2) every active training dataset appears in some teacher's `applicable_datasets`.
+  Overlap enforcement stays in `DiffusionOPDTrainer`.
+- **Examples** — `examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml` (HF teachers,
+  upstream `mopd` recipe) and `geneval_pickscore_ocr.yaml` (GenEval/PickScore/OCR
+  with eval-only `*_no-cfg` ablation tracks).
+
+### Fixed (Part B)
+
+- **Eval CFG preprocessing** (`data_utils/loader.py`): `get_eval_dataloaders`
+  merges per-dataset eval overrides via `DatasetEvalSpec.get_merged_eval_kwargs`,
+  matching `BaseTrainer.evaluate`. Fixes silent CFG disable when per-dataset
+  `guidance_scale > 1.0` but shared `eval.guidance_scale` was used at preprocess time.
+- **Distillation step selection** — steps from `train.timestep_range`, not
+  SDE-only `scheduler.train_timesteps` (empty under ODE). `resolve_distill_step_band()`
+  shared by `sample()`, `optimize()`, and `get_num_train_timesteps()`.
+- **Gradient accumulation** — `get_num_train_timesteps()` returns distilled step
+  count so `gradient_step_per_epoch` math is correct.
+- **Teacher validation gate** — `_validate_teacher_sources` gated on
+  `isinstance(DiffusionOPDTrainingArguments)`.
+
+### Docs (Part B)
+
+- `guidance/algorithms.md`: "DiffusionOPD: On-Policy Distillation" + reference [14].
+- `README.md` / `examples/README.md`: `diffusion-opd` trainer and `opd` examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## Unreleased — `feat/diffusion-opd`
+
+**Branch:** `feat/diffusion-opd` (off `main` @ `#168`)
+**Repo:** [X-GenGroup/Flow-Factory](https://github.com/X-GenGroup/Flow-Factory)
+
+Adds **DiffusionOPD** ([paper](https://arxiv.org/abs/2605.15055)), a multi-teacher
+on-policy distillation trainer built on the multi-dataset infrastructure from
+#168. One LoRA teacher per training source is distilled into a single student
+along the student's own rollout trajectories via a closed-form per-step KL
+(pathwise mean-matching), supporting **both ODE and SDE** dynamics.
+
+### Added
+
+- **`trainer_type: diffusion-opd`** — `DiffusionOPDTrainer`
+  (`trainers/opd/trainer.py`), registered in `trainers/registry.py`. Uses a
+  2-pass `optimize()`: PASS 1 (`no_grad`) caches each teacher's per-step
+  transition mean `mu_T` on its routed samples with **one weight swap per
+  teacher**; PASS 2 runs a student-only gradient loop matching each sample's
+  `mu_S` to its own cached `mu_T` (per-step loss `kl_div_j`). Reuses the GRPO
+  trajectory-replay primitives and the `sample() → optimize()` lifecycle.
+  Rewards are used only for eval monitoring.
+- **`DiffusionOPDTrainingArguments` + `TeacherConfig`**
+  (`hparams/training_args/opd.py`): `teachers` (list of
+  `{path, name, applicable_datasets, guidance_scale}`) and
+  `teacher_param_device`. Registered under key `diffusion-opd`; exported from
+  `hparams`. Overrides `get_preprocess_guidance_scale()` to cover the max of the
+  student and any per-teacher CFG. The schema permits several teachers to share
+  a dataset (for a future multi-teacher/ensemble trainer); the current
+  `DiffusionOPDTrainer` enforces one teacher per dataset.
+- **`SDESchedulerMixin.get_kl_divergence_denominator(std_dev_t, dt)`**
+  (`scheduler/abc.py`): centralizes the per-dynamics transition variance so the
+  distillation loss is dynamics-agnostic — `1.0` for ODE,
+  `std_dev_t²·(-dt)` for Flow-SDE/Dance-SDE, `std_dev_t²` for CPS (clamped to
+  `>= eps`).
+- **`trainers/opd/common.py`** — `load_teachers`: loads each teacher LoRA into a
+  named-parameter snapshot (snapshot student → `_load_lora` → `add_named_parameters`
+  → restore student) with a clear LoRA-architecture compatibility error. LoRA
+  teachers only; full-parameter teachers deferred.
+- **`Arguments._validate_teacher_sources`** (`hparams/args.py`): fail-fast config
+  validation that every teacher `applicable_datasets` entry is a declared training
+  dataset. The one-teacher-per-dataset rule is enforced in `DiffusionOPDTrainer`
+  (not here), keeping the schema reusable. No-op for non-OPD trainers.
+- **Examples** under `examples/opd/lora/sd3_5/`: `DiffusionOPD_aligned.yaml`
+  (3 Hugging Face teachers — GenEval/OCR/Aes — aligned to the upstream `mopd`
+  recipe: `group_size=1`, `per_device_batch_size=3`, the Aes teacher distilled
+  on the `pickscore` dataset, per-teacher CFG 4.5/4.5/1.0) and
+  `geneval_pickscore_ocr.yaml` (3 local-checkpoint teachers). Both default to
+  `dynamics_type: ODE`; switch to `Flow-SDE` + `noise_level > 0` for SDE
+  distillation.
+
+### Docs
+
+- `guidance/algorithms.md`: new "DiffusionOPD: On-Policy Distillation" section +
+  reference [14].
+- `README.md` / `examples/README.md`: list the `diffusion-opd` trainer and the
+  new `opd` examples.
+
 ## Unreleased — `feat/multi-eval-dataset`
 
 **Range:** `652f7315..HEAD` (2026-05-26 … 2026-05-31)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This experimental feature leverages `diffusers`'s `transformer.set_attention_bac
 | DGPO           | dgpo           | [DGPO](https://arxiv.org/abs/2510.08425) |
 | GRPO-Guard     | grpo-guard     | [GRPO-Guard](https://arxiv.org/abs/2510.22319) |
 | CRD            | crd            | [Centered Reward Distillation](https://arxiv.org/abs/2603.14128) ([Blog (Chinese)](https://mp.weixin.qq.com/s/fpTi7PPi3APSNJQ2kXN3Dw))|
+| DiffusionOPD   | diffusion-opd  | [DiffusionOPD](https://arxiv.org/abs/2605.15055) |
 
 See [`Algorithm Guidance`](guidance/algorithms.md) for more information.
 
@@ -156,7 +157,7 @@ We provide a set of guidance documents to help you understand the framework and 
 | Document | Description |
 |---|---|
 | [Workflow](guidance/workflow.md) | End-to-end training pipeline: the overall stages from data preprocessing to policy optimization |
-| [Algorithms](guidance/algorithms.md) | Supported RL algorithms (GRPO, GRPO-Guard, DiffusionNFT, AWM, DPO, DGPO, CRD) and their configurations |
+| [Algorithms](guidance/algorithms.md) | Supported RL algorithms (GRPO, GRPO-Guard, DiffusionNFT, AWM, DPO, DGPO, CRD, DiffusionOPD) and their configurations |
 | [Rewards](guidance/rewards.md) | Reward model system: built-in models, custom rewards, and remote reward servers |
 | [New Model](guidance/new_model.md) | How to add support for a new Diffusion/Flow-Matching model |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ examples/{algorithm}/{finetune_type}/{model_type}/{variant}.yaml
 
 | Level | Description | Examples |
 |-------|-------------|---------|
-| `algorithm` | Training algorithm | `grpo`, `nft`, `awm`, `dgpo`, `dpo`, `crd` |
+| `algorithm` | Training algorithm | `grpo`, `nft`, `awm`, `dgpo`, `dpo`, `crd`, `opd` |
 | `finetune_type` | Parameter-efficient or full | `lora`, `full` |
 | `model_type` | Model family (underscore-separated) | `flux1`, `sd3_5`, `wan21`, `ltx2` |
 | `variant` | Config variant | `default.yaml`, `nocfg.yaml`, `t2v.yaml` |
@@ -23,6 +23,8 @@ examples/{algorithm}/{finetune_type}/{model_type}/{variant}.yaml
 ```bash
 ff-train examples/grpo/lora/flux1/default.yaml
 ```
+
+**DiffusionOPD (`opd`)**: multi-teacher on-policy distillation. Each config declares one LoRA `teacher` per `data.datasets` entry; teachers must share the student's LoRA architecture. See [`opd/lora/sd3_5/DiffusionOPD_aligned.yaml`](opd/lora/sd3_5/DiffusionOPD_aligned.yaml) (Hugging Face teachers, aligned to the upstream `mopd` recipe) and [`opd/lora/sd3_5/geneval_pickscore_ocr.yaml`](opd/lora/sd3_5/geneval_pickscore_ocr.yaml) (local-checkpoint teachers), plus the [Algorithm Guidance](../guidance/algorithms.md#diffusionopd-on-policy-distillation).
 
 ## Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,8 +24,6 @@ examples/{algorithm}/{finetune_type}/{model_type}/{variant}.yaml
 ff-train examples/grpo/lora/flux1/default.yaml
 ```
 
-**DiffusionOPD (`opd`)**: multi-teacher on-policy distillation. Each config declares one LoRA `teacher` per `data.datasets` entry; teachers must share the student's LoRA architecture. See [`opd/lora/sd3_5/DiffusionOPD_aligned.yaml`](opd/lora/sd3_5/DiffusionOPD_aligned.yaml) (Hugging Face teachers, aligned to the upstream `mopd` recipe) and [`opd/lora/sd3_5/geneval_pickscore_ocr.yaml`](opd/lora/sd3_5/geneval_pickscore_ocr.yaml) (local-checkpoint teachers), plus the [Algorithm Guidance](../guidance/algorithms.md#diffusionopd-on-policy-distillation).
-
 ## Contributing
 
 We welcome community contributions! Here's what you can contribute and how:

--- a/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
+++ b/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
@@ -1,0 +1,197 @@
+# DiffusionOPD reproduction (mopd): multi-task on-policy distillation on SD3.5.
+#
+# Aligned to the upstream `mopd` recipe in
+# https://github.com/ali-vilab/DiffusionOPD/blob/8797d5717d9503edc8cec0705aed5354c203e547/config/opd.py
+# Three task-specialized teachers are distilled into one student LoRA along the
+# student's own ODE rollout trajectories.
+#
+# Teacher -> dataset mapping (NOTE: upstream applies the Aesthetics teacher to
+# the `pickscore` prompt set — "aesthetic" IS the pickscore task here):
+#   - quanhaol/Aes-Teacher      -> dataset `pickscore`   (guidance_scale 4.5)
+#   - quanhaol/OCR-Teacher      -> dataset `ocr`         (guidance_scale 4.5)
+#   - quanhaol/GenEval-Teacher  -> dataset `geneval`     (guidance_scale 1.0)
+# Each must share the student's LoRA architecture (target modules, rank/alpha).
+#
+# Batch geometry (matches upstream `mopd` on 8 GPUs):
+#   num_image_per_prompt=1   -> group_size=1
+#   train_batch_size=3       -> per_device_batch_size=3
+#   num_batches_per_epoch=3  -> 1 batch per teacher/dataset, so
+#   unique_sample_num_per_epoch = num_gpus(8) * num_batches_per_epoch(3) * per_device_batch_size(3) / group_size(1)
+#                              = 72  (== 24 prompts/teacher * 3 teachers)
+#
+# To distill under SDE instead of ODE, set `scheduler.dynamics_type` to an SDE
+# variant (e.g. Flow-SDE) and `scheduler.noise_level > 0`; the per-step loss
+# picks up the transition-variance denominator automatically.
+
+# Environment Configuration
+launcher: "accelerate"  # Options: accelerate
+config_file: config/deepspeed/deepspeed_zero2.yaml  # Path to distributed config file
+num_processes: 8  # Number of GPU processes to launch (geometry above assumes 8)
+main_process_port: 29500  # Port for distributed communication
+mixed_precision: "bf16"  # Options: no, fp16, bf16 (upstream used fp16; bf16 is the FF default)
+
+# Data Configuration — 3 datasets, one teacher each (weighted 1:1:1)
+data:
+  datasets:
+    - name: pickscore  # Aesthetics task in upstream mopd (served by the Aes teacher)
+      dataset_dir: "dataset/pickscore"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other datasets sets batch allocation
+        max_dataset_size: null  # No cap on training prompts (matches upstream mopd: full prompt set)
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 4.5  # Eval samples the student at its CFG (4.5)
+
+    - name: ocr  # Unique identifier (dataset tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/ocr"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other datasets sets batch allocation
+        max_dataset_size: null  # No cap on training prompts (matches upstream mopd: full prompt set)
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 4.5  # Eval samples the student at its CFG (4.5)
+
+    - name: geneval  # Unique identifier (dataset tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/geneval"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other datasets sets batch allocation
+        max_dataset_size: null  # No cap on training prompts (matches upstream mopd: full prompt set)
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 4.5  # Eval samples the student at its CFG (4.5)
+
+  preprocessing_batch_size: 8  # Batch size for preprocessing
+  dataloader_num_workers: 16  # Number of workers for DataLoader
+  force_reprocess: false  # Force reprocessing of the dataset (ignores cache)
+  cache_dir: "~/.cache/flow_factory/datasets"  # Cache directory for preprocessed datasets
+  sampler_type: "auto"  # Options: auto, distributed_k_repeat, group_contiguous
+
+# Model Configuration (student LoRA)
+model:
+  finetune_type: 'lora'  # Options: full, lora (DiffusionOPD currently supports LoRA teachers only)
+  lora_rank: 32  # LoRA rank dimension (must match the teacher checkpoints' rank)
+  lora_alpha: 64  # LoRA scaling factor (typically 2x rank)
+  target_modules: "default"  # Options: all, default, or list of module names
+  model_name_or_path: "stabilityai/stable-diffusion-3.5-medium"  # HuggingFace model ID or local path
+  model_type: "sd3-5"  # Model type identifier for adapter selection
+  resume_path: null  # Path or HF repo for checkpoint resume (null = train from scratch)
+  resume_type: null  # Options: lora, full, state. Null to auto-detect
+
+log:
+  run_name: null  # Run name (auto: {model_type}_{finetune_type}_{trainer_type}_{timestamp})
+  project: "Flow-Factory"  # Project name for logging backend
+  logging_backend: "wandb"  # Options: wandb, swanlab, tensorboard, none
+  save_dir: "saves/"  # Directory to save model checkpoints and logs
+  save_freq: 30  # Save frequency in epochs (0 to disable) — upstream mopd save_freq
+  save_model_only: true  # Save only model weights (not optimizer/scheduler state)
+
+# Training Configuration
+train:
+  trainer_type: 'diffusion-opd'  # On-policy distillation trainer
+
+  # ---- Teachers: one HF LoRA per dataset, distilled into the student ----
+  teachers:
+    - name: "aes-teacher"  # Aesthetics teacher; upstream applies it to the pickscore prompt set
+      path: "quanhaol/Aes-Teacher"  # HF Hub PEFT LoRA checkpoint
+      applicable_datasets: [pickscore]  # Distill this teacher on pickscore rollouts
+      guidance_scale: 4.5  # Teacher CFG for its forward (upstream pickscore_teacher_gs)
+    - name: "ocr-teacher"  # Unique teacher id (named snapshot + log keys)
+      path: "quanhaol/OCR-Teacher"  # HF Hub PEFT LoRA checkpoint
+      applicable_datasets: [ocr]  # Distill this teacher on ocr rollouts
+      guidance_scale: 4.5  # Teacher CFG for its forward (upstream ocr_teacher_gs)
+    - name: "geneval-teacher"  # Unique teacher id (named snapshot + log keys)
+      path: "quanhaol/GenEval-Teacher"  # HF Hub PEFT LoRA checkpoint
+      applicable_datasets: [geneval]  # Distill this teacher on geneval rollouts
+      guidance_scale: 1.0  # Teacher queried at its no-CFG distribution (upstream geneval_teacher_gs)
+
+  teacher_param_device: 'cuda'  # Teacher snapshot storage: 'cuda' (fast swaps) or 'cpu' (low VRAM)
+
+  resolution: 512  # Training resolution. Can be int or [height, width]
+  num_inference_steps: 10  # Number of denoising timesteps in the on-policy rollout
+  guidance_scale: 4.5  # Student CFG for rollout + forward (upstream sample.guidance_scale)
+
+  per_device_batch_size: 3  # Batch size per GPU device (upstream train_batch_size)
+  group_size: 1  # Rollouts generated per prompt (upstream num_image_per_prompt = 1)
+  unique_sample_num_per_epoch: 72  # 24 prompts/teacher * 3 teachers (see geometry note in header)
+  num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
+  gradient_step_per_epoch: 1  # One optimizer step per epoch (accumulate the 3 per-dataset batches)
+  gradient_accumulation_steps: auto  # Options: auto, or positive integer
+
+  learning_rate: 3.0e-4  # Initial learning rate for AdamW optimizer
+  adam_weight_decay: 1.0e-4  # AdamW weight decay regularization
+  adam_betas: [0.9, 0.999]  # AdamW momentum coefficients (beta1, beta2)
+  adam_epsilon: 1.0e-8  # AdamW epsilon for numerical stability
+  max_grad_norm: 1.0  # Max gradient norm for gradient clipping
+  max_epochs: 200  # Stop after this many epochs (-1 / null = unbounded)
+
+  ema_decay: 0.99  # EMA decay rate for model weights (0 to disable)
+  ema_update_interval: 4  # Update EMA every N epochs
+  ema_device: "cuda"  # Device to store EMA model. Options: cpu, cuda
+
+  enable_gradient_checkpointing: false  # Trade compute for memory savings
+  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher means) to CPU
+  seed: 42  # Random seed for reproducibility
+
+# Scheduler Configuration
+scheduler:
+  dynamics_type: "ODE"  # ODE distillation (mean matching). Switch to Flow-SDE + noise_level>0 for SDE.
+  noise_level: 0.0  # Noise injection level (0.0 for ODE; >0 enables SDE transition matching)
+  seed: 42  # Scheduler seed (for noise step selection)
+
+# Evaluation settings (shared defaults; per-dataset overrides above take precedence)
+eval:
+  resolution: 512  # Evaluation image resolution
+  per_device_batch_size: 16  # Eval batch size per device (upstream test_batch_size)
+  guidance_scale: 4.5  # Eval guidance scale (student CFG)
+  num_inference_steps: 40  # Eval denoising steps (more steps = higher quality)
+  eval_freq: 30  # Run evaluation every N epochs (0 to disable) — upstream mopd eval_freq
+  seed: 42  # Eval random seed
+
+# Reward Model Configuration (monitoring only — NOT used by the distillation loss)
+# Routing via `applicable_datasets`: geneval -> geneval, ocr -> ocr,
+# pick_score -> all three datasets (covers the `pickscore` dataset and provides
+# a general-quality signal on the others).
+rewards:
+  - name: "geneval"  # Reward identifier (appears in log keys)
+    reward_model: "GenEval"  # Reward model class (from registry)
+    batch_size: 32  # Inference batch size for this reward model
+    device: "cuda"  # Device to run reward model on
+    dtype: float32  # Precision for reward model inference
+    applicable_datasets: ["geneval"]  # Only fires on geneval source batches
+
+  - name: "ocr"  # Reward identifier (appears in log keys)
+    reward_model: "OCR"  # Reward model class (from registry)
+    batch_size: 32  # Inference batch size for this reward model
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    applicable_datasets: ["ocr"]  # Only fires on ocr source batches
+
+  - name: "pick_score"  # General image-quality reward (covers the pickscore dataset)
+    reward_model: "PickScore"  # Reward model class (from registry)
+    batch_size: 32  # Inference batch size for this reward model
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    # applicable_datasets omitted -> applies to ALL training datasets (pickscore, ocr, geneval)
+
+# Eval Reward Models (same routing as training rewards)
+eval_rewards:
+  - name: "geneval"  # Eval reward identifier
+    reward_model: "GenEval"  # Reward model class (from registry)
+    batch_size: 32  # Larger batch for eval (no gradient, more memory available)
+    device: "cuda"  # Device to run reward model on
+    dtype: float32  # Precision for reward model inference
+    applicable_datasets: ["geneval"]  # Only scores geneval eval samples
+
+  - name: "ocr"  # Eval reward identifier
+    reward_model: "OCR"  # Reward model class (from registry)
+    batch_size: 32  # Larger batch for eval (no gradient, more memory available)
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    applicable_datasets: ["ocr"]  # Only scores ocr eval samples
+
+  - name: "pick_score"  # Eval reward identifier (covers the pickscore dataset)
+    reward_model: "PickScore"  # Reward model class (from registry)
+    batch_size: 32  # Larger batch for eval (no gradient, more memory available)
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    # applicable_datasets omitted -> applies to all eval datasets (pickscore, ocr, geneval)

--- a/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
+++ b/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
@@ -5,12 +5,18 @@
 # Three task-specialized teachers are distilled into one student LoRA along the
 # student's own ODE rollout trajectories.
 #
+# All official checkpoints live under ONE repo, quanhaol/DiffusionOPD, as
+# subfolders (each teacher's LoRA is in <Teacher>/lora; the released distilled
+# student is in Student/lora). Flow-Factory loads a subfolder via the
+# owner/repo/subfolder path spec.
+#
 # Teacher -> dataset mapping (NOTE: upstream applies the Aesthetics teacher to
 # the `pickscore` prompt set — "aesthetic" IS the pickscore task here):
-#   - quanhaol/Aes-Teacher      -> dataset `pickscore`   (guidance_scale 4.5)
-#   - quanhaol/OCR-Teacher      -> dataset `ocr`         (guidance_scale 4.5)
-#   - quanhaol/GenEval-Teacher  -> dataset `geneval`     (guidance_scale 1.0)
-# Each must share the student's LoRA architecture (target modules, rank/alpha).
+#   - quanhaol/DiffusionOPD/AesTeacher/lora     -> dataset `pickscore`  (guidance_scale 4.5)
+#   - quanhaol/DiffusionOPD/OCRTeacher/lora     -> dataset `ocr`        (guidance_scale 4.5)
+#   - quanhaol/DiffusionOPD/GenEvalTeacher/lora -> dataset `geneval`    (guidance_scale 1.0)
+# Each must share the student's LoRA architecture; these teachers are r=32,
+# lora_alpha=64 with SD3.5 attention target modules — matching the student below.
 #
 # Batch geometry (matches upstream `mopd` on 8 GPUs):
 #   num_image_per_prompt=1   -> group_size=1
@@ -92,15 +98,15 @@ train:
   # ---- Teachers: one HF LoRA per dataset, distilled into the student ----
   teachers:
     - name: "aes-teacher"  # Aesthetics teacher; upstream applies it to the pickscore prompt set
-      path: "quanhaol/Aes-Teacher"  # HF Hub PEFT LoRA checkpoint
+      path: "quanhaol/DiffusionOPD/AesTeacher/lora"  # HF subfolder spec (owner/repo/subfolder)
       applicable_datasets: [pickscore]  # Distill this teacher on pickscore rollouts
       guidance_scale: 4.5  # Teacher CFG for its forward (upstream pickscore_teacher_gs)
     - name: "ocr-teacher"  # Unique teacher id (named snapshot + log keys)
-      path: "quanhaol/OCR-Teacher"  # HF Hub PEFT LoRA checkpoint
+      path: "quanhaol/DiffusionOPD/OCRTeacher/lora"  # HF subfolder spec (owner/repo/subfolder)
       applicable_datasets: [ocr]  # Distill this teacher on ocr rollouts
       guidance_scale: 4.5  # Teacher CFG for its forward (upstream ocr_teacher_gs)
     - name: "geneval-teacher"  # Unique teacher id (named snapshot + log keys)
-      path: "quanhaol/GenEval-Teacher"  # HF Hub PEFT LoRA checkpoint
+      path: "quanhaol/DiffusionOPD/GenEvalTeacher/lora"  # HF subfolder spec (owner/repo/subfolder)
       applicable_datasets: [geneval]  # Distill this teacher on geneval rollouts
       guidance_scale: 1.0  # Teacher queried at its no-CFG distribution (upstream geneval_teacher_gs)
 

--- a/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
+++ b/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
@@ -1,7 +1,7 @@
 # DiffusionOPD reproduction (mopd): multi-task on-policy distillation on SD3.5.
 #
 # Aligned to the upstream `mopd` recipe in
-# https://github.com/ali-vilab/DiffusionOPD/blob/8797d5717d9503edc8cec0705aed5354c203e547/config/opd.py
+# https://github.com/ali-vilab/DiffusionOPD/blob/8797d5717d9503edc8cec0705aed5354c203e547/config/opd.py#L34
 # Three task-specialized teachers are distilled into one student LoRA along the
 # student's own ODE rollout trajectories.
 #

--- a/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
+++ b/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
@@ -115,6 +115,7 @@ train:
   resolution: 512  # Training resolution. Can be int or [height, width]
   num_inference_steps: 10  # Number of denoising timesteps in the on-policy rollout
   guidance_scale: 4.5  # Student CFG for rollout + forward (upstream sample.guidance_scale)
+  timestep_range: 0.99  # Distill the first 99% of denoising steps (upstream timestep_fraction); float f -> band [0, f]
 
   per_device_batch_size: 3  # Batch size per GPU device (upstream train_batch_size)
   group_size: 1  # Rollouts generated per prompt (upstream num_image_per_prompt = 1)

--- a/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
+++ b/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
@@ -129,7 +129,7 @@ train:
   adam_betas: [0.9, 0.999]  # AdamW momentum coefficients (beta1, beta2)
   adam_epsilon: 1.0e-8  # AdamW epsilon for numerical stability
   max_grad_norm: 1.0  # Max gradient norm for gradient clipping
-  max_epochs: 200  # Stop after this many epochs (-1 / null = unbounded)
+  max_epochs: 500  # Stop after this many epochs (-1 / null = unbounded)
 
   ema_decay: 0.99  # EMA decay rate for model weights (0 to disable)
   ema_update_interval: 4  # Update EMA every N epochs

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -107,7 +107,7 @@ train:
 
   per_device_batch_size: 8  # Batch size per GPU device
   group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
-  unique_sample_num_per_epoch: 144  # Total unique prompts per epoch (48 per source * 3 sources)
+  unique_sample_num_per_epoch: 72  # Total unique prompts per epoch (24 per source * 3 sources)
   num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
   gradient_step_per_epoch: 1  # Number of gradient updates per epoch
   gradient_accumulation_steps: auto  # Options: auto, or positive integer

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -132,9 +132,9 @@ train:
   guidance_scale: 1.0  # Student CFG for rollout + forward (1.0 = no guidance)
   timestep_range: 0.99  # Distill the first 99% of denoising steps (upstream timestep_fraction); float f -> band [0, f]
 
-  per_device_batch_size: 8  # Batch size per GPU device
+  per_device_batch_size: 3  # Batch size per GPU device
   group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
-  unique_sample_num_per_epoch: 144  # Total unique prompts per epoch (48 per source * 3 sources)
+  unique_sample_num_per_epoch: 72  # Total unique prompts per epoch (24 per source * 3 sources)
   num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
   gradient_step_per_epoch: 1  # Number of gradient updates per epoch
   gradient_accumulation_steps: auto  # Options: auto, or positive integer

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -107,7 +107,7 @@ train:
 
   per_device_batch_size: 8  # Batch size per GPU device
   group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
-  unique_sample_num_per_epoch: 72  # Total unique prompts per epoch (24 per source * 3 sources)
+  unique_sample_num_per_epoch: 144  # Total unique prompts per epoch (48 per source * 3 sources)
   num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
   gradient_step_per_epoch: 1  # Number of gradient updates per epoch
   gradient_accumulation_steps: auto  # Options: auto, or positive integer

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -36,7 +36,7 @@ data:
         max_dataset_size: 1024  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
-        guidance_scale: 1.0  # Override eval guidance scale for this dataset
+        guidance_scale: 4.5  # Override eval guidance scale for this dataset
 
     - name: pickscore  # Unique identifier (source tag, metrics, reward + teacher routing)
       dataset_dir: "dataset/pickscore"  # Folder with train.jsonl / test.jsonl
@@ -45,7 +45,7 @@ data:
         max_dataset_size: 1024  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
-        guidance_scale: 1.0  # Override eval guidance scale for this dataset
+        guidance_scale: 4.5  # Override eval guidance scale for this dataset
 
     - name: ocr  # Unique identifier (source tag, metrics, reward + teacher routing)
       dataset_dir: "dataset/ocr"  # Folder with train.jsonl / test.jsonl
@@ -54,7 +54,7 @@ data:
         max_dataset_size: 1024  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
-        guidance_scale: 1.0  # Override eval guidance scale for this dataset
+        guidance_scale: 4.5  # Override eval guidance scale for this dataset
 
   preprocessing_batch_size: 8  # Batch size for preprocessing
   dataloader_num_workers: 16  # Number of workers for DataLoader
@@ -105,10 +105,10 @@ train:
   guidance_scale: 1.0  # Student CFG for rollout + forward (1.0 = no guidance)
 
   per_device_batch_size: 8  # Batch size per GPU device
-  group_size: 16  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
+  group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
   unique_sample_num_per_epoch: 144  # Total unique prompts per epoch (48 per source * 3 sources)
   num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
-  gradient_step_per_epoch: 2  # Number of gradient updates per epoch
+  gradient_step_per_epoch: 1  # Number of gradient updates per epoch
   gradient_accumulation_steps: auto  # Options: auto, or positive integer
 
   learning_rate: 3.0e-4  # Initial learning rate for AdamW optimizer

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -103,6 +103,7 @@ train:
   resolution: 512  # Training resolution. Can be int or [height, width]
   num_inference_steps: 10  # Number of denoising timesteps in the on-policy rollout
   guidance_scale: 1.0  # Student CFG for rollout + forward (1.0 = no guidance)
+  timestep_range: 0.99  # Distill the first 99% of denoising steps (upstream timestep_fraction); float f -> band [0, f]
 
   per_device_batch_size: 8  # Batch size per GPU device
   group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -144,7 +144,7 @@ train:
   adam_betas: [0.9, 0.999]  # AdamW momentum coefficients (beta1, beta2)
   adam_epsilon: 1.0e-8  # AdamW epsilon for numerical stability
   max_grad_norm: 1.0  # Max gradient norm for gradient clipping
-  max_epochs: 200  # Stop after this many epochs (-1 / null = unbounded)
+  max_epochs: 500  # Stop after this many epochs (-1 / null = unbounded)
 
   ema_decay: 0.9  # EMA decay rate for model weights (0 to disable)
   ema_update_interval: 4  # Update EMA every N epochs

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -1,0 +1,190 @@
+# DiffusionOPD: multi-teacher on-policy distillation (GenEval + PickScore + OCR).
+#
+# One LoRA teacher per dataset is distilled into a single student LoRA along the
+# student's own rollout trajectories via a per-step mean-matching KL:
+#     kl_div_j = 0.5 * || mu_S - mu_T ||^2 / denom
+# where `denom` is the scheduler transition variance (1.0 for ODE). Rewards are
+# used ONLY for periodic eval monitoring, never in the distillation loss.
+#
+# Teacher checkpoints below use the original `~/checkpoints/...` paths
+# (placeholders to be uploaded); each must share the student's LoRA
+# architecture (same target modules, compatible rank/alpha) since it is loaded
+# into the student's active adapter slot.
+#
+# Aligns to the Flow-Factory-Private MoF online config, minus all MoF-specific
+# machinery (mof_checkpoint / mof_module_type / source_ratio / normalize_d_k /
+# eval_baselines_at_start) which belong to the out-of-scope MoF extension.
+#
+# To distill under SDE instead of ODE, set `scheduler.dynamics_type` to an SDE
+# variant (e.g. Flow-SDE) and `scheduler.noise_level > 0`; the loss picks up the
+# transition-variance denominator automatically (no other change needed).
+
+# Environment Configuration
+launcher: "accelerate"  # Options: accelerate
+config_file: config/deepspeed/deepspeed_zero2.yaml  # Path to distributed config file
+num_processes: 8  # Number of GPU processes to launch
+main_process_port: 29500  # Port for distributed communication
+mixed_precision: "bf16"  # Options: no, fp16, bf16
+
+# Data Configuration — 3 sources, one teacher each (weighted 1:1:1)
+data:
+  datasets:
+    - name: geneval  # Unique identifier (source tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/geneval"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
+        max_dataset_size: 1024  # Cap on number of training prompts for this source
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 1.0  # Override eval guidance scale for this dataset
+
+    - name: pickscore  # Unique identifier (source tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/pickscore"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
+        max_dataset_size: 1024  # Cap on number of training prompts for this source
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 1.0  # Override eval guidance scale for this dataset
+
+    - name: ocr  # Unique identifier (source tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/ocr"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
+        max_dataset_size: 1024  # Cap on number of training prompts for this source
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 1.0  # Override eval guidance scale for this dataset
+
+  preprocessing_batch_size: 8  # Batch size for preprocessing
+  dataloader_num_workers: 16  # Number of workers for DataLoader
+  force_reprocess: false  # Force reprocessing of the dataset (ignores cache)
+  cache_dir: "~/.cache/flow_factory/datasets"  # Cache directory for preprocessed datasets
+  sampler_type: "auto"  # Options: auto, distributed_k_repeat, group_contiguous
+
+# Model Configuration (student LoRA)
+model:
+  finetune_type: 'lora'  # Options: full, lora (DiffusionOPD currently supports LoRA teachers only)
+  lora_rank: 32  # LoRA rank dimension
+  lora_alpha: 64  # LoRA scaling factor (typically 2x rank)
+  target_modules: "default"  # Options: all, default, or list of module names
+  model_name_or_path: "stabilityai/stable-diffusion-3.5-medium"  # HuggingFace model ID or local path
+  model_type: "sd3-5"  # Model type identifier for adapter selection
+  resume_path: null  # Path or HF repo for checkpoint resume (null = train from scratch)
+  resume_type: null  # Options: lora, full, state. Null to auto-detect
+
+log:
+  run_name: null  # Run name (auto: {model_type}_{finetune_type}_{trainer_type}_{timestamp})
+  project: "Flow-Factory"  # Project name for logging backend
+  logging_backend: "wandb"  # Options: wandb, swanlab, tensorboard, none
+  save_dir: "saves/"  # Directory to save model checkpoints and logs
+  save_freq: 10  # Save frequency in epochs (0 to disable)
+  save_model_only: true  # Save only model weights (not optimizer/scheduler state)
+
+# Training Configuration
+train:
+  trainer_type: 'diffusion-opd'  # On-policy distillation trainer
+
+  # ---- Teachers: one LoRA per dataset, distilled into the student ----
+  teachers:
+    - name: "teacher-geneval"  # Unique teacher id (named snapshot + log keys)
+      path: "~/checkpoints/dppo_geneval_teacher/checkpoints/checkpoint-600"  # Teacher LoRA checkpoint
+      applicable_datasets: [geneval]  # Distill this teacher on geneval rollouts
+    - name: "teacher-pickscore"  # Unique teacher id (named snapshot + log keys)
+      path: "~/checkpoints/dppo_pickscore_teacher/checkpoints/checkpoint-1500"  # Teacher LoRA checkpoint
+      applicable_datasets: [pickscore]  # Distill this teacher on pickscore rollouts
+    - name: "teacher-ocr"  # Unique teacher id (named snapshot + log keys)
+      path: "~/checkpoints/dppo_ocr_teacher/checkpoints/checkpoint-220"  # Teacher LoRA checkpoint
+      applicable_datasets: [ocr]  # Distill this teacher on ocr rollouts
+
+  teacher_param_device: 'cuda'  # Teacher snapshot storage: 'cuda' (fast swaps) or 'cpu' (low VRAM)
+  # guidance_scale: per-teacher CFG override via TeacherConfig.guidance_scale (null = student CFG)
+
+  resolution: 512  # Training resolution. Can be int or [height, width]
+  num_inference_steps: 10  # Number of denoising timesteps in the on-policy rollout
+  guidance_scale: 1.0  # Student CFG for rollout + forward (1.0 = no guidance)
+
+  per_device_batch_size: 8  # Batch size per GPU device
+  group_size: 16  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
+  unique_sample_num_per_epoch: 144  # Total unique prompts per epoch (48 per source * 3 sources)
+  num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
+  gradient_step_per_epoch: 2  # Number of gradient updates per epoch
+  gradient_accumulation_steps: auto  # Options: auto, or positive integer
+
+  learning_rate: 3.0e-4  # Initial learning rate for AdamW optimizer
+  adam_weight_decay: 1.0e-4  # AdamW weight decay regularization
+  adam_betas: [0.9, 0.999]  # AdamW momentum coefficients (beta1, beta2)
+  adam_epsilon: 1.0e-8  # AdamW epsilon for numerical stability
+  max_grad_norm: 1.0  # Max gradient norm for gradient clipping
+  max_epochs: 200  # Stop after this many epochs (-1 / null = unbounded)
+
+  ema_decay: 0.9  # EMA decay rate for model weights (0 to disable)
+  ema_update_interval: 4  # Update EMA every N epochs
+  ema_device: "cuda"  # Device to store EMA model. Options: cpu, cuda
+
+  enable_gradient_checkpointing: false  # Trade compute for memory savings
+  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher means) to CPU
+  seed: 42  # Random seed for reproducibility
+
+# Scheduler Configuration
+scheduler:
+  dynamics_type: "ODE"  # ODE distillation (mean matching). Switch to Flow-SDE + noise_level>0 for SDE.
+  noise_level: 0.0  # Noise injection level (0.0 for ODE; >0 enables SDE transition matching)
+  seed: 42  # Scheduler seed (for noise step selection)
+
+# Evaluation settings (shared defaults; per-dataset overrides above take precedence)
+eval:
+  resolution: 512  # Evaluation image resolution
+  per_device_batch_size: 8  # Eval batch size per device
+  guidance_scale: 1.0  # Eval guidance scale
+  num_inference_steps: 40  # Eval denoising steps (more steps = higher quality)
+  eval_freq: 10  # Run evaluation every N epochs (0 to disable)
+  seed: 42  # Eval random seed
+
+# Reward Model Configuration (monitoring only — NOT used by the distillation loss)
+# Routing via `applicable_datasets`: geneval -> geneval, ocr -> ocr,
+# pick_score -> all three sources (applicable_datasets omitted = applies to all).
+rewards:
+  - name: "geneval"  # Reward identifier (appears in log keys)
+    reward_model: "GenEval"  # Reward model class (from registry)
+    batch_size: 32  # Inference batch size for this reward model
+    device: "cuda"  # Device to run reward model on
+    dtype: float32  # Precision for reward model inference
+    applicable_datasets: ["geneval"]  # Only fires on geneval source batches
+
+  - name: "ocr"  # Reward identifier (appears in log keys)
+    reward_model: "OCR"  # Reward model class (from registry)
+    batch_size: 32  # Inference batch size for this reward model
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    applicable_datasets: ["ocr"]  # Only fires on ocr source batches
+
+  - name: "pick_score"  # Reward identifier (appears in log keys)
+    reward_model: "PickScore"  # Reward model class (from registry)
+    batch_size: 32  # Inference batch size for this reward model
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    # applicable_datasets omitted -> applies to ALL training sources (geneval, pickscore, ocr)
+
+# Eval Reward Models (same routing as training rewards)
+eval_rewards:
+  - name: "geneval"  # Eval reward identifier
+    reward_model: "GenEval"  # Reward model class (from registry)
+    batch_size: 32  # Larger batch for eval (no gradient, more memory available)
+    device: "cuda"  # Device to run reward model on
+    dtype: float32  # Precision for reward model inference
+    applicable_datasets: ["geneval"]  # Only scores geneval eval samples
+
+  - name: "ocr"  # Eval reward identifier
+    reward_model: "OCR"  # Reward model class (from registry)
+    batch_size: 32  # Larger batch for eval (no gradient, more memory available)
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    applicable_datasets: ["ocr"]  # Only scores ocr eval samples
+
+  - name: "pick_score"  # Eval reward identifier
+    reward_model: "PickScore"  # Reward model class (from registry)
+    batch_size: 32  # Larger batch for eval (no gradient, more memory available)
+    device: "cuda"  # Device to run reward model on
+    dtype: bfloat16  # Precision for reward model inference
+    # applicable_datasets omitted -> applies to all eval sources (geneval, pickscore, ocr)

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -88,13 +88,13 @@ train:
   # ---- Teachers: one LoRA per dataset, distilled into the student ----
   teachers:
     - name: "teacher-geneval"  # Unique teacher id (named snapshot + log keys)
-      path: "~/checkpoints/dppo_geneval_teacher/checkpoints/checkpoint-600"  # Teacher LoRA checkpoint
+      path: "Jayce-Ping/GenEval-Teacher"  # Teacher LoRA checkpoint
       applicable_datasets: [geneval]  # Distill this teacher on geneval rollouts
     - name: "teacher-pickscore"  # Unique teacher id (named snapshot + log keys)
-      path: "~/checkpoints/dppo_pickscore_teacher/checkpoints/checkpoint-1500"  # Teacher LoRA checkpoint
+      path: "Jayce-Ping/Pickscore-Teacher"  # Teacher LoRA checkpoint
       applicable_datasets: [pickscore]  # Distill this teacher on pickscore rollouts
     - name: "teacher-ocr"  # Unique teacher id (named snapshot + log keys)
-      path: "~/checkpoints/dppo_ocr_teacher/checkpoints/checkpoint-220"  # Teacher LoRA checkpoint
+      path: "Jayce-Ping/OCR-Teacher"  # Teacher LoRA checkpoint
       applicable_datasets: [ocr]  # Distill this teacher on ocr rollouts
 
   teacher_param_device: 'cuda'  # Teacher snapshot storage: 'cuda' (fast swaps) or 'cpu' (low VRAM)

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -26,14 +26,16 @@ num_processes: 8  # Number of GPU processes to launch
 main_process_port: 29500  # Port for distributed communication
 mixed_precision: "bf16"  # Options: no, fp16, bf16
 
-# Data Configuration — 3 sources, one teacher each (weighted 1:1:1)
+# Data Configuration — 3 training sources (geneval / pickscore / ocr), weighted 1:1:1.
+# Below them, three eval-only *_no-cfg aliases (same test split, guidance_scale=1.0)
+# isolate the effect of classifier-free guidance at eval time; they do not train.
 data:
   datasets:
     - name: geneval  # Unique identifier (source tag, metrics, reward + teacher routing)
       dataset_dir: "dataset/geneval"  # Folder with train.jsonl / test.jsonl
       train:  # Training participation config
         weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
-        max_dataset_size: 1024  # Cap on number of training prompts for this source
+        max_dataset_size: null  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
         guidance_scale: 4.5  # Override eval guidance scale for this dataset
@@ -42,7 +44,7 @@ data:
       dataset_dir: "dataset/pickscore"  # Folder with train.jsonl / test.jsonl
       train:  # Training participation config
         weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
-        max_dataset_size: 1024  # Cap on number of training prompts for this source
+        max_dataset_size: null  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
         guidance_scale: 4.5  # Override eval guidance scale for this dataset
@@ -51,10 +53,35 @@ data:
       dataset_dir: "dataset/ocr"  # Folder with train.jsonl / test.jsonl
       train:  # Training participation config
         weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
-        max_dataset_size: 1024  # Cap on number of training prompts for this source
+        max_dataset_size: null  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
         guidance_scale: 4.5  # Override eval guidance scale for this dataset
+
+    # --- Eval-only no-CFG ablations (guidance_scale=1.0 vs 4.5 above) ---
+    # Same dataset_dir and test split as the matching source; train: null avoids
+    # loading train.jsonl twice. Compare W&B keys eval/{name}/... to measure CFG impact.
+
+    - name: geneval_no-cfg
+      dataset_dir: "dataset/geneval"
+      train: null
+      eval:
+        num_inference_steps: 40
+        guidance_scale: 1.0
+
+    - name: pickscore_no-cfg
+      dataset_dir: "dataset/pickscore"
+      train: null
+      eval:
+        num_inference_steps: 40
+        guidance_scale: 1.0
+
+    - name: ocr_no-cfg
+      dataset_dir: "dataset/ocr"
+      train: null
+      eval:
+        num_inference_steps: 40
+        guidance_scale: 1.0
 
   preprocessing_batch_size: 8  # Batch size for preprocessing
   dataloader_num_workers: 16  # Number of workers for DataLoader
@@ -174,18 +201,18 @@ eval_rewards:
     batch_size: 32  # Larger batch for eval (no gradient, more memory available)
     device: "cuda"  # Device to run reward model on
     dtype: float32  # Precision for reward model inference
-    applicable_datasets: ["geneval"]  # Only scores geneval eval samples
+    applicable_datasets: ["geneval", "geneval_no-cfg"]  # CFG and no-CFG eval tracks
 
   - name: "ocr"  # Eval reward identifier
     reward_model: "OCR"  # Reward model class (from registry)
     batch_size: 32  # Larger batch for eval (no gradient, more memory available)
     device: "cuda"  # Device to run reward model on
     dtype: bfloat16  # Precision for reward model inference
-    applicable_datasets: ["ocr"]  # Only scores ocr eval samples
+    applicable_datasets: ["ocr", "ocr_no-cfg"]
 
   - name: "pick_score"  # Eval reward identifier
     reward_model: "PickScore"  # Reward model class (from registry)
     batch_size: 32  # Larger batch for eval (no gradient, more memory available)
     device: "cuda"  # Device to run reward model on
     dtype: bfloat16  # Precision for reward model inference
-    # applicable_datasets omitted -> applies to all eval sources (geneval, pickscore, ocr)
+    # applicable_datasets omitted -> all eval sources (incl. *_no-cfg aliases)

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -23,6 +23,8 @@
 
 - [CRD: Centered Reward Distillation](#crd-centered-reward-distillation)
 
+- [DiffusionOPD: On-Policy Distillation](#diffusionopd-on-policy-distillation)
+
 - [References](#references)
 
 ## Overview
@@ -481,6 +483,66 @@ train:
 | `> 0` | Softmax temperature | Dual-direction: `softmax(adv/τ)` and `softmax(-adv/τ)` |
 
 
+## DiffusionOPD: On-Policy Distillation
+
+This algorithm is introduced in [[14]](#ref14). **DiffusionOPD** is a *decoupled-paradigm* multi-task distillation method: instead of jointly optimizing several rewards from scratch, it first trains one task-specialized **teacher** per task (e.g. GenEval, OCR, aesthetics) and then distills their capabilities into a single unified **student** along the student's own rollout trajectories. This reduces reward conflict and catastrophic forgetting relative to multi-reward RL.
+
+Unlike the policy-gradient algorithms above, the loss is a closed-form **per-step KL on the denoising transition** — a pathwise mean-matching objective that covers both stochastic SDE samplers and deterministic ODE samplers:
+
+```
+kl_div_j = 0.5 * || mu_S - mu_T ||^2 / denom
+```
+
+where `mu_S` / `mu_T` are the student / teacher transition means at the student-visited state `x_j`, and `denom` is the scheduler's transition variance for the active dynamics (centralized in `scheduler.get_kl_divergence_denominator`):
+
+| `dynamics_type` | `denom` | resulting `kl_div_j` |
+|---|---|---|
+| `ODE` | `1.0` | pure mean matching: `0.5 * ||μ_S − μ_T||²` |
+| `Flow-SDE`, `Dance-SDE` | `std_dev_t² · (-dt)` | Gaussian transition KL: `||μ_S − μ_T||² / (2 σ̄²)` |
+| `CPS` | `std_dev_t²` | `||μ_S − μ_T||² / (2 std_dev_t²)` |
+
+There is no loss-scaling coefficient (DiffusionOPD has no REINFORCE term). Rewards are used **only** for periodic eval monitoring (`evaluate()`), never in the distillation loss.
+
+### How it works (2-pass per epoch)
+
+Built directly on the multi-dataset infrastructure (`data.datasets`, per-source `source`/`source_id`, `train_dataloaders_by_source`), so each teacher is routed to one or more training datasets:
+
+1. **`sample()`** — the student rolls out on-policy trajectories over the multi-source dataloader (each sample tagged with its `source`), reusing the standard sampling pipeline.
+2. **`optimize()` PASS 1** (`no_grad`) — for each teacher (exactly **one** weight swap, via the named-parameter snapshot), forward over its routed samples' stored states `x_j` and cache the teacher means `mu_T` on each sample.
+3. **`optimize()` PASS 2** (student params only) — a standard gradient loop forwards the student at the same `x_j`, matching each sample's `mu_S` to its own cached `mu_T` (a micro-batch may mix teachers; the batch-mean is an implicit per-teacher KL averaged over the batch).
+
+Teacher swaps are thus **M-per-epoch** (one per teacher), the gradient loop runs with student params only (no autocast-cache toggling, no DDP bypass), and the loss is a clean student-vs-cached-target MSE.
+
+### Teacher loading
+
+Teachers are **LoRA-only** (full-parameter teachers are deferred). Each teacher checkpoint is loaded into a named-parameter snapshot and **must share the student's LoRA architecture** (same `target_components` / target modules, compatible rank/alpha), because it is loaded into the student's active adapter slot. Local paths and Hugging Face Hub repo ids are both accepted.
+
+To use this algorithm, set:
+
+```yaml
+train:
+  trainer_type: 'diffusion-opd'
+
+  teachers:
+    - name: "geneval-teacher"           # unique id (named snapshot + log keys)
+      path: "quanhaol/GenEval-Teacher"  # local path or HF repo id (PEFT LoRA)
+      applicable_datasets: [geneval]    # distill on geneval rollouts
+      # guidance_scale: 4.5             # (optional) per-teacher CFG override (null = student CFG)
+    - name: "ocr-teacher"
+      path: "quanhaol/OCR-Teacher"
+      applicable_datasets: [ocr]
+
+  teacher_param_device: 'cuda'  # teacher snapshot device: 'cuda' (fast swaps) / 'cpu' (low VRAM)
+  guidance_scale: 1.0           # student CFG for rollout + forward
+
+scheduler:
+  dynamics_type: "ODE"  # mean matching; switch to Flow-SDE + noise_level>0 for SDE distillation
+  noise_level: 0.0
+```
+
+Each teacher's `applicable_datasets` must reference declared `data.datasets[*].name` entries (validated at config load). The config schema allows several teachers to share a dataset for a future multi-teacher/ensemble trainer, but the current `DiffusionOPDTrainer` requires exactly one teacher per dataset and raises otherwise. See [`examples/opd/lora/sd3_5/`](../examples/opd/lora/sd3_5/) for two complete configs (HF teachers and local-checkpoint teachers).
+
+
 ## References
 
 * <a name="ref1"></a>[1] [**Flow-GRPO:** Training Flow Matching Models via Online RL](https://arxiv.org/abs/2505.05470)
@@ -496,3 +558,4 @@ train:
 * <a name="ref11"></a>[11] [**Diffusion-DPO**: Diffusion Model Alignment Using Direct Preference Optimization](https://arxiv.org/abs/2311.12908)
 * <a name="ref12"></a>[12] [**TDM-R1**: Reinforcing Few-Step Diffusion Models with Non-Differentiable Reward](https://arxiv.org/abs/2510.08425)
 * <a name="ref13"></a>[13] [**CRD**: Diffusion Reinforcement Learning via Centered Reward Distillation](https://arxiv.org/abs/2603.14128)
+* <a name="ref14"></a>[14] [**DiffusionOPD**: A Unified Perspective of On-Policy Distillation in Diffusion Models](https://arxiv.org/abs/2605.15055)

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -513,6 +513,8 @@ Built directly on the multi-dataset infrastructure (`data.datasets`, per-source 
 
 Teacher swaps are thus **M-per-epoch** (one per teacher), the gradient loop runs with student params only (no autocast-cache toggling, no DDP bypass), and the loss is a clean student-vs-cached-target MSE.
 
+Which denoising steps are distilled is set by `train.timestep_range` (default `0.99`), the same fraction idiom NFT uses: a float `f` selects the band `[0, f]` of the trajectory's step indices (the first `f`-fraction of denoising steps, skipping the near-clean tail), and a tuple is an explicit `[lo, hi]` band. This reproduces upstream DiffusionOPD's `timestep_fraction` and is **dynamics-agnostic** — it selects by trajectory step index rather than the SDE-only stochastic-step set, so it works identically under ODE and SDE.
+
 ### Teacher loading
 
 Teachers are **LoRA-only** (full-parameter teachers are deferred). Each teacher checkpoint is loaded into a named-parameter snapshot and **must share the student's LoRA architecture** (same `target_components` / target modules, compatible rank/alpha), because it is loaded into the student's active adapter slot. Local paths and Hugging Face Hub repo ids are both accepted.
@@ -534,6 +536,7 @@ train:
 
   teacher_param_device: 'cuda'  # teacher snapshot device: 'cuda' (fast swaps) / 'cpu' (low VRAM)
   guidance_scale: 1.0           # student CFG for rollout + forward
+  timestep_range: 0.99          # distill the first 99% of denoising steps (upstream timestep_fraction)
 
 scheduler:
   dynamics_type: "ODE"  # mean matching; switch to Flow-SDE + noise_level>0 for SDE distillation

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -543,8 +543,7 @@ scheduler:
   noise_level: 0.0
 ```
 
-Each teacher's `applicable_datasets` must reference declared `data.datasets[*].name` entries (validated at config load). The config schema allows several teachers to share a dataset for a future multi-teacher/ensemble trainer, but the current `DiffusionOPDTrainer` requires exactly one teacher per dataset and raises otherwise. See [`examples/opd/lora/sd3_5/`](../examples/opd/lora/sd3_5/) for two complete configs (HF teachers and local-checkpoint teachers).
-
+Each teacher's `applicable_datasets` must reference declared `data.datasets[*].name` entries (validated at config load). The config schema allows several teachers to share a dataset for a future multi-teacher/ensemble trainer, but the current `DiffusionOPDTrainer` requires exactly one teacher per dataset and raises otherwise. See [`examples/opd/lora/sd3_5/`](../examples/opd/lora/sd3_5/) for two complete configs (`DiffusionOPD_aligned.yaml` to reproduce official results).
 
 ## References
 

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -524,12 +524,12 @@ train:
   trainer_type: 'diffusion-opd'
 
   teachers:
-    - name: "geneval-teacher"           # unique id (named snapshot + log keys)
-      path: "quanhaol/GenEval-Teacher"  # local path or HF repo id (PEFT LoRA)
-      applicable_datasets: [geneval]    # distill on geneval rollouts
-      # guidance_scale: 4.5             # (optional) per-teacher CFG override (null = student CFG)
+    - name: "geneval-teacher"                            # unique id (named snapshot + log keys)
+      path: "quanhaol/DiffusionOPD/GenEvalTeacher/lora"  # local path or HF spec owner/repo[/subfolder][@rev]
+      applicable_datasets: [geneval]                     # distill on geneval rollouts
+      # guidance_scale: 4.5                              # (optional) per-teacher CFG override (null = student CFG)
     - name: "ocr-teacher"
-      path: "quanhaol/OCR-Teacher"
+      path: "quanhaol/DiffusionOPD/OCRTeacher/lora"
       applicable_datasets: [ocr]
 
   teacher_param_device: 'cuda'  # teacher snapshot device: 'cuda' (fast swaps) / 'cpu' (low VRAM)

--- a/src/flow_factory/data_utils/loader.py
+++ b/src/flow_factory/data_utils/loader.py
@@ -464,13 +464,6 @@ def get_eval_dataloaders(
     enable_distributed = accelerator.num_processes > 1 and data_args.enable_preprocess
     preprocess_parallelism = getattr(data_args, 'preprocess_parallelism', 'local')
 
-    # Pre-compute eval preprocess kwargs (invariant across datasets)
-    base_preprocess_kwargs = None
-    if preprocess_func:
-        base_preprocess_kwargs = filter_kwargs(preprocess_func, **data_args).copy()
-        base_preprocess_kwargs.update({'is_train': False, **eval_args})
-        base_preprocess_kwargs = filter_kwargs(preprocess_func, **base_preprocess_kwargs)
-
     eval_dataloaders: Dict[str, DataLoader] = {}
 
     for ed in eval_datasets:
@@ -481,6 +474,19 @@ def get_eval_dataloaders(
             # Defensive: caller should have already filtered via the
             # `is_eval_source` property, but keep this safety net.
             continue
+
+        # Per-dataset eval preprocess kwargs: merge this dataset's eval
+        # overrides (notably `guidance_scale`) with the shared EvaluationArguments
+        # via the same `get_merged_eval_kwargs` used by `BaseTrainer.evaluate`.
+        # This keeps Stage 1 (encode_prompt) consistent with Stage 2 (inference):
+        # a dataset evaluated at guidance_scale > 1.0 must cache negative prompt
+        # embeds during preprocessing, otherwise CFG is silently disabled at eval.
+        per_preprocess_kwargs = None
+        if preprocess_func:
+            merged_eval = spec.get_merged_eval_kwargs(eval_args)
+            per_preprocess_kwargs = filter_kwargs(preprocess_func, **data_args).copy()
+            per_preprocess_kwargs.update({'is_train': False, **merged_eval})
+            per_preprocess_kwargs = filter_kwargs(preprocess_func, **per_preprocess_kwargs)
 
         # Check that the split file exists
         if not GeneralDataset.check_exists(ed.dataset_dir, spec.split):
@@ -493,7 +499,7 @@ def get_eval_dataloaders(
         # Start with filter_kwargs from data_args (same pattern as get_dataloader)
         base_kwargs = {
             "preprocess_func": preprocess_func,
-            "preprocess_kwargs": base_preprocess_kwargs,
+            "preprocess_kwargs": per_preprocess_kwargs,
             "extra_hash_strs": [
                 config.model_args.model_type,
                 config.model_args.model_name_or_path,

--- a/src/flow_factory/data_utils/loader.py
+++ b/src/flow_factory/data_utils/loader.py
@@ -16,9 +16,8 @@
 import json
 import os
 import shutil
-from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
-import torch
 from accelerate import Accelerator
 from torch.utils.data import DataLoader
 
@@ -28,6 +27,7 @@ from ..hparams.dataset_args import DatasetArguments
 from ..utils.base import filter_kwargs
 from ..utils.logger_utils import setup_logger
 from .dataset import GeneralDataset
+from .multi_source import MultiSourceTrainDataLoader, WeightedSourceBatchScheduler
 from .sampler_loader import get_data_sampler
 
 logger = setup_logger(__name__, rank_zero_only=False)
@@ -432,171 +432,6 @@ def _load_per_source_train_dataloaders(
         )
 
     return out
-
-
-# ============================================================================
-# Multi-source train DataLoader components
-# ============================================================================
-
-class WeightedSourceBatchScheduler:
-    """Deterministic shared-across-ranks list of source names, length per epoch.
-
-    Built by repeating each source's ``num_batches_per_source[name]`` times
-    and shuffling under a ``torch.Generator`` seeded by ``seed + epoch``.
-    All ranks see the same list every epoch (constructor takes only seed +
-    counts; no rank-dependent randomness).
-
-    The input dict's iteration order is **ignored** — sources are processed
-    in ``sorted(name)`` order so the generated schedule is byte-identical
-    across runs and across rank-zero re-runs (no insertion-order
-    dependence).  Combined with the seed, this yields total reproducibility.
-
-    Why a list, not a stream:
-
-    - We need ``__len__`` for ``tqdm`` and exact-length validation.
-    - Mid-epoch checkpointing can record an integer step index and resume
-      from there.
-    - The "effective num_batches_per_epoch" is checked against
-      ``training_args.num_batches_per_epoch`` once at build time.
-    """
-
-    def __init__(self, num_batches_per_source: Dict[str, int], seed: int):
-        self._counts: Dict[str, int] = dict(num_batches_per_source)
-        self._seed = int(seed)
-        self._epoch = 0
-        self._schedule: List[str] = []
-        self._build()
-
-    def _build(self) -> None:
-        """Materialise the per-epoch shuffled name sequence."""
-        flat: List[str] = []
-        for name in sorted(self._counts.keys()):
-            flat.extend([name] * self._counts[name])
-
-        if not flat:
-            self._schedule = []
-            return
-
-        g = torch.Generator()
-        g.manual_seed(hash((self._seed, self._epoch, "multi_source_schedule")) & 0xFFFF_FFFF_FFFF_FFFF)
-        perm = torch.randperm(len(flat), generator=g).tolist()
-        self._schedule = [flat[i] for i in perm]
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._schedule)
-
-    def __len__(self) -> int:
-        return len(self._schedule)
-
-    def set_epoch(self, epoch: int) -> None:
-        """Reseed the shuffle for the given epoch."""
-        self._epoch = int(epoch)
-        self._build()
-
-
-class MultiSourceTrainDataLoader:
-    """Iterate per-source DataLoaders in a weighted, shuffled order.
-
-    Wraps a ``Dict[str, DataLoader]`` plus a
-    :class:`WeightedSourceBatchScheduler`.  Each yielded batch dict is
-    augmented with ``__source__: List[str]`` of length ``B`` (homogeneous
-    in this PR; the per-sample shape leaves room for future PRs that
-    might interleave within a batch without code changes).
-
-    Key contracts (consumed by ``BaseTrainer``):
-
-    - ``__len__`` == ``num_batches_per_epoch`` (so existing
-      ``tqdm(range(num_batches_per_epoch))`` keeps working unchanged).
-    - ``set_epoch(epoch)`` reseeds the schedule AND propagates to every
-      per-source ``batch_sampler.set_epoch(epoch)``, then drops cached
-      iters so the next ``__iter__()`` starts fresh.
-    - ``dataloaders_by_source`` exposes the underlying per-source dict
-      so the future ``DiffusionOPDTrainer`` can drive its own balanced
-      per-teacher sampling without going through the global scheduler.
-    """
-
-    def __init__(
-        self,
-        dataloaders_by_source: Dict[str, DataLoader],
-        scheduler: WeightedSourceBatchScheduler,
-        source_name_to_id: Optional[Dict[str, int]] = None,
-        batch_size: Optional[int] = None,
-    ):
-        self._loaders_by_source = dataloaders_by_source
-        self._scheduler = scheduler
-        # Optional name -> id mapping; when present, every batch carries
-        # both `__source__` (str, for logs/debugging) and `__source_id__`
-        # (int, for hot-path gate + cross-rank gather). Resolved by
-        # `Arguments._assign_source_ids` and read here from
-        # `data_args.source_name_to_id`. None means "id form not configured" —
-        # the str form alone is emitted (legacy behavior).
-        self._source_name_to_id = source_name_to_id or {}
-        # Explicit batch size when known (item 7's exact-divisibility
-        # geometry guarantees every batch is exactly `per_device_batch_size`).
-        # When None, fall back to the per-batch heuristic in `_infer_batch_size`.
-        self._batch_size = batch_size
-        self._iters: Dict[str, Iterator] = {}
-
-    @property
-    def dataloaders_by_source(self) -> Dict[str, DataLoader]:
-        """Public access for OPD-style consumers."""
-        return self._loaders_by_source
-
-    def _ensure_iters(self) -> None:
-        """Lazily refresh per-source iterators (after set_epoch / first use)."""
-        for name, loader in self._loaders_by_source.items():
-            if name not in self._iters:
-                self._iters[name] = iter(loader)
-
-    def __iter__(self) -> Iterator[Dict[str, Any]]:
-        self._ensure_iters()
-        for src in self._scheduler:
-            batch = next(self._iters[src])
-
-            B = (
-                self._batch_size
-                if self._batch_size is not None
-                else self._infer_batch_size(batch)
-            )
-            batch = dict(batch)
-            batch["__source__"] = [src] * B
-            # Emit the small-int form too when the registry is configured,
-            # so `_inject_batch_metadata` populates `BaseSample.source_id`
-            # for hot-path comparisons. Falls back gracefully when not set.
-            if self._source_name_to_id:
-                batch["__source_id__"] = [self._source_name_to_id[src]] * B
-            yield batch
-
-    def __len__(self) -> int:
-        return len(self._scheduler)
-
-    def set_epoch(self, epoch: int) -> None:
-        """Reseed the schedule and propagate to per-source samplers."""
-        self._scheduler.set_epoch(epoch)
-        for loader in self._loaders_by_source.values():
-            sampler = getattr(loader, "batch_sampler", None) or getattr(loader, "sampler", None)
-            if sampler is not None and hasattr(sampler, "set_epoch"):
-                sampler.set_epoch(epoch)
-        # Force fresh iters next epoch.
-        self._iters.clear()
-
-    @staticmethod
-    def _infer_batch_size(batch: Dict[str, Any]) -> int:
-        """Best-effort batch-size inference from a dataloader batch dict.
-
-        Prefers ``prompt`` (length-bearing list of strings used by every
-        adapter), falls back to the first length-bearing value found.
-        """
-        if "prompt" in batch and hasattr(batch["prompt"], "__len__"):
-            return len(batch["prompt"])
-        for v in batch.values():
-            if hasattr(v, "__len__"):
-                try:
-                    return len(v)
-                except TypeError:
-                    continue
-        return 1
-
 
 
 def get_eval_dataloaders(

--- a/src/flow_factory/data_utils/multi_source.py
+++ b/src/flow_factory/data_utils/multi_source.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# src/flow_factory/data_utils/multi_source.py
+"""Multi-source train DataLoader components.
+
+Houses the weighted, deterministic cross-source scheduler and the wrapper
+DataLoader that drives one underlying DataLoader per training source. These
+are composed by ``data_utils.loader.get_train_dataloader`` when more than one
+training source is declared.
+"""
+from typing import Any, Dict, Iterator, List, Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+
+class WeightedSourceBatchScheduler:
+    """Deterministic shared-across-ranks list of source names, length per epoch.
+
+    Built by repeating each source's ``num_batches_per_source[name]`` times
+    and shuffling under a ``torch.Generator`` seeded by ``seed + epoch``.
+    All ranks see the same list every epoch (constructor takes only seed +
+    counts; no rank-dependent randomness).
+
+    The input dict's iteration order is **ignored** — sources are processed
+    in ``sorted(name)`` order so the generated schedule is byte-identical
+    across runs and across rank-zero re-runs (no insertion-order
+    dependence).  Combined with the seed, this yields total reproducibility.
+
+    Why a list, not a stream:
+
+    - We need ``__len__`` for ``tqdm`` and exact-length validation.
+    - Mid-epoch checkpointing can record an integer step index and resume
+      from there.
+    - The "effective num_batches_per_epoch" is checked against
+      ``training_args.num_batches_per_epoch`` once at build time.
+    """
+
+    def __init__(self, num_batches_per_source: Dict[str, int], seed: int):
+        self._counts: Dict[str, int] = dict(num_batches_per_source)
+        self._seed = int(seed)
+        self._epoch = 0
+        self._schedule: List[str] = []
+        self._build()
+
+    def _build(self) -> None:
+        """Materialise the per-epoch shuffled name sequence."""
+        flat: List[str] = []
+        for name in sorted(self._counts.keys()):
+            flat.extend([name] * self._counts[name])
+
+        if not flat:
+            self._schedule = []
+            return
+
+        g = torch.Generator()
+        g.manual_seed(hash((self._seed, self._epoch, "multi_source_schedule")) & 0xFFFF_FFFF_FFFF_FFFF)
+        perm = torch.randperm(len(flat), generator=g).tolist()
+        self._schedule = [flat[i] for i in perm]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._schedule)
+
+    def __len__(self) -> int:
+        return len(self._schedule)
+
+    def set_epoch(self, epoch: int) -> None:
+        """Reseed the shuffle for the given epoch."""
+        self._epoch = int(epoch)
+        self._build()
+
+
+class MultiSourceTrainDataLoader:
+    """Iterate per-source DataLoaders in a weighted, shuffled order.
+
+    Wraps a ``Dict[str, DataLoader]`` plus a
+    :class:`WeightedSourceBatchScheduler`.  Each yielded batch dict is
+    augmented with ``__source__: List[str]`` of length ``B`` (homogeneous
+    in this PR; the per-sample shape leaves room for future PRs that
+    might interleave within a batch without code changes).
+
+    Key contracts (consumed by ``BaseTrainer``):
+
+    - ``__len__`` == ``num_batches_per_epoch`` (so existing
+      ``tqdm(range(num_batches_per_epoch))`` keeps working unchanged).
+    - ``set_epoch(epoch)`` reseeds the schedule AND propagates to every
+      per-source ``batch_sampler.set_epoch(epoch)``, then drops cached
+      iters so the next ``__iter__()`` starts fresh.
+    - ``dataloaders_by_source`` exposes the underlying per-source dict
+      so the future ``DiffusionOPDTrainer`` can drive its own balanced
+      per-teacher sampling without going through the global scheduler.
+    """
+
+    def __init__(
+        self,
+        dataloaders_by_source: Dict[str, DataLoader],
+        scheduler: WeightedSourceBatchScheduler,
+        source_name_to_id: Optional[Dict[str, int]] = None,
+        batch_size: Optional[int] = None,
+    ):
+        self._loaders_by_source = dataloaders_by_source
+        self._scheduler = scheduler
+        # Optional name -> id mapping; when present, every batch carries
+        # both `__source__` (str, for logs/debugging) and `__source_id__`
+        # (int, for hot-path gate + cross-rank gather). Resolved by
+        # `Arguments._assign_source_ids` and read here from
+        # `data_args.source_name_to_id`. None means "id form not configured" —
+        # the str form alone is emitted (legacy behavior).
+        self._source_name_to_id = source_name_to_id or {}
+        # Explicit batch size when known (item 7's exact-divisibility
+        # geometry guarantees every batch is exactly `per_device_batch_size`).
+        # When None, fall back to the per-batch heuristic in `_infer_batch_size`.
+        self._batch_size = batch_size
+        self._iters: Dict[str, Iterator] = {}
+
+    @property
+    def dataloaders_by_source(self) -> Dict[str, DataLoader]:
+        """Public access for OPD-style consumers."""
+        return self._loaders_by_source
+
+    def _ensure_iters(self) -> None:
+        """Lazily refresh per-source iterators (after set_epoch / first use)."""
+        for name, loader in self._loaders_by_source.items():
+            if name not in self._iters:
+                self._iters[name] = iter(loader)
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        self._ensure_iters()
+        for src in self._scheduler:
+            batch = next(self._iters[src])
+
+            B = (
+                self._batch_size
+                if self._batch_size is not None
+                else self._infer_batch_size(batch)
+            )
+            batch = dict(batch)
+            batch["__source__"] = [src] * B
+            # Emit the small-int form too when the registry is configured,
+            # so `_inject_batch_metadata` populates `BaseSample.source_id`
+            # for hot-path comparisons. Falls back gracefully when not set.
+            if self._source_name_to_id:
+                batch["__source_id__"] = [self._source_name_to_id[src]] * B
+            yield batch
+
+    def __len__(self) -> int:
+        return len(self._scheduler)
+
+    def set_epoch(self, epoch: int) -> None:
+        """Reseed the schedule and propagate to per-source samplers."""
+        self._scheduler.set_epoch(epoch)
+        for loader in self._loaders_by_source.values():
+            sampler = getattr(loader, "batch_sampler", None) or getattr(loader, "sampler", None)
+            if sampler is not None and hasattr(sampler, "set_epoch"):
+                sampler.set_epoch(epoch)
+        # Force fresh iters next epoch.
+        self._iters.clear()
+
+    @staticmethod
+    def _infer_batch_size(batch: Dict[str, Any]) -> int:
+        """Best-effort batch-size inference from a dataloader batch dict.
+
+        Prefers ``prompt`` (length-bearing list of strings used by every
+        adapter), falls back to the first length-bearing value found.
+        """
+        if "prompt" in batch and hasattr(batch["prompt"], "__len__"):
+            return len(batch["prompt"])
+        for v in batch.values():
+            if hasattr(v, "__len__"):
+                try:
+                    return len(v)
+                except TypeError:
+                    continue
+        return 1

--- a/src/flow_factory/data_utils/multi_source.py
+++ b/src/flow_factory/data_utils/multi_source.py
@@ -20,6 +20,7 @@ DataLoader that drives one underlying DataLoader per training source. These
 are composed by ``data_utils.loader.get_train_dataloader`` when more than one
 training source is declared.
 """
+
 from typing import Any, Dict, Iterator, List, Optional
 
 import torch
@@ -66,7 +67,9 @@ class WeightedSourceBatchScheduler:
             return
 
         g = torch.Generator()
-        g.manual_seed(hash((self._seed, self._epoch, "multi_source_schedule")) & 0xFFFF_FFFF_FFFF_FFFF)
+        g.manual_seed(
+            hash((self._seed, self._epoch, "multi_source_schedule")) & 0xFFFF_FFFF_FFFF_FFFF
+        )
         perm = torch.randperm(len(flat), generator=g).tolist()
         self._schedule = [flat[i] for i in perm]
 
@@ -141,11 +144,7 @@ class MultiSourceTrainDataLoader:
         for src in self._scheduler:
             batch = next(self._iters[src])
 
-            B = (
-                self._batch_size
-                if self._batch_size is not None
-                else self._infer_batch_size(batch)
-            )
+            B = self._batch_size if self._batch_size is not None else self._infer_batch_size(batch)
             batch = dict(batch)
             batch["__source__"] = [src] * B
             # Emit the small-int form too when the registry is configured,

--- a/src/flow_factory/hparams/__init__.py
+++ b/src/flow_factory/hparams/__init__.py
@@ -27,6 +27,8 @@ from .training_args import (
     DGPOTrainingArguments,
     DPOTrainingArguments,
     CRDTrainingArguments,
+    DiffusionOPDTrainingArguments,
+    TeacherConfig,
     get_training_args_class,
 )
 from .reward_args import RewardArguments, MultiRewardArguments
@@ -46,6 +48,8 @@ __all__ = [
     "DGPOTrainingArguments",
     "DPOTrainingArguments",
     "CRDTrainingArguments",
+    "DiffusionOPDTrainingArguments",
+    "TeacherConfig",
     "get_training_args_class",
     "RewardArguments",
     "MultiRewardArguments",

--- a/src/flow_factory/hparams/args.py
+++ b/src/flow_factory/hparams/args.py
@@ -155,6 +155,11 @@ class Arguments(ArgABC):
         # gate. Trivially deterministic on every rank because IDs come
         # from the same shared config.
         self._resolve_reward_dataset_ids()
+        # DiffusionOPD teacher routing (no-op for other trainers): each teacher's
+        # `applicable_datasets` must reference declared training datasets. The
+        # one-teacher-per-dataset rule is enforced in DiffusionOPDTrainer, not here
+        # (the config schema stays permissive for a future multi-teacher trainer).
+        self._validate_teacher_sources()
         self._resolve_scheduler_sde_defaults()
         self._resolve_sampler_type()
         self._align_batch_geometry()
@@ -315,6 +320,40 @@ class Arguments(ArgABC):
 
         _check_side(self.reward_args, train_names, side="Training")
         _check_side(self.eval_reward_args, eval_names, side="Eval")
+
+    def _validate_teacher_sources(self) -> None:
+        """Validate DiffusionOPD teacher routing (OPD trainer only).
+
+        Every ``TeacherConfig.applicable_datasets`` entry must reference a
+        declared training dataset (``data.datasets[*].name`` with training
+        enabled). The schema deliberately permits several teachers to share a
+        dataset; the one-teacher-per-dataset constraint is enforced by
+        ``DiffusionOPDTrainer`` (not here), so a future multi-teacher/ensemble
+        trainer can reuse this config unchanged.
+
+        No-op for non-OPD trainers (their ``TrainingArguments`` has no
+        ``teachers`` attribute).
+        """
+        ta = self.training_args
+        teachers = getattr(ta, "teachers", None)
+        if not teachers:
+            return
+
+        train_names = {d.name for d in self.data_args.training_datasets}
+        if not train_names:
+            raise ValueError(
+                "DiffusionOPD requires `data.datasets` with at least one training dataset, "
+                "but none were found. Declare each teacher's dataset under `data.datasets`."
+            )
+
+        for i, teacher in enumerate(teachers):
+            unknown = [d for d in teacher.applicable_datasets if d not in train_names]
+            if unknown:
+                raise ValueError(
+                    f"DiffusionOPD teacher[{i}] (name={teacher.name!r}, path={teacher.path!r}) references "
+                    f"dataset(s) {unknown} not in training datasets {sorted(train_names)}. "
+                    "Each `applicable_datasets` entry must match a `data.datasets[*].name` whose `train` is enabled."
+                )
 
     def _validate_dataset_routing(self) -> None:
         """Validate the unified ``data.datasets`` schema and reward routing.

--- a/src/flow_factory/hparams/args.py
+++ b/src/flow_factory/hparams/args.py
@@ -365,6 +365,20 @@ class Arguments(ArgABC):
                     "Each `applicable_datasets` entry must match a `data.datasets[*].name` whose `train` is enabled."
                 )
 
+        # Reverse check: every active training dataset must be claimed by at
+        # least one teacher (mirrors `_validate_every_source_has_a_reward`).
+        # The one-teacher-per-dataset (no-overlap) rule stays in
+        # DiffusionOPDTrainer; here we only require full coverage so an
+        # uncovered dataset fails at config parse, not mid-rollout.
+        covered = {ds for t in teachers for ds in t.applicable_datasets}
+        uncovered = sorted(train_names - covered)
+        if uncovered:
+            raise ValueError(
+                f"DiffusionOPD training dataset(s) {uncovered} are not distilled by any teacher. "
+                f"Each `data.datasets[*].name` with `train.enabled` must appear in exactly one "
+                f"teacher's `applicable_datasets`. Declared teachers cover: {sorted(covered)}."
+            )
+
     def _validate_dataset_routing(self) -> None:
         """Validate the unified ``data.datasets`` schema and reward routing.
 

--- a/src/flow_factory/hparams/args.py
+++ b/src/flow_factory/hparams/args.py
@@ -32,7 +32,12 @@ from .abc import ArgABC
 from .data_args import DataArguments
 from .model_args import ModelArguments
 from .scheduler_args import SchedulerArguments
-from .training_args import TrainingArguments, EvaluationArguments, get_training_args_class
+from .training_args import (
+    DiffusionOPDTrainingArguments,
+    EvaluationArguments,
+    TrainingArguments,
+    get_training_args_class,
+)
 from .reward_args import RewardArguments, MultiRewardArguments
 from .log_args import LogArguments
 from ..utils.logger_utils import setup_logger
@@ -331,11 +336,16 @@ class Arguments(ArgABC):
         ``DiffusionOPDTrainer`` (not here), so a future multi-teacher/ensemble
         trainer can reuse this config unchanged.
 
-        No-op for non-OPD trainers (their ``TrainingArguments`` has no
-        ``teachers`` attribute).
+        Gated on ``isinstance(DiffusionOPDTrainingArguments)`` so it is a no-op
+        for non-OPD trainers. (A plain ``getattr(ta, "teachers", ...)`` would be
+        unsafe: ``ArgABC.__getattr__`` falls back to ``extra_kwargs``, so a stray
+        ``teachers:`` key in a non-OPD YAML would be picked up here and raise a
+        confusing error.)
         """
         ta = self.training_args
-        teachers = getattr(ta, "teachers", None)
+        if not isinstance(ta, DiffusionOPDTrainingArguments):
+            return
+        teachers = ta.teachers
         if not teachers:
             return
 

--- a/src/flow_factory/hparams/dataset_args.py
+++ b/src/flow_factory/hparams/dataset_args.py
@@ -44,15 +44,16 @@ Reward routing references each dataset by ``name`` via
 ``RewardArguments.applicable_datasets``.  The ``__source__`` carried on every sample
 is exactly this name.
 """
+
 from __future__ import annotations
 
 import re
-import yaml
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, List, Optional, Tuple, Union
 
-from .abc import ArgABC
+import yaml
 
+from .abc import ArgABC
 
 # Names appear in metric keys (``train/source/{name}/...``), in cache
 # fingerprints (``train_source:{name}``), and as the routing key for
@@ -86,7 +87,9 @@ class DatasetTrainSpec(ArgABC):
 
     enabled: bool = field(
         default=True,
-        metadata={"help": "Set False to keep this dataset configured but exclude it from training."},
+        metadata={
+            "help": "Set False to keep this dataset configured but exclude it from training."
+        },
     )
     split: str = field(
         default="train",
@@ -94,12 +97,16 @@ class DatasetTrainSpec(ArgABC):
     )
     weight: int = field(
         default=1,
-        metadata={"help": "Mixing weight (positive integer). Used as the LCM denominator for "
-                          "per-source batch allocation; ensures every batch comes from a single source."},
+        metadata={
+            "help": "Mixing weight (positive integer). Used as the LCM denominator for "
+            "per-source batch allocation; ensures every batch comes from a single source."
+        },
     )
     max_dataset_size: Optional[int] = field(
         default=None,
-        metadata={"help": "Cap on training samples for this source (None = inherit DataArguments.max_dataset_size)."},
+        metadata={
+            "help": "Cap on training samples for this source (None = inherit DataArguments.max_dataset_size)."
+        },
     )
 
     # ---- Resolved values written by `Arguments._align_unique_sample_num` ----
@@ -157,7 +164,9 @@ class DatasetEvalSpec(ArgABC):
 
     enabled: bool = field(
         default=True,
-        metadata={"help": "Set False to keep this dataset configured but exclude it from evaluation."},
+        metadata={
+            "help": "Set False to keep this dataset configured but exclude it from evaluation."
+        },
     )
     split: str = field(
         default="test",
@@ -169,7 +178,9 @@ class DatasetEvalSpec(ArgABC):
     )
     resolution: Optional[Union[int, Tuple[int, int], List[int]]] = field(
         default=None,
-        metadata={"help": "Override eval resolution for this dataset. None inherits shared eval.resolution."},
+        metadata={
+            "help": "Override eval resolution for this dataset. None inherits shared eval.resolution."
+        },
     )
     num_inference_steps: Optional[int] = field(
         default=None,
@@ -208,13 +219,13 @@ class DatasetEvalSpec(ArgABC):
 
         # Resolution requires special handling (expands to height/width)
         if self.resolution is not None:
-            merged['resolution'] = self.resolution
+            merged["resolution"] = self.resolution
             if isinstance(self.resolution, int):
-                merged['height'] = self.resolution
-                merged['width'] = self.resolution
+                merged["height"] = self.resolution
+                merged["width"] = self.resolution
             elif isinstance(self.resolution, (list, tuple)) and len(self.resolution) >= 2:
-                merged['height'] = self.resolution[0]
-                merged['width'] = self.resolution[1]
+                merged["height"] = self.resolution[0]
+                merged["width"] = self.resolution[1]
 
         return merged
 
@@ -266,7 +277,9 @@ class DatasetArguments(ArgABC):
 
     name: str = field(
         default="default",
-        metadata={"help": "Unique dataset name (used in metric keys, cache fingerprints, reward routing)."},
+        metadata={
+            "help": "Unique dataset name (used in metric keys, cache fingerprints, reward routing)."
+        },
     )
     dataset_dir: str = field(
         default="data",

--- a/src/flow_factory/hparams/training_args/__init__.py
+++ b/src/flow_factory/hparams/training_args/__init__.py
@@ -28,6 +28,7 @@ from .awm import AWMTrainingArguments
 from .dpo import DPOTrainingArguments
 from .dgpo import DGPOTrainingArguments
 from .crd import CRDTrainingArguments
+from .opd import DiffusionOPDTrainingArguments, TeacherConfig
 
 __all__ = [
     "EvaluationArguments",
@@ -38,6 +39,8 @@ __all__ = [
     "DPOTrainingArguments",
     "DGPOTrainingArguments",
     "CRDTrainingArguments",
+    "DiffusionOPDTrainingArguments",
+    "TeacherConfig",
     "get_training_args_class",
     "list_registered_training_args",
 ]

--- a/src/flow_factory/hparams/training_args/_registry.py
+++ b/src/flow_factory/hparams/training_args/_registry.py
@@ -25,6 +25,7 @@ from .awm import AWMTrainingArguments
 from .dpo import DPOTrainingArguments
 from .dgpo import DGPOTrainingArguments
 from .crd import CRDTrainingArguments
+from .opd import DiffusionOPDTrainingArguments
 
 
 # ============================================================================
@@ -39,6 +40,7 @@ _TRAINING_ARGS_REGISTRY: Dict[str, Type[TrainingArguments]] = {
     'dgpo': DGPOTrainingArguments,
     'dpo': DPOTrainingArguments,
     'crd': CRDTrainingArguments,
+    'diffusion-opd': DiffusionOPDTrainingArguments,
 }
 
 

--- a/src/flow_factory/hparams/training_args/opd.py
+++ b/src/flow_factory/hparams/training_args/opd.py
@@ -23,10 +23,32 @@ entries) via :class:`TeacherConfig.applicable_datasets`.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Any, List, Literal, Optional, Tuple, Union
 
 from ..abc import ArgABC
 from ._base import TrainingArguments, _standardize_timestep_range
+
+
+def resolve_distill_step_band(
+    num_inference_steps: int,
+    timestep_range: Union[float, Tuple[float, float]],
+) -> Tuple[int, int]:
+    """Resolve ``timestep_range`` to the ``[lo, hi)`` denoising-step index band.
+
+    Single source of truth for which trajectory steps DiffusionOPD distills:
+    a bare float ``f`` means ``(0, f)``; ``(frac_lo, frac_hi)`` maps to
+    ``[int(T*frac_lo), int(T*frac_hi))`` with ``T = num_inference_steps``,
+    clamped to at least one step. Used both by
+    :meth:`DiffusionOPDTrainingArguments.get_num_train_timesteps` (gradient-
+    accumulation math) and the trainer's per-step loop, so the two never drift.
+    """
+    if isinstance(timestep_range, (int, float)):
+        frac_lo, frac_hi = 0.0, float(timestep_range)
+    else:
+        frac_lo, frac_hi = timestep_range
+    lo = int(num_inference_steps * frac_lo)
+    hi = max(lo + 1, int(num_inference_steps * frac_hi))
+    return lo, hi
 
 
 @dataclass
@@ -171,3 +193,15 @@ class DiffusionOPDTrainingArguments(TrainingArguments):
             if teacher.guidance_scale is not None
         ]
         return max(scales)
+
+    def get_num_train_timesteps(self, args: Any) -> int:
+        """Per-micro-batch backward count = number of distilled denoising steps.
+
+        The optimize loop runs one ``accelerator.backward`` per distilled step
+        (``timestep_range`` band), so the gradient-accumulation math must scale
+        by this count for ``gradient_step_per_epoch`` to hold (mirrors GRPO
+        returning ``num_sde_steps``). Without this override the base returns 1
+        and the trainer takes ``num_distill_steps``x too many optimizer steps.
+        """
+        lo, hi = resolve_distill_step_band(self.num_inference_steps, self.timestep_range)
+        return hi - lo

--- a/src/flow_factory/hparams/training_args/opd.py
+++ b/src/flow_factory/hparams/training_args/opd.py
@@ -23,10 +23,10 @@ entries) via :class:`TeacherConfig.applicable_datasets`.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Tuple, Union
 
 from ..abc import ArgABC
-from ._base import TrainingArguments
+from ._base import TrainingArguments, _standardize_timestep_range
 
 
 @dataclass
@@ -95,9 +95,26 @@ class DiffusionOPDTrainingArguments(TrainingArguments):
             "help": "Device to store teacher LoRA snapshots ('cuda' = fast swaps, 'cpu' = lower VRAM)."
         },
     )
+    timestep_range: Union[float, Tuple[float, float]] = field(
+        default=0.99,
+        metadata={
+            "help": (
+                "Fraction band of denoising transitions to distill, along the denoise axis "
+                "1000->0. A float ``f`` means the band ``[0, f]`` (the first ``f``-fraction of "
+                "steps, skipping the near-clean tail); a tuple is an explicit ``[lo, hi]`` band. "
+                "Default 0.99 matches upstream DiffusionOPD's ``timestep_fraction``. "
+                "Dynamics-agnostic (does not use the SDE-only ``scheduler.train_timesteps``)."
+            )
+        },
+    )
 
     def __post_init__(self):
         super().__post_init__()
+
+        # Standardize to (frac_lo, frac_hi); a float f -> (0.0, f). Mirrors NFT's
+        # `timestep_range` convention so the trainer can derive distillation-step
+        # indices from a fraction band.
+        self.timestep_range = _standardize_timestep_range(self.timestep_range)
 
         # Coerce dict entries -> TeacherConfig (ArgABC.from_dict does not recurse
         # into nested list-of-ArgABC fields).

--- a/src/flow_factory/hparams/training_args/opd.py
+++ b/src/flow_factory/hparams/training_args/opd.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Training arguments for DiffusionOPD (on-policy distillation).
+
+DiffusionOPD distills several task-specialized teachers into a single
+student along the student's own rollout trajectories. Each teacher is a
+LoRA checkpoint routed to one or more training datasets (``data.datasets``
+entries) via :class:`TeacherConfig.applicable_datasets`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+from ..abc import ArgABC
+from ._base import TrainingArguments
+
+
+@dataclass
+class TeacherConfig(ArgABC):
+    """Configuration for a single DiffusionOPD teacher.
+
+    Attributes:
+        path: Path or HuggingFace repo id of the teacher LoRA checkpoint.
+            Must share the student's LoRA architecture (target modules;
+            rank/alpha compatible) since it is loaded into the student's
+            active adapter slot.
+        name: Unique teacher identifier (used for the named-parameter
+            snapshot and log keys). Defaults to ``opd_teacher_{i}``.
+        applicable_datasets: Dataset names (matching ``data.datasets[*].name``)
+            whose student rollouts are distilled from this teacher's per-step
+            KL. Required and non-empty. NOTE: the schema intentionally permits
+            several teachers to list the same dataset (so a future
+            multi-teacher/ensemble trainer can reuse this config), but the
+            current ``DiffusionOPDTrainer`` distills exactly one teacher per
+            dataset and raises if a dataset is claimed by more than one teacher.
+        guidance_scale: Optional per-teacher CFG override for the teacher
+            forward. ``None`` falls back to the trainer-global student
+            ``guidance_scale`` (e.g. a GenEval teacher queried at its
+            no-CFG training distribution while the student rolls out at a
+            higher scale).
+    """
+
+    path: str = field(
+        metadata={"help": "Path or HF repo id of the teacher LoRA checkpoint."},
+    )
+    name: Optional[str] = field(
+        default=None,
+        metadata={"help": "Unique teacher name (defaults to opd_teacher_{i})."},
+    )
+    applicable_datasets: List[str] = field(
+        default_factory=list,
+        metadata={
+            "help": "Dataset names this teacher is distilled on (matches data.datasets[*].name)."
+        },
+    )
+    guidance_scale: Optional[float] = field(
+        default=None,
+        metadata={
+            "help": "Per-teacher CFG override for the teacher forward (None = student guidance_scale)."
+        },
+    )
+
+
+@dataclass
+class DiffusionOPDTrainingArguments(TrainingArguments):
+    r"""Training arguments for the DiffusionOPD distillation trainer.
+
+    Supports both ODE and SDE dynamics: the per-step loss is
+    ``kl_div_j = 0.5 * ||mu_S - mu_T||^2 / denom`` where ``denom`` is the
+    scheduler's transition variance (``1`` for ODE), so no extra config is
+    needed to switch dynamics — only ``scheduler.dynamics_type``.
+    """
+
+    teachers: List[TeacherConfig] = field(
+        default_factory=list,
+        metadata={"help": "List of teacher configs; each maps a LoRA checkpoint -> dataset(s)."},
+    )
+    teacher_param_device: Literal["cpu", "cuda"] = field(
+        default="cuda",
+        metadata={
+            "help": "Device to store teacher LoRA snapshots ('cuda' = fast swaps, 'cpu' = lower VRAM)."
+        },
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Coerce dict entries -> TeacherConfig (ArgABC.from_dict does not recurse
+        # into nested list-of-ArgABC fields).
+        coerced: List[TeacherConfig] = []
+        for i, teacher in enumerate(self.teachers):
+            if isinstance(teacher, TeacherConfig):
+                coerced.append(teacher)
+            elif isinstance(teacher, dict):
+                coerced.append(TeacherConfig.from_dict(teacher))
+            else:
+                raise TypeError(
+                    f"train.teachers[{i}] must be a dict or TeacherConfig, "
+                    f"got {type(teacher).__name__}."
+                )
+        self.teachers = coerced
+
+        if not self.teachers:
+            raise ValueError(
+                "DiffusionOPDTrainingArguments requires at least one teacher; "
+                "got an empty `train.teachers` list."
+            )
+
+        seen_names: set[str] = set()
+        for i, teacher in enumerate(self.teachers):
+            if not teacher.path:
+                raise ValueError(f"train.teachers[{i}] is missing a `path`.")
+            if not teacher.applicable_datasets:
+                raise ValueError(
+                    f"DiffusionOPD requires each teacher to specify non-empty `applicable_datasets`; "
+                    f"teacher[{i}] (path={teacher.path!r}) has none. Each teacher must declare "
+                    "which `data.datasets[*].name` dataset(s) it is distilled on."
+                )
+            if teacher.name is None:
+                teacher.name = f"opd_teacher_{i}"
+            if teacher.name in seen_names:
+                raise ValueError(
+                    f"Duplicate teacher name {teacher.name!r}; teacher names must be unique."
+                )
+            seen_names.add(teacher.name)
+            if teacher.guidance_scale is not None:
+                teacher.guidance_scale = float(teacher.guidance_scale)
+
+    def get_preprocess_guidance_scale(self) -> float:
+        """Encode negative prompts if the student OR any teacher uses CFG > 1.
+
+        DiffusionOPD rolls out / forwards at the student ``guidance_scale``
+        but may query a teacher at its own (possibly higher) scale, so the
+        preprocessing stage must cover the max of both.
+        """
+        scales = [self.guidance_scale]
+        scales += [
+            teacher.guidance_scale
+            for teacher in self.teachers
+            if teacher.guidance_scale is not None
+        ]
+        return max(scales)

--- a/src/flow_factory/scheduler/abc.py
+++ b/src/flow_factory/scheduler/abc.py
@@ -152,3 +152,61 @@ class SDESchedulerMixin(ABC):
     def get_noise_level_for_sigma(self, sigma: float) -> float:
         """Get noise level for specific sigma value."""
         ...
+
+    # ==================== Distillation / KL ====================
+    def get_kl_divergence_denominator(
+        self,
+        std_dev_t: Optional[torch.Tensor],
+        dt: Optional[torch.Tensor],
+        eps: float = 1e-8,
+    ) -> Union[float, torch.Tensor]:
+        """Transition variance ``sigma_bar^2`` for the pathwise per-step KL.
+
+        Distillation trainers (e.g. DiffusionOPD) match the student mean
+        ``mu_S`` to a teacher mean ``mu_T`` along the rollout via
+        ``loss = 0.5 * ||mu_S - mu_T||^2 / denom`` where ``denom`` is the
+        variance of the Gaussian transition ``N(mu, sigma_bar^2)`` that
+        this scheduler's :meth:`step` defines for the active
+        ``dynamics_type``:
+
+        =============  ========================  ================================
+        dynamics_type  denom                     transition sampled in ``step``
+        =============  ========================  ================================
+        ODE            ``1.0``                   deterministic (mean matching)
+        Flow-SDE       ``std_dev_t**2 * (-dt)``  ``mu + std_dev_t*sqrt(-dt)*eps``
+        Dance-SDE      ``std_dev_t**2 * (-dt)``  ``mu + std_dev_t*sqrt(-dt)*eps``
+        CPS            ``std_dev_t**2``          ``mu + std_dev_t*eps``
+        =============  ========================  ================================
+
+        For ``ODE`` it returns the scalar ``1.0`` without touching
+        ``std_dev_t``/``dt`` (which are zero/``None`` under ODE), so the
+        same loss expression is dynamics-agnostic. Non-ODE results are
+        clamped to ``>= eps`` to avoid div-by-zero at near-deterministic
+        steps.
+
+        Args:
+            std_dev_t: Per-sample std from the student ``step`` output.
+            dt: Per-sample ``sigma_next - sigma`` (negative) from ``step``.
+            eps: Lower clamp for the (non-ODE) denominator.
+
+        Returns:
+            ``1.0`` for ODE, otherwise a tensor broadcastable against the
+            per-element squared error.
+        """
+        if self.dynamics_type == "ODE":
+            return 1.0
+        if not isinstance(std_dev_t, torch.Tensor):
+            raise ValueError(
+                f"get_kl_divergence_denominator requires a `std_dev_t` tensor for "
+                f"dynamics_type={self.dynamics_type!r}, got {type(std_dev_t).__name__}. "
+                "Ensure the student step() returns 'std_dev_t' (and 'dt')."
+            )
+        if self.dynamics_type == "CPS":
+            return (std_dev_t.float() ** 2).clamp_min(eps)
+        # Flow-SDE / Dance-SDE: Euler-Maruyama transition variance std_dev_t^2 * (-dt).
+        if not isinstance(dt, torch.Tensor):
+            raise ValueError(
+                f"get_kl_divergence_denominator requires a `dt` tensor for "
+                f"dynamics_type={self.dynamics_type!r}, got {type(dt).__name__}."
+            )
+        return (std_dev_t.float() ** 2 * (-dt.float())).clamp_min(eps)

--- a/src/flow_factory/trainers/opd/__init__.py
+++ b/src/flow_factory/trainers/opd/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DiffusionOPD on-policy distillation trainer."""
+
+from .trainer import DiffusionOPDTrainer
+
+__all__ = ["DiffusionOPDTrainer"]

--- a/src/flow_factory/trainers/opd/common.py
+++ b/src/flow_factory/trainers/opd/common.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# src/flow_factory/trainers/opd/common.py
+"""Teacher-loading helper for the DiffusionOPD trainer.
+
+The trainer's 2-pass design (teacher targets pre-computed in a no_grad pass,
+then a student-only gradient loop) removes the reference implementation's hot
+swap machinery, so this module needs exactly one helper: :func:`load_teachers`,
+which loads each teacher LoRA checkpoint into a named-parameter snapshot using
+the adapter primitives already in :mod:`flow_factory.models.abc`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, List, Optional
+
+import torch
+
+from ...utils.logger_utils import setup_logger
+
+if TYPE_CHECKING:
+    from ...models.abc import BaseAdapter
+
+logger = setup_logger(__name__, rank_zero_only=True)
+
+
+def load_teachers(
+    adapter: "BaseAdapter",
+    teacher_paths: List[str],
+    teacher_param_device: str,
+    teacher_names: Optional[List[Optional[str]]] = None,
+) -> List[str]:
+    """Load each teacher LoRA checkpoint into a named-parameter snapshot.
+
+    For every teacher the live student LoRA tensors are snapshotted, the
+    teacher checkpoint is loaded into the active adapter slot via
+    :meth:`BaseAdapter._load_lora` (clobbering the student weights), captured
+    into a named snapshot via :meth:`BaseAdapter.add_named_parameters`, and the
+    student weights are then restored. Swap a teacher in at run time with
+    ``with adapter.use_named_parameters(name): ...``.
+
+    Because ``_load_lora`` loads into the student's active ``"default"`` adapter
+    slot, every teacher checkpoint MUST share the student's LoRA architecture
+    (same ``target_components`` / target modules and rank-compatible weights).
+    Incompatible checkpoints raise a clear error pointing at this constraint.
+
+    Args:
+        adapter: Active :class:`BaseAdapter` in LoRA finetune mode with the
+            student adapter already attached.
+        teacher_paths: Local checkpoint paths or HF Hub repo ids
+            (``owner/repo[/subfolder][@revision]``, optional ``hf://`` prefix),
+            resolved via :meth:`BaseAdapter._resolve_checkpoint_path`. Must be
+            non-empty.
+        teacher_param_device: ``'cpu'`` (low VRAM, H2D copy per swap) or
+            ``'cuda'`` (on-device, LoRA-sized VRAM per teacher).
+        teacher_names: Optional snapshot names (one per path). A ``None`` entry
+            (or short list) falls back to ``'opd_teacher_{i}'``.
+
+    Returns:
+        Snapshot names in the same order as ``teacher_paths`` -- the lookup
+        keys for :meth:`BaseAdapter.use_named_parameters`.
+
+    Raises:
+        ValueError: ``teacher_paths`` is empty, the adapter is not in LoRA
+            mode, or it exposes no trainable LoRA components.
+        RuntimeError: a teacher checkpoint is incompatible with the student's
+            LoRA architecture.
+    """
+    if not teacher_paths:
+        raise ValueError(
+            f"DiffusionOPD requires at least one teacher LoRA path; got teacher_paths={teacher_paths!r}."
+        )
+    if adapter.model_args.finetune_type != "lora":
+        raise ValueError(
+            "load_teachers requires the adapter to be in 'lora' finetune mode "
+            f"(teacher LoRAs load into the student's adapter slot), but "
+            f"model_args.finetune_type={adapter.model_args.finetune_type!r}."
+        )
+
+    target_components: List[str] = [
+        comp for comp, mods in adapter.target_module_map.items() if mods
+    ]
+    if not target_components:
+        raise ValueError(
+            "Adapter has no trainable LoRA components; expected at least one entry with "
+            f"non-empty modules in target_module_map={adapter.target_module_map!r}."
+        )
+
+    names: List[str] = []
+    for i, path in enumerate(teacher_paths):
+        name = (
+            teacher_names[i]
+            if teacher_names and i < len(teacher_names) and teacher_names[i]
+            else f"opd_teacher_{i}"
+        )
+        _load_one_teacher(adapter, name, path, target_components, teacher_param_device)
+        names.append(name)
+
+    logger.info(
+        f"Loaded {len(names)} DiffusionOPD teacher(s): {names} (device={teacher_param_device!r})."
+    )
+    return names
+
+
+def _load_one_teacher(
+    adapter: "BaseAdapter",
+    name: str,
+    lora_path: str,
+    target_components: List[str],
+    device: str,
+) -> None:
+    """Load one teacher LoRA into snapshot ``name``, restoring student weights.
+
+    The student LoRA tensors are the live ``nn.Parameter`` objects; ``_load_lora``
+    mutates them in place, so we keep detached clones and copy them back in a
+    ``finally`` block (even if loading raised). Loading errors are surfaced with
+    the LoRA-architecture constraint that almost always causes them.
+    """
+    # Resolve HF Hub specs / validate local layout before touching weights.
+    lora_path = adapter._resolve_checkpoint_path(lora_path)
+    if len(target_components) > 1:
+        for comp in target_components:
+            sub = os.path.join(lora_path, comp)
+            if not os.path.exists(sub):
+                raise FileNotFoundError(
+                    f"Multi-component LoRA layout requires per-component subdirectories; "
+                    f"missing {sub!r} for component {comp!r} under teacher path {lora_path!r}."
+                )
+
+    live_params = adapter._get_component_parameters(target_components)
+    if not live_params:
+        raise ValueError(
+            f"No trainable LoRA parameters found on components {target_components!r}; "
+            "ensure the student LoRA adapter is attached before loading teachers."
+        )
+    saved_data = [p.detach().clone() for p in live_params]
+
+    try:
+        adapter._load_lora(lora_path)
+        adapter.add_named_parameters(
+            name=name,
+            target_components=target_components,
+            device=device,
+            overwrite=True,
+        )
+    except (RuntimeError, ValueError, KeyError, TypeError) as e:
+        # Almost always a LoRA-architecture mismatch (rank/alpha/target modules)
+        # between the teacher checkpoint and the student adapter slot.
+        raise RuntimeError(
+            f"Failed to load teacher LoRA {name!r} from {lora_path!r}. Teacher checkpoints "
+            f"must share the student's LoRA architecture (target_components={target_components}, "
+            "matching target modules and compatible rank/alpha), since they load into the "
+            "student's active adapter slot. Verify the teacher was trained with the same "
+            f"LoRA config as the student. Original error: {e}"
+        ) from e
+    finally:
+        # Always restore the student weights, even if loading/snapshotting raised.
+        with torch.no_grad():
+            for live, saved in zip(live_params, saved_data):
+                live.data.copy_(saved.to(live.device))

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -50,7 +50,7 @@ import math
 import os
 from collections import defaultdict
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import torch
 import tqdm as tqdm_
@@ -58,9 +58,9 @@ import tqdm as tqdm_
 tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
 
 from ...hparams import DiffusionOPDTrainingArguments
+from ...hparams.training_args.opd import resolve_distill_step_band
 from ...samples import BaseSample
 from ...utils.base import create_generator, filter_kwargs
-from ...utils.dist import reduce_loss_info
 from ...utils.logger_utils import setup_logger
 from ...utils.trajectory_collector import compute_trajectory_indices
 from ..abc import BaseTrainer
@@ -286,7 +286,13 @@ class DiffusionOPDTrainer(BaseTrainer):
             shuffled_samples = [samples[i] for i in perm]
 
             self.adapter.train()
-            loss_info: Dict[str, Any] = defaultdict(list)
+            # Per-teacher KL accumulators over the current gradient-accumulation window.
+            # Fixed (num_teachers,) shape so the cross-rank reduce in `_log_distill_metrics`
+            # is collective-safe regardless of which teachers each rank's micro-batches held.
+            num_teachers = len(self._teacher_names)
+            teacher_kl_sum = torch.zeros(num_teachers, device=device)
+            teacher_kl_count = torch.zeros(num_teachers, device=device)
+            grad_norm = None
 
             with self.autocast():
                 for batch_idx in tqdm(
@@ -301,6 +307,12 @@ class DiffusionOPDTrainer(BaseTrainer):
                         s.to(device)
                         for s in shuffled_samples[start : start + per_device_batch_size]
                     ]
+                    # Teacher index per sample in this (possibly source-mixed) micro-batch.
+                    teacher_idx = torch.tensor(
+                        [self._teacher_index_for_sample(s) for s in batch_samples],
+                        device=device,
+                        dtype=torch.long,
+                    )  # (B,)
                     batch = BaseSample.stack(batch_samples)
                     # extra_kwargs tensors are not moved by BaseSample.to(); move explicitly.
                     mu_teacher_all = batch["mu_teacher"]
@@ -330,10 +342,7 @@ class DiffusionOPDTrainer(BaseTrainer):
                                 return_kwargs=["next_latents_mean", "std_dev_t", "dt"],
                             )
                             # Each sample is matched to ITS OWN routed teacher: mu_teacher
-                            # was cached per-sample in PASS 1, so a micro-batch may mix
-                            # teachers. The batch-mean below is therefore an (implicit)
-                            # per-teacher KL averaged over the batch, weighted by each
-                            # teacher's sample count -- not all-teachers-vs-student.
+                            # was cached per-sample in PASS 1, so a micro-batch may mix teachers.
                             mu_T = mu_teacher_all[:, idx]  # (B, *latent) this sample's teacher mean
                             # Per-sample MSE between student and teacher transition means.
                             per_sample_mse = (
@@ -348,11 +357,17 @@ class DiffusionOPDTrainer(BaseTrainer):
                                 denom = denom.reshape(per_sample_mse.shape[0], -1).mean(
                                     dim=1
                                 )  # (B,)
-                            # (B,) / (B,) -> (B,); 0.5 * mean over batch -> scalar.
-                            kl_div_j = 0.5 * (per_sample_mse / denom).mean()
+                            per_sample_kl = 0.5 * (per_sample_mse / denom)  # (B,)
+                            loss = per_sample_kl.mean()  # scalar (mean over batch)
 
-                            self.accelerator.backward(kl_div_j)
-                            loss_info["kl_div_j"].append(kl_div_j.detach())
+                            self.accelerator.backward(loss)
+
+                            # Accumulate per-teacher KL sums/counts for logging (detached).
+                            with torch.no_grad():
+                                teacher_kl_sum.index_add_(0, teacher_idx, per_sample_kl.detach())
+                                teacher_kl_count.index_add_(
+                                    0, teacher_idx, torch.ones_like(per_sample_kl)
+                                )
 
                             if self.accelerator.sync_gradients:
                                 grad_norm = self.accelerator.clip_grad_norm_(
@@ -361,16 +376,47 @@ class DiffusionOPDTrainer(BaseTrainer):
                                 )
                                 self.optimizer.step()
                                 self.optimizer.zero_grad()
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info["grad_norm"] = grad_norm
-                                self.log_data(
-                                    {f"train/{k}": v for k, v in loss_info.items()},
-                                    step=self.step,
+                                self._log_distill_metrics(
+                                    teacher_kl_sum, teacher_kl_count, grad_norm
                                 )
                                 self.step += 1
-                                loss_info = defaultdict(list)
+                                teacher_kl_sum.zero_()
+                                teacher_kl_count.zero_()
 
     # =============================== Helpers ===============================
+    def _log_distill_metrics(
+        self,
+        teacher_kl_sum: torch.Tensor,
+        teacher_kl_count: torch.Tensor,
+        grad_norm: Optional[torch.Tensor],
+    ) -> None:
+        """Globally reduce per-teacher KL sums/counts and log per-teacher + overall means.
+
+        Logs one ``train/kl_div_{teacher_name}`` per teacher seen this window
+        (the KL averaged over that teacher's samples x timesteps) plus the
+        overall ``train/kl_div`` (averaged across all teachers). The reduce
+        operates on fixed ``(num_teachers,)`` tensors, identical on every rank,
+        so it is collective-safe even when teachers are unevenly distributed
+        across ranks/micro-batches.
+        """
+        # Pack sum + count into one tensor so the cross-rank reduction is a single
+        # collective (the pack-and-reduce idiom used across utils/dist.py).
+        packed = torch.stack([teacher_kl_sum, teacher_kl_count])  # (2, num_teachers)
+        packed = cast(torch.Tensor, self.accelerator.reduce(packed, reduction="sum"))
+        g_sum, g_count = packed[0], packed[1]
+
+        metrics: Dict[str, Any] = {}
+        total_count = g_count.sum()
+        if total_count > 0:
+            metrics["kl_div"] = g_sum.sum() / total_count
+        for teacher_idx, name in enumerate(self._teacher_names):
+            if g_count[teacher_idx] > 0:
+                metrics[f"kl_div_{name}"] = g_sum[teacher_idx] / g_count[teacher_idx]
+        if grad_norm is not None:
+            metrics["grad_norm"] = grad_norm
+
+        self.log_data({f"train/{k}": v for k, v in metrics.items()}, step=self.step)
+
     @staticmethod
     def _select_train_step_indices(
         num_inference_steps: int,
@@ -385,14 +431,11 @@ class DiffusionOPDTrainer(BaseTrainer):
         (distill the first 99% of steps, ``int(10*0.99)=9`` -> indices ``[0..8]``,
         skipping the near-clean tail). Deterministic and dynamics-agnostic, so it
         does NOT use the SDE-only ``scheduler.train_timesteps`` (empty under ODE),
-        and gives identical indices in ``sample()`` and ``optimize()``.
+        and gives identical indices in ``sample()`` and ``optimize()``. The band
+        comes from :func:`resolve_distill_step_band`, the same resolver
+        ``get_num_train_timesteps`` uses for the gradient-accumulation count.
         """
-        if isinstance(timestep_range, (int, float)):
-            frac_lo, frac_hi = 0.0, float(timestep_range)
-        else:
-            frac_lo, frac_hi = timestep_range
-        lo = int(num_inference_steps * frac_lo)
-        hi = max(lo + 1, int(num_inference_steps * frac_hi))
+        lo, hi = resolve_distill_step_band(num_inference_steps, timestep_range)
         return torch.arange(lo, hi, dtype=torch.long)
 
     def _teacher_index_for_sample(self, sample: BaseSample) -> int:

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# src/flow_factory/trainers/opd/trainer.py
+"""DiffusionOPD on-policy distillation trainer.
+
+Distills several task-specialized LoRA teachers into a single student along
+the student's own rollout trajectories using a pathwise mean-matching loss.
+Supports both ODE and SDE dynamics — the per-step transition variance is
+supplied by ``scheduler.get_kl_divergence_denominator`` so the loss is
+dynamics-agnostic.
+
+Reference:
+[1] On-Policy Distillation of Diffusion Models — https://github.com/ali-vilab/DiffusionOPD
+
+Design (2-pass, per epoch):
+  sample()    -> student rolls out on-policy trajectories (tagged by source),
+                 reusing the standard ``generate_samples`` pipeline.
+  optimize()  -> PASS 1 (no_grad): for each teacher (ONE weight swap), forward
+                 over its routed samples' stored states x_j and cache the teacher
+                 mean mu_T_j on each sample.
+              -> PASS 2 (student params only): standard gradient loop that
+                 forwards the student at the same x_j and matches mu_S to the
+                 cached mu_T_j.
+
+This keeps teacher swaps to M-per-epoch, runs the gradient loop with student
+params only (no autocast-cache disable, no DDP bypass), and reuses proven FF
+trajectory-replay primitives shared with GRPO.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections import defaultdict
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+import tqdm as tqdm_
+
+tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
+
+from ...hparams import DiffusionOPDTrainingArguments
+from ...samples import BaseSample
+from ...utils.base import create_generator, filter_kwargs
+from ...utils.dist import reduce_loss_info
+from ...utils.logger_utils import setup_logger
+from ...utils.trajectory_collector import compute_trajectory_indices
+from ..abc import BaseTrainer
+from .common import load_teachers
+
+logger = setup_logger(__name__)
+
+
+class DiffusionOPDTrainer(BaseTrainer):
+    """Multi-teacher on-policy distillation trainer (ODE + SDE)."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.training_args: DiffusionOPDTrainingArguments
+
+        scheduler = self.adapter.scheduler
+        self._is_sde = scheduler.dynamics_type != "ODE"
+        # Teacher mu_T and student mu_S are computed at the SAME stored state x_j
+        # with the SAME noise_level so the transition means are comparable.
+        self._student_noise_level = float(scheduler.noise_level) if self._is_sde else 0.0
+
+        # --- Teachers: load each LoRA checkpoint into a named snapshot ---
+        teachers = self.training_args.teachers
+        self._teacher_names: List[str] = load_teachers(
+            self.adapter,
+            [teacher.path for teacher in teachers],
+            self.training_args.teacher_param_device,
+            [teacher.name for teacher in teachers],
+        )
+        student_gs = float(self.training_args.guidance_scale)
+        self._teacher_gs: List[float] = [
+            float(teacher.guidance_scale) if teacher.guidance_scale is not None else student_gs
+            for teacher in teachers
+        ]
+
+        # --- Dataset -> teacher routing ---
+        # The config schema permits several teachers to share a dataset (so a
+        # future multi-teacher/ensemble trainer can reuse it), but the current
+        # DiffusionOPDTrainer distills exactly one teacher per dataset and
+        # rejects any overlap below. Routing is keyed on ``BaseSample.source``,
+        # which is exactly the dataset name.
+        self._source_to_teacher: Dict[str, int] = {}
+        for teacher_idx, teacher in enumerate(teachers):
+            for dataset in teacher.applicable_datasets:
+                if dataset in self._source_to_teacher:
+                    raise ValueError(
+                        f"Dataset {dataset!r} is claimed by multiple teachers "
+                        f"({self._teacher_names[self._source_to_teacher[dataset]]!r} and "
+                        f"{self._teacher_names[teacher_idx]!r}). The DiffusionOPD config schema "
+                        "permits this for a future multi-teacher/ensemble trainer, but the current "
+                        "DiffusionOPDTrainer distills exactly one teacher per dataset."
+                    )
+                self._source_to_teacher[dataset] = teacher_idx
+
+        # Runtime cross-check against the actually-built per-dataset dataloaders.
+        self._available_sources = set(self.train_dataloaders_by_source.keys())
+        for teacher_idx, teacher in enumerate(teachers):
+            for dataset in teacher.applicable_datasets:
+                if dataset not in self._available_sources:
+                    raise ValueError(
+                        f"Teacher {self._teacher_names[teacher_idx]!r} references dataset {dataset!r} "
+                        f"that has no training dataloader. Available datasets: "
+                        f"{sorted(self._available_sources)}. Check that `data.datasets` has an entry "
+                        "with this `name` and `train.enabled: true`."
+                    )
+
+        self._mu_store_device = (
+            "cpu" if self.training_args.offload_samples_to_cpu else self.accelerator.device
+        )
+
+        logger.info(
+            f"DiffusionOPDTrainer initialized: {len(self._teacher_names)} teacher(s) "
+            f"{self._teacher_names}, dynamics={scheduler.dynamics_type!r} "
+            f"(is_sde={self._is_sde}, student_noise_level={self._student_noise_level}), "
+            f"datasets={sorted(self._available_sources)}, "
+            f"student_gs={student_gs}, teacher_gs={self._teacher_gs}."
+        )
+
+    # =============================== Lifecycle ===============================
+    def start(self) -> None:
+        """Main training loop (mirrors GRPO/NFT: save -> eval -> sample -> optimize)."""
+        while self.should_continue_training():
+            self.adapter.scheduler.set_seed(self.epoch + self.training_args.seed)
+
+            if (
+                self.log_args.save_freq > 0
+                and self.epoch % self.log_args.save_freq == 0
+                and self.log_args.save_dir
+            ):
+                save_dir = os.path.join(
+                    self.log_args.save_dir,
+                    str(self.log_args.run_name),
+                    "checkpoints",
+                )
+                self.save_checkpoint(save_dir, epoch=self.epoch)
+
+            if self.eval_args.eval_freq > 0 and self.epoch % self.eval_args.eval_freq == 0:
+                self.evaluate()
+
+            samples = self.sample()
+            self.prepare_feedback(samples)
+            self.optimize(samples)
+
+            self.adapter.ema_step(step=self.epoch)
+            self.epoch += 1
+
+    def sample(self) -> List[BaseSample]:
+        """Roll out on-policy student trajectories over the multi-source dataloader.
+
+        Stores the trajectory positions needed for per-step distillation
+        (current + next latents at every training timestep). Rewards are not
+        used by the distillation loss, so no reward buffer is attached;
+        reward monitoring is left to :meth:`evaluate`.
+        """
+        trajectory_indices = compute_trajectory_indices(
+            train_timestep_indices=self.adapter.scheduler.train_timesteps,
+            num_inference_steps=self.training_args.num_inference_steps,
+        )
+        return self.generate_samples(
+            reward_buffer=None,
+            compute_log_prob=False,
+            trajectory_indices=trajectory_indices,
+        )
+
+    def prepare_feedback(self, samples: List[BaseSample]) -> None:
+        """No-op: DiffusionOPD has no reward/advantage stage."""
+        return
+
+    # =============================== Optimization ===============================
+    def optimize(self, samples: List[BaseSample]) -> None:
+        """Two-pass distillation: cache teacher means, then student gradient loop."""
+        if not samples:
+            logger.warning("DiffusionOPD optimize() received no samples; skipping epoch.")
+            return
+
+        # Train-mode dynamics for BOTH passes (scheduler.is_eval=False) so the SDE
+        # transition means are computed consistently for teacher and student.
+        self.adapter.train()
+        train_timesteps = self.adapter.scheduler.train_timesteps
+
+        self._precompute_teacher_targets(samples, train_timesteps)
+        self._distill(samples, train_timesteps)
+
+    @torch.no_grad()
+    def _precompute_teacher_targets(
+        self,
+        samples: List[BaseSample],
+        train_timesteps: torch.Tensor,
+    ) -> None:
+        """PASS 1: cache each teacher's per-step mean mu_T on its routed samples.
+
+        One ``use_named_parameters`` swap per teacher (performed OUTSIDE the
+        autocast block); a per-teacher ``autocast`` scope gives each teacher a
+        fresh weight cache (so no stale-cast across swaps), with an explicit
+        ``clear_autocast_cache`` as a belt-and-suspenders guard.
+        """
+        device = self.accelerator.device
+        per_device_batch_size = self.training_args.per_device_batch_size
+
+        samples_by_teacher: Dict[int, List[BaseSample]] = defaultdict(list)
+        for sample in samples:
+            samples_by_teacher[self._teacher_index_for_sample(sample)].append(sample)
+
+        for teacher_idx, teacher_samples in samples_by_teacher.items():
+            teacher_name = self._teacher_names[teacher_idx]
+            teacher_gs = self._teacher_gs[teacher_idx]
+            num_batches = math.ceil(len(teacher_samples) / per_device_batch_size)
+
+            # Swap teacher weights in OUTSIDE the autocast context.
+            with self.adapter.use_named_parameters(teacher_name):
+                with self.autocast():
+                    for batch_idx in tqdm(
+                        range(num_batches),
+                        total=num_batches,
+                        desc=f"Epoch {self.epoch} Teacher[{teacher_name}] targets",
+                        disable=not self.show_progress_bar,
+                    ):
+                        start = batch_idx * per_device_batch_size
+                        micro_batch_samples = [
+                            sample.to(device)
+                            for sample in teacher_samples[start : start + per_device_batch_size]
+                        ]
+                        batch = BaseSample.stack(micro_batch_samples)
+                        # mu_T at each training step: (B, *latent) per step.
+                        mu_teacher_steps = [
+                            self._forward_step(
+                                batch,
+                                timestep_index,
+                                guidance_scale=teacher_gs,
+                                return_kwargs=["next_latents_mean"],
+                            )[0].detach()
+                            for timestep_index in train_timesteps
+                        ]
+                        # (B, num_train_steps, *latent)
+                        mu_teacher_stacked = torch.stack(mu_teacher_steps, dim=1)
+                        for i, sample in enumerate(micro_batch_samples):
+                            sample.extra_kwargs["mu_teacher"] = (
+                                mu_teacher_stacked[i].to(self._mu_store_device).clone()
+                            )
+            # Belt-and-suspenders guard against a nested-autocast cache edge case.
+            torch.clear_autocast_cache()
+
+    def _distill(
+        self,
+        samples: List[BaseSample],
+        train_timesteps: torch.Tensor,
+    ) -> None:
+        """PASS 2: student-only gradient loop matching mu_S to the cached mu_T."""
+        device = self.accelerator.device
+        per_device_batch_size = self.training_args.per_device_batch_size
+        num_batches = math.ceil(len(samples) / per_device_batch_size)
+
+        for inner_epoch in range(self.training_args.num_inner_epochs):
+            perm_gen = create_generator(self.training_args.seed, self.epoch, inner_epoch)
+            perm = torch.randperm(len(samples), generator=perm_gen)
+            shuffled_samples = [samples[i] for i in perm]
+
+            self.adapter.train()
+            loss_info: Dict[str, Any] = defaultdict(list)
+
+            with self.autocast():
+                for batch_idx in tqdm(
+                    range(num_batches),
+                    total=num_batches,
+                    desc=f"Epoch {self.epoch} Distill",
+                    position=0,
+                    disable=not self.show_progress_bar,
+                ):
+                    start = batch_idx * per_device_batch_size
+                    batch_samples = [
+                        s.to(device)
+                        for s in shuffled_samples[start : start + per_device_batch_size]
+                    ]
+                    batch = BaseSample.stack(batch_samples)
+                    # extra_kwargs tensors are not moved by BaseSample.to(); move explicitly.
+                    mu_teacher_all = batch["mu_teacher"]
+                    if not isinstance(mu_teacher_all, torch.Tensor):
+                        raise RuntimeError(
+                            "Expected cached teacher means `mu_teacher` (a tensor) on every "
+                            f"sample, got {type(mu_teacher_all).__name__}. PASS 1 "
+                            "(_precompute_teacher_targets) must run before PASS 2."
+                        )
+                    mu_teacher_all = mu_teacher_all.to(device)
+
+                    for idx, timestep_index in enumerate(
+                        tqdm(
+                            train_timesteps,
+                            desc=f"Epoch {self.epoch} Timestep",
+                            position=1,
+                            leave=False,
+                            disable=not self.show_progress_bar,
+                        )
+                    ):
+                        with self.accelerator.accumulate(*self.adapter.trainable_components):
+                            # mu_S: (B, *latent) student transition mean at this step.
+                            mu_S, std_dev_t, dt = self._forward_step(
+                                batch,
+                                timestep_index,
+                                guidance_scale=self.training_args.guidance_scale,
+                                return_kwargs=["next_latents_mean", "std_dev_t", "dt"],
+                            )
+                            # Each sample is matched to ITS OWN routed teacher: mu_teacher
+                            # was cached per-sample in PASS 1, so a micro-batch may mix
+                            # teachers. The batch-mean below is therefore an (implicit)
+                            # per-teacher KL averaged over the batch, weighted by each
+                            # teacher's sample count -- not all-teachers-vs-student.
+                            mu_T = mu_teacher_all[:, idx]  # (B, *latent) this sample's teacher mean
+                            # Per-sample MSE between student and teacher transition means.
+                            per_sample_mse = (
+                                (mu_S.float() - mu_T.float()).pow(2).flatten(1).mean(dim=1)
+                            )  # (B,)
+                            # Transition variance sigma_bar^2: 1.0 (ODE) or (B, 1, 1) (SDE).
+                            denom = self.adapter.scheduler.get_kl_divergence_denominator(
+                                std_dev_t, dt
+                            )
+                            if isinstance(denom, torch.Tensor):
+                                # denom is per-sample-constant, so reduce (B,1,1) -> (B,).
+                                denom = denom.reshape(per_sample_mse.shape[0], -1).mean(
+                                    dim=1
+                                )  # (B,)
+                            # (B,) / (B,) -> (B,); 0.5 * mean over batch -> scalar.
+                            kl_div_j = 0.5 * (per_sample_mse / denom).mean()
+
+                            self.accelerator.backward(kl_div_j)
+                            loss_info["kl_div_j"].append(kl_div_j.detach())
+
+                            if self.accelerator.sync_gradients:
+                                grad_norm = self.accelerator.clip_grad_norm_(
+                                    self.adapter.get_trainable_parameters(),
+                                    self.training_args.max_grad_norm,
+                                )
+                                self.optimizer.step()
+                                self.optimizer.zero_grad()
+                                loss_info = reduce_loss_info(self.accelerator, loss_info)
+                                loss_info["grad_norm"] = grad_norm
+                                self.log_data(
+                                    {f"train/{k}": v for k, v in loss_info.items()},
+                                    step=self.step,
+                                )
+                                self.step += 1
+                                loss_info = defaultdict(list)
+
+    # =============================== Helpers ===============================
+    def _teacher_index_for_sample(self, sample: BaseSample) -> int:
+        """Resolve a sample's teacher index from its dataset (``sample.source``).
+
+        Single-dataset configs use a bare DataLoader that does not inject
+        ``__source__`` (so ``sample.source`` is None); route those to the sole
+        teacher of the only available dataset.
+        """
+        dataset = sample.source
+        if dataset is None:
+            if len(self._available_sources) == 1:
+                dataset = next(iter(self._available_sources))
+            else:
+                raise RuntimeError(
+                    f"DiffusionOPD sample is missing `source` but {len(self._available_sources)} "
+                    "datasets are active; cannot route to a teacher. Multi-dataset rollouts must "
+                    "carry `source` (set by MultiSourceTrainDataLoader)."
+                )
+        if dataset not in self._source_to_teacher:
+            raise RuntimeError(
+                f"Sample dataset {dataset!r} is not routed to any teacher. "
+                f"Routing: {self._source_to_teacher}."
+            )
+        return self._source_to_teacher[dataset]
+
+    def _forward_step(
+        self,
+        batch: Dict[str, Any],
+        timestep_index: Union[int, torch.Tensor],
+        guidance_scale: float,
+        return_kwargs: List[str],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Forward the adapter at stored trajectory step ``timestep_index``.
+
+        Replays the rollout transition ``x_j -> x_{j+1}`` (current/next latents
+        and ``t``/``t_next`` come from the stored trajectory, fetched via the
+        same index maps GRPO uses). Returns ``(mu, std_dev_t, dt)`` where ``mu``
+        is the (validated non-None) transition mean ``next_latents_mean`` and
+        ``std_dev_t``/``dt`` are the SDE statistics used by the loss denominator
+        (present on the student pass, ``None``/zero under ODE).
+        """
+        latents_index_map = batch["latent_index_map"]
+        num_timesteps = batch["timesteps"].shape[1]
+
+        t = batch["timesteps"][:, timestep_index]
+        t_next = (
+            batch["timesteps"][:, timestep_index + 1]
+            if timestep_index + 1 < num_timesteps
+            else torch.zeros_like(t)
+        )
+        latents = batch["all_latents"][:, latents_index_map[timestep_index]]
+        next_latents = batch["all_latents"][:, latents_index_map[timestep_index + 1]]
+
+        forward_inputs = {
+            **self.training_args,
+            **batch,
+            "t": t,
+            "t_next": t_next,
+            "latents": latents,
+            "next_latents": next_latents,
+            "compute_log_prob": False,
+            "noise_level": self._student_noise_level,
+            # guidance_scale set before filter_kwargs so it is dropped for adapters
+            # whose forward() does not accept it (overrides the training_args value).
+            "guidance_scale": guidance_scale,
+        }
+        forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
+        forward_inputs["return_kwargs"] = list(return_kwargs)
+        output = self.adapter.forward(**forward_inputs)
+
+        if output.next_latents_mean is None:
+            raise RuntimeError(
+                "DiffusionOPD requires `next_latents_mean` from adapter.forward, got None. "
+                f"Ensure the adapter/scheduler returns it (return_kwargs={list(return_kwargs)})."
+            )
+        return output.next_latents_mean, output.std_dev_t, output.dt

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -24,6 +24,11 @@ dynamics-agnostic.
 Reference:
 [1] On-Policy Distillation of Diffusion Models — https://github.com/ali-vilab/DiffusionOPD
 
+The distilled denoising steps are selected by ``train.timestep_range`` (a
+fraction band of the trajectory step indices; default 0.99 = upstream
+``timestep_fraction``), NOT the SDE-only ``scheduler.train_timesteps`` (which is
+empty under ODE). See ``_select_train_step_indices``.
+
 Design (2-pass, per epoch):
   sample()    -> student rolls out on-policy trajectories (tagged by source),
                  reusing the standard ``generate_samples`` pipeline.
@@ -165,13 +170,16 @@ class DiffusionOPDTrainer(BaseTrainer):
     def sample(self) -> List[BaseSample]:
         """Roll out on-policy student trajectories over the multi-source dataloader.
 
-        Stores the trajectory positions needed for per-step distillation
-        (current + next latents at every training timestep). Rewards are not
-        used by the distillation loss, so no reward buffer is attached;
-        reward monitoring is left to :meth:`evaluate`.
+        Stores only the trajectory positions needed for the distilled step band
+        (``timestep_range``): current + next latents for each step in the band.
+        Rewards are not used by the distillation loss, so no reward buffer is
+        attached; reward monitoring is left to :meth:`evaluate`.
         """
+        train_step_indices = self._select_train_step_indices(
+            self.training_args.num_inference_steps, self.training_args.timestep_range
+        )
         trajectory_indices = compute_trajectory_indices(
-            train_timestep_indices=self.adapter.scheduler.train_timesteps,
+            train_timestep_indices=train_step_indices,
             num_inference_steps=self.training_args.num_inference_steps,
         )
         return self.generate_samples(
@@ -194,7 +202,11 @@ class DiffusionOPDTrainer(BaseTrainer):
         # Train-mode dynamics for BOTH passes (scheduler.is_eval=False) so the SDE
         # transition means are computed consistently for teacher and student.
         self.adapter.train()
-        train_timesteps = self.adapter.scheduler.train_timesteps
+        # Distilled denoising-step band from `timestep_range` (see `_select_train_step_indices`).
+        # Same indices the rollout stored in `sample()`, so the replay aligns.
+        train_timesteps = self._select_train_step_indices(
+            self.training_args.num_inference_steps, self.training_args.timestep_range
+        )
 
         self._precompute_teacher_targets(samples, train_timesteps)
         self._distill(samples, train_timesteps)
@@ -359,6 +371,30 @@ class DiffusionOPDTrainer(BaseTrainer):
                                 loss_info = defaultdict(list)
 
     # =============================== Helpers ===============================
+    @staticmethod
+    def _select_train_step_indices(
+        num_inference_steps: int,
+        timestep_range: Union[float, Tuple[float, float]],
+    ) -> torch.Tensor:
+        """Trajectory step indices to distill on, from ``timestep_range``.
+
+        ``timestep_range=(frac_lo, frac_hi)`` (a bare float ``f`` is treated as
+        ``(0, f)``) selects the contiguous band of denoising transitions
+        ``[int(T*frac_lo), int(T*frac_hi))`` where ``T = num_inference_steps``.
+        Default ``0.99`` reproduces upstream DiffusionOPD's ``timestep_fraction``
+        (distill the first 99% of steps, ``int(10*0.99)=9`` -> indices ``[0..8]``,
+        skipping the near-clean tail). Deterministic and dynamics-agnostic, so it
+        does NOT use the SDE-only ``scheduler.train_timesteps`` (empty under ODE),
+        and gives identical indices in ``sample()`` and ``optimize()``.
+        """
+        if isinstance(timestep_range, (int, float)):
+            frac_lo, frac_hi = 0.0, float(timestep_range)
+        else:
+            frac_lo, frac_hi = timestep_range
+        lo = int(num_inference_steps * frac_lo)
+        hi = max(lo + 1, int(num_inference_steps * frac_hi))
+        return torch.arange(lo, hi, dtype=torch.long)
+
     def _teacher_index_for_sample(self, sample: BaseSample) -> int:
         """Resolve a sample's teacher index from its dataset (``sample.source``).
 

--- a/src/flow_factory/trainers/registry.py
+++ b/src/flow_factory/trainers/registry.py
@@ -34,6 +34,7 @@ _TRAINER_REGISTRY: Dict[str, str] = {
     'dgpo': 'flow_factory.trainers.dgpo.DGPOTrainer',
     'dpo': 'flow_factory.trainers.dpo.DPOTrainer',
     'crd': 'flow_factory.trainers.crd.CRDTrainer',
+    'diffusion-opd': 'flow_factory.trainers.opd.trainer.DiffusionOPDTrainer',
 }
 
 


### PR DESCRIPTION
## Summary

Adds **DiffusionOPD** ([paper](https://arxiv.org/abs/2605.15055), [upstream](https://github.com/ali-vilab/DiffusionOPD)), a multi-teacher on-policy distillation trainer (`trainer_type: diffusion-opd`) built on the multi-dataset infra from #168. Several task-specialized LoRA teachers are distilled into one student along the student's own rollout trajectories via a closed-form per-step KL, supporting **both ODE and SDE** dynamics.

### Core design
- **2-pass `optimize()`**: PASS 1 (`no_grad`) caches each teacher's per-step transition mean `mu_T` on its routed samples with **one weight swap per teacher**; PASS 2 runs a student-only gradient loop matching each sample's `mu_S` to its own cached `mu_T`. Reuses the GRPO trajectory-replay primitives and the `sample() -> optimize()` lifecycle.
- **Loss**: `kl_div_j = 0.5 * ||mu_S - mu_T||^2 / denom`, where `denom` is the scheduler's per-dynamics transition variance (new `SDESchedulerMixin.get_kl_divergence_denominator`): `1.0` (ODE), `std_dev_t^2*(-dt)` (Flow/Dance-SDE), `std_dev_t^2` (CPS). No loss-scaling coefficient (no REINFORCE term).
- **One teacher per dataset**, routed by `BaseSample.source`. The config schema stays multi-teacher-ready (a future ensemble trainer can reuse it); the current trainer raises on overlap.
- **LoRA teachers only** (full-param deferred), loaded into named-parameter snapshots via `load_teachers`; teacher checkpoints must share the student's LoRA architecture.

### Step selection & gradient accumulation
- Distilled denoising steps are chosen by `train.timestep_range` (NFT-idiomatic fraction band, default `0.99` = upstream `timestep_fraction`), **not** the SDE-only `scheduler.train_timesteps` (empty under ODE). `resolve_distill_step_band` is the single source of truth shared by the trainer loop and the grad-accum math.
- `get_num_train_timesteps` returns the number of distilled steps so `gradient_accumulation_steps` scales correctly and `gradient_step_per_epoch` holds (mirrors GRPO's `num_sde_steps`).

### Logging
- Per-teacher `train/kl_div_{teacher_name}` plus overall `train/kl_div`, accumulated into fixed `(num_teachers,)` buffers and reduced with a single packed collective (collective-safe under uneven teacher distribution across ranks).

### Config / hparams
- `DiffusionOPDTrainingArguments` + `TeacherConfig` (`{path, name, applicable_datasets, guidance_scale}`), registered under `diffusion-opd`. `get_preprocess_guidance_scale` covers the max of student and per-teacher CFG.
- `Arguments._validate_teacher_sources`: fail-fast that each teacher's `applicable_datasets` are declared training datasets.

### Examples
- `examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml`: aligned to upstream `mopd` on 8 GPUs (`group_size=1`, `per_device_batch_size=3`, 3 HF teachers from `quanhaol/DiffusionOPD/<Teacher>/lora`; Aes teacher distilled on the `pickscore` dataset; per-teacher CFG 4.5/4.5/1.0).
- `examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml`: local-checkpoint teachers.

### Docs
- `guidance/algorithms.md` (new DiffusionOPD section), `README.md`, `examples/README.md`, `CHANGELOG.md`.

## Test plan
- [x] `.scratch/test_opd_smoke.py`: registry round-trip, teacher coercion + fail-fast validation, schema overlap permitted, scheduler KL denominator (ODE/CPS/Flow-SDE + clamp), `timestep_range` selector (upstream parity), `get_num_train_timesteps`, both example configs load + validate.
- [x] Geometry verified under simulated 8 GPUs: `DiffusionOPD_aligned` -> `unique=72`, `num_batches=3`, `n_distill=9`, `GAS=27` -> exactly 1 optimizer step/epoch (`gradient_step_per_epoch=1`).
- [x] `black --check` / `isort --check` clean; no lint errors.
- [x] Full multi-GPU ODE run (reward improvement / loss decreasing) — to confirm on GPU.

Made with [Cursor](https://cursor.com)

## Training Curves

Reproduce [Diffusion-OPD](https://github.com/ali-vilab/DiffusionOPD/tree/main)

<img width="1634" height="844" alt="Clipboard_Screenshot_1780350647" src="https://github.com/user-attachments/assets/4df957b8-33c7-41a1-9cab-75a4e2625931" />


> examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml


Another config for three teachers trained without cfg

<img width="1629" height="786" alt="Clipboard_Screenshot_1780350715" src="https://github.com/user-attachments/assets/ddbec16e-24a0-4ba9-966d-7f8c1f8dc3f8" />

<img width="1628" height="809" alt="Clipboard_Screenshot_1780350766" src="https://github.com/user-attachments/assets/7ef6f4b2-54e0-4a7d-99d2-df5f5bc84b46" />

> examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml