### PR TITLE
[model] fix: defer 'state' checkpoint resume until after accelerator.prepare()

### DIFF
--- a/src/flow_factory/models/abc.py
+++ b/src/flow_factory/models/abc.py
@@ -169,7 +169,7 @@ class BaseAdapter(ABC):
         """Hook for additional initialization after main trainer's `accelerator.prepare`."""
         # Full training-state resume must happen here: accelerator.prepare() has now
         # registered the trainable modules and optimizer, so accelerator.load_state()
-        # can actually restore model + optimizer + scheduler + RNG.
+        # can actually restore model + optimizer + RNG (and any other prepared objects).
         if self.model_args.resume_path and self.model_args.resume_type == 'state':
             self.load_checkpoint(self.model_args.resume_path, resume_type='state')
         self._init_ema()
@@ -1750,7 +1750,7 @@ class BaseAdapter(ABC):
             resume_type: Type of checkpoint to load.
                 - 'lora': Load LoRA adapters only
                 - 'full': Load full model weights
-                - 'state': Load full training state (model + optimizer + scheduler + RNG)
+                - 'state': Load full training state (model + optimizer + RNG)
                 - None: Auto-detect based on checkpoint directory contents
         """
         path = self._resolve_checkpoint_path(path)

--- a/src/flow_factory/models/abc.py
+++ b/src/flow_factory/models/abc.py
@@ -129,8 +129,11 @@ class BaseAdapter(ABC):
         # Cache target module mapping
         self.target_module_map = self._init_target_module_map()
 
-        # Load checkpoint
-        if self.model_args.resume_path:
+        # Load checkpoint.
+        # 'lora'/'full' load into the unwrapped pipeline modules here (before prepare()).
+        # 'state' is deferred to post_init(): accelerator.load_state() only restores into
+        # modules/optimizer registered by accelerator.prepare(), which the trainer runs later.
+        if self.model_args.resume_path and self.model_args.resume_type != 'state':
             self.load_checkpoint(
                 self.model_args.resume_path,
                 resume_type=self.model_args.resume_type
@@ -164,6 +167,11 @@ class BaseAdapter(ABC):
     # ================================== Post Init =================================
     def post_init(self):
         """Hook for additional initialization after main trainer's `accelerator.prepare`."""
+        # Full training-state resume must happen here: accelerator.prepare() has now
+        # registered the trainable modules and optimizer, so accelerator.load_state()
+        # can actually restore model + optimizer + scheduler + RNG.
+        if self.model_args.resume_path and self.model_args.resume_type == 'state':
+            self.load_checkpoint(self.model_args.resume_path, resume_type='state')
         self._init_ema()
         self._init_ref_parameters()
 


### PR DESCRIPTION
## Summary

- Fixes a silent no-op when resuming with `resume_type='state'`.
- `accelerator.load_state()` only restores into models/optimizers/schedulers registered via `accelerator.prepare()`. `BaseAdapter.__init__` called `load_checkpoint(resume_type='state')` **before** the trainer ran `accelerator.prepare()`, so the registration lists were still empty and the restore loaded nothing (only RNG state was touched).
- The `'state'` resume is now deferred to `BaseAdapter.post_init()`, which the trainer invokes right after `_initialization()` runs `accelerator.prepare()` (and registers the prepared optimizer). `'lora'`/`'full'` resumes are unchanged — they load directly into the unwrapped pipeline modules and are correct at init time.

## Why this is contained

- `resume_type='state'` is only ever set explicitly; `_detect_checkpoint_type()` never returns `'state'`, so the new `__init__` guard cannot skip auto-detected checkpoints.
- No subclass overrides `post_init()`, and the only init-time resume caller is `BaseAdapter.__init__`.
- State load runs before `_init_ema()` / `_init_ref_parameters()` so EMA/ref snapshots start from the resumed weights.

## Test plan

- [ ] Resume a run with `resume_type='state'` and confirm trainable weights + optimizer state actually match the saved checkpoint after `post_init()`.
- [ ] Regression: `'lora'` and `'full'` resume paths still load correctly (unchanged code path).
- [ ] Smoke-run one GRPO (LoRA) and one full-finetune example.

Made with [Cursor](https://cursor.com)