### PR TITLE
[reward] fix: bind async judge client/semaphore to the per-call event loop

### DIFF
--- a/src/flow_factory/rewards/qwen_image_bench/reward.py
+++ b/src/flow_factory/rewards/qwen_image_bench/reward.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from accelerate import Accelerator
@@ -155,6 +155,7 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
                 "QwenImageBenchRewardModel requires the `openai` package. "
                 "Install with: pip install openai"
             )
+        self._async_openai_cls = AsyncOpenAI
 
         extra = config.extra_kwargs
         self.api_base_url: str = extra.get("api_base_url", "http://localhost:8000/v1")
@@ -195,9 +196,6 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
                 f"expected score_dimension == 'total' or one of {list(DIM_TO_CHECKLIST)}, "
                 f"got {self.score_dimension!r}"
             )
-
-        self.client = AsyncOpenAI(base_url=self.api_base_url, api_key=self.api_key)
-        self.semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
 
     # ============================== Public API ==============================
 
@@ -247,7 +245,7 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
             pil_image_to_base64(self._prepare_image(img), format="PNG") for img in image
         ]
 
-        scores = asyncio.run(self._async_score_batch(prompt, image_data_urls, l1_dims_per_sample))
+        scores = asyncio.run(self._run_batch(prompt, image_data_urls, l1_dims_per_sample))
         rewards = torch.tensor(scores, dtype=torch.float32, device=self.device)
         return RewardModelOutput(rewards=rewards, extra_info={})
 
@@ -275,21 +273,48 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
 
     # ============================== Async scoring ==============================
 
+    async def _run_batch(
+        self,
+        prompts: List[str],
+        image_data_urls: List[str],
+        l1_dims_per_sample: List[List[str]],
+    ) -> List[float]:
+        """Create a loop-local client + semaphore, then score the batch.
+
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound. ``__call__``
+        scores each batch inside a fresh ``asyncio.run`` loop (and the async-reward
+        path runs ``__call__`` from a thread pool), so these objects must be created
+        inside the running loop and threaded through the call chain -- never cached
+        on ``self`` -- otherwise reuse across loops raises
+        ``RuntimeError: ... bound to a different event loop``.
+        """
+        async with self._async_openai_cls(
+            base_url=self.api_base_url, api_key=self.api_key
+        ) as client:
+            semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
+            return await self._async_score_batch(
+                client, semaphore, prompts, image_data_urls, l1_dims_per_sample
+            )
+
     async def _async_score_batch(
         self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
         prompts: List[str],
         image_data_urls: List[str],
         l1_dims_per_sample: List[List[str]],
     ) -> List[float]:
         """Score every image concurrently; returns per-image rewards in [0, 1]."""
         tasks = [
-            self._score_single_image(p, url, dims)
+            self._score_single_image(client, semaphore, p, url, dims)
             for p, url, dims in zip(prompts, image_data_urls, l1_dims_per_sample)
         ]
         return list(await asyncio.gather(*tasks))
 
     async def _score_single_image(
         self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
         prompt: str,
         image_data_url: str,
         l1_dims: List[str],
@@ -300,6 +325,8 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
             outputs = await asyncio.gather(
                 *[
                     self._call_judge(
+                        client,
+                        semaphore,
                         USER_PROMPT_TEMPLATE.format(
                             prompt=prompt,
                             level1_dim=l1,
@@ -320,12 +347,20 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
         # single_call
         all_checklists = "\n\n".join(f"## {l1}\n{DIM_TO_CHECKLIST[l1]}" for l1 in l1_dims)
         output = await self._call_judge(
+            client,
+            semaphore,
             _SINGLE_CALL_TEMPLATE.format(prompt=prompt, all_checklists=all_checklists),
             image_data_url,
         )
         return self._aggregate(self._parse_single_call(output, l1_dims))
 
-    async def _call_judge(self, user_text: str, image_data_url: str) -> Optional[str]:
+    async def _call_judge(
+        self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
+        user_text: str,
+        image_data_url: str,
+    ) -> Optional[str]:
         """Issue one judge request with retries; returns raw text or None on failure."""
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
@@ -340,8 +375,8 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
         last_err: Optional[BaseException] = None
         for attempt in range(self.max_retries):
             try:
-                async with self.semaphore:
-                    completion = await self.client.chat.completions.create(
+                async with semaphore:
+                    completion = await client.chat.completions.create(
                         model=self.vlm_model,
                         messages=messages,
                         temperature=self.temperature,

--- a/src/flow_factory/rewards/qwen_image_bench/reward.py
+++ b/src/flow_factory/rewards/qwen_image_bench/reward.py
@@ -281,12 +281,13 @@ class QwenImageBenchRewardModel(PointwiseRewardModel):
     ) -> List[float]:
         """Create a loop-local client + semaphore, then score the batch.
 
-        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound. ``__call__``
-        scores each batch inside a fresh ``asyncio.run`` loop (and the async-reward
-        path runs ``__call__`` from a thread pool), so these objects must be created
-        inside the running loop and threaded through the call chain -- never cached
-        on ``self`` -- otherwise reuse across loops raises
-        ``RuntimeError: ... bound to a different event loop``.
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound, so they
+        must be created inside this per-call ``asyncio.run`` loop and threaded
+        through the call chain -- never cached on ``self`` (caching reuses them
+        across loops and raises "bound to a different event loop"). The semaphore
+        is per call: ``max_concurrent`` caps in-flight judge requests per batch,
+        so with ``async_reward`` and ``num_workers`` > 1 the effective server
+        concurrency is ``num_workers * max_concurrent``.
         """
         async with self._async_openai_cls(
             base_url=self.api_base_url, api_key=self.api_key

--- a/src/flow_factory/rewards/rational_rewards_edit.py
+++ b/src/flow_factory/rewards/rational_rewards_edit.py
@@ -25,20 +25,20 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from accelerate import Accelerator
 from PIL import Image
 
+from ..hparams import RewardArguments
+from ..utils.image import pil_image_to_base64
 from .abc import PointwiseRewardModel, RewardModelOutput
 from .rational_rewards_t2i import (
     _clip_vlm_text_for_log,
     aggregate_aspect_scores,
     extract_numeric_score,
 )
-from ..hparams import RewardArguments
-from ..utils.image import pil_image_to_base64
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("openai").setLevel(logging.WARNING)
@@ -251,7 +251,9 @@ def build_scoring_messages_edit(
 def _first_condition_image(cond: Union[Image.Image, List[Image.Image]]) -> Image.Image:
     if isinstance(cond, list):
         if not cond:
-            raise ValueError("condition_images entry is an empty list; need at least one source image")
+            raise ValueError(
+                "condition_images entry is an empty list; need at least one source image"
+            )
         first = cond[0]
         if not isinstance(first, Image.Image):
             raise TypeError(
@@ -315,8 +317,7 @@ class RationalRewardsEditRewardModel(PointwiseRewardModel):
                 f"unsupported aspect(s) {unknown!r}; allowed: {list(SUPPORTED_ASPECTS)}"
             )
 
-        self.client = AsyncOpenAI(base_url=self.api_base_url, api_key=self.api_key)
-        self.semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
+        self._async_openai_cls = AsyncOpenAI
 
     @torch.no_grad()
     def __call__(
@@ -341,20 +342,52 @@ class RationalRewardsEditRewardModel(PointwiseRewardModel):
             )
 
         source_images = [_first_condition_image(c) for c in condition_images]
-        scores = asyncio.run(self._async_score_batch(prompt, source_images, image))
+        scores = asyncio.run(self._run_batch(prompt, source_images, image))
         rewards = torch.tensor(scores, dtype=torch.float32, device=self.device)
         return RewardModelOutput(rewards=rewards, extra_info={})
 
-    async def _async_score_batch(
+    async def _run_batch(
         self,
         prompts: List[str],
         sources: List[Image.Image],
         edited: List[Image.Image],
     ) -> List[float]:
-        tasks = [self._score_single(p, s, e) for p, s, e in zip(prompts, sources, edited)]
+        """Create a loop-local client + semaphore, then score the batch.
+
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound; each batch
+        runs in a fresh ``asyncio.run`` loop (and the async-reward path runs from a
+        thread pool), so they must be created inside the running loop and passed
+        down -- never cached on ``self`` -- to avoid
+        ``RuntimeError: ... bound to a different event loop``.
+        """
+        async with self._async_openai_cls(
+            base_url=self.api_base_url, api_key=self.api_key
+        ) as client:
+            semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
+            return await self._async_score_batch(client, semaphore, prompts, sources, edited)
+
+    async def _async_score_batch(
+        self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
+        prompts: List[str],
+        sources: List[Image.Image],
+        edited: List[Image.Image],
+    ) -> List[float]:
+        tasks = [
+            self._score_single(client, semaphore, p, s, e)
+            for p, s, e in zip(prompts, sources, edited)
+        ]
         return list(await asyncio.gather(*tasks))
 
-    async def _score_single(self, prompt: str, source: Image.Image, edited: Image.Image) -> float:
+    async def _score_single(
+        self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
+        prompt: str,
+        source: Image.Image,
+        edited: Image.Image,
+    ) -> float:
         from openai import APIConnectionError, APITimeoutError, RateLimitError
 
         source_url = pil_image_to_base64(source, format="PNG")
@@ -364,8 +397,8 @@ class RationalRewardsEditRewardModel(PointwiseRewardModel):
         last_err: Optional[BaseException] = None
         for attempt in range(self.max_retries):
             try:
-                async with self.semaphore:
-                    completion = await self.client.chat.completions.create(
+                async with semaphore:
+                    completion = await client.chat.completions.create(
                         model=self.vlm_model,
                         messages=messages,
                         temperature=self.temperature,

--- a/src/flow_factory/rewards/rational_rewards_edit.py
+++ b/src/flow_factory/rewards/rational_rewards_edit.py
@@ -354,11 +354,13 @@ class RationalRewardsEditRewardModel(PointwiseRewardModel):
     ) -> List[float]:
         """Create a loop-local client + semaphore, then score the batch.
 
-        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound; each batch
-        runs in a fresh ``asyncio.run`` loop (and the async-reward path runs from a
-        thread pool), so they must be created inside the running loop and passed
-        down -- never cached on ``self`` -- to avoid
-        ``RuntimeError: ... bound to a different event loop``.
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound, so they
+        must be created inside this per-call ``asyncio.run`` loop and threaded
+        through the call chain -- never cached on ``self`` (caching reuses them
+        across loops and raises "bound to a different event loop"). The semaphore
+        is per call: ``max_concurrent`` caps in-flight judge requests per batch,
+        so with ``async_reward`` and ``num_workers`` > 1 the effective server
+        concurrency is ``num_workers * max_concurrent``.
         """
         async with self._async_openai_cls(
             base_url=self.api_base_url, api_key=self.api_key

--- a/src/flow_factory/rewards/rational_rewards_t2i.py
+++ b/src/flow_factory/rewards/rational_rewards_t2i.py
@@ -33,9 +33,9 @@ import torch
 from accelerate import Accelerator
 from PIL import Image
 
-from .abc import PointwiseRewardModel, RewardModelOutput
 from ..hparams import RewardArguments
 from ..utils.image import pil_image_to_base64
+from .abc import PointwiseRewardModel, RewardModelOutput
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("openai").setLevel(logging.WARNING)
@@ -88,7 +88,9 @@ def _extract_score_from_block(block_text: str) -> Optional[Union[float, str]]:
     return None
 
 
-def parse_scores_from_detailed_judgement(detailed_judgement: str) -> Dict[str, Optional[Union[float, str]]]:
+def parse_scores_from_detailed_judgement(
+    detailed_judgement: str,
+) -> Dict[str, Optional[Union[float, str]]]:
     """
     Parse aspect scores from the ``# Detailed Judgement`` section.
 
@@ -341,8 +343,7 @@ class RationalRewardsT2IRewardModel(PointwiseRewardModel):
                 f"unsupported aspect(s) {unknown!r}; allowed: {list(SUPPORTED_ASPECTS)}"
             )
 
-        self.client = AsyncOpenAI(base_url=self.api_base_url, api_key=self.api_key)
-        self.semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
+        self._async_openai_cls = AsyncOpenAI
 
     @torch.no_grad()
     def __call__(
@@ -363,19 +364,46 @@ class RationalRewardsT2IRewardModel(PointwiseRewardModel):
                 f"expected len(prompt)==len(image), got {len(prompt)} prompts and {len(image)} images"
             )
 
-        scores = asyncio.run(self._async_score_batch(prompt, image))
+        scores = asyncio.run(self._run_batch(prompt, image))
         rewards = torch.tensor(scores, dtype=torch.float32, device=self.device)
         return RewardModelOutput(rewards=rewards, extra_info={})
 
-    async def _async_score_batch(
+    async def _run_batch(
         self,
         prompts: List[str],
         images: List[Image.Image],
     ) -> List[float]:
-        tasks = [self._score_single(p, img) for p, img in zip(prompts, images)]
+        """Create a loop-local client + semaphore, then score the batch.
+
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound; each batch
+        runs in a fresh ``asyncio.run`` loop (and the async-reward path runs from a
+        thread pool), so they must be created inside the running loop and passed
+        down -- never cached on ``self`` -- to avoid
+        ``RuntimeError: ... bound to a different event loop``.
+        """
+        async with self._async_openai_cls(
+            base_url=self.api_base_url, api_key=self.api_key
+        ) as client:
+            semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
+            return await self._async_score_batch(client, semaphore, prompts, images)
+
+    async def _async_score_batch(
+        self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
+        prompts: List[str],
+        images: List[Image.Image],
+    ) -> List[float]:
+        tasks = [self._score_single(client, semaphore, p, img) for p, img in zip(prompts, images)]
         return list(await asyncio.gather(*tasks))
 
-    async def _score_single(self, prompt: str, image: Image.Image) -> float:
+    async def _score_single(
+        self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
+        prompt: str,
+        image: Image.Image,
+    ) -> float:
         from openai import APIConnectionError, APITimeoutError, RateLimitError
 
         data_url = pil_image_to_base64(image, format="PNG")
@@ -384,8 +412,8 @@ class RationalRewardsT2IRewardModel(PointwiseRewardModel):
         last_err: Optional[BaseException] = None
         for attempt in range(self.max_retries):
             try:
-                async with self.semaphore:
-                    completion = await self.client.chat.completions.create(
+                async with semaphore:
+                    completion = await client.chat.completions.create(
                         model=self.vlm_model,
                         messages=messages,
                         temperature=self.temperature,

--- a/src/flow_factory/rewards/rational_rewards_t2i.py
+++ b/src/flow_factory/rewards/rational_rewards_t2i.py
@@ -375,11 +375,13 @@ class RationalRewardsT2IRewardModel(PointwiseRewardModel):
     ) -> List[float]:
         """Create a loop-local client + semaphore, then score the batch.
 
-        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound; each batch
-        runs in a fresh ``asyncio.run`` loop (and the async-reward path runs from a
-        thread pool), so they must be created inside the running loop and passed
-        down -- never cached on ``self`` -- to avoid
-        ``RuntimeError: ... bound to a different event loop``.
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound, so they
+        must be created inside this per-call ``asyncio.run`` loop and threaded
+        through the call chain -- never cached on ``self`` (caching reuses them
+        across loops and raises "bound to a different event loop"). The semaphore
+        is per call: ``max_concurrent`` caps in-flight judge requests per batch,
+        so with ``async_reward`` and ``num_workers`` > 1 the effective server
+        concurrency is ``num_workers * max_concurrent``.
         """
         async with self._async_openai_cls(
             base_url=self.api_base_url, api_key=self.api_key

--- a/src/flow_factory/rewards/vllm_evaluate.py
+++ b/src/flow_factory/rewards/vllm_evaluate.py
@@ -234,16 +234,18 @@ class VLMEvaluateRewardModel(PointwiseRewardModel):
     ) -> List[float]:
         """Create a loop-local client + semaphore, then score the batch.
 
-        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound; each batch
-        runs in a fresh ``asyncio.run`` loop (and the async-reward path runs from a
-        thread pool), so they must be created inside the running loop and passed
-        down -- never cached on ``self`` -- to avoid
-        ``RuntimeError: ... bound to a different event loop``.
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound, so they
+        must be created inside this per-call ``asyncio.run`` loop and threaded
+        through the call chain -- never cached on ``self`` (caching reuses them
+        across loops and raises "bound to a different event loop"). The semaphore
+        is per call: ``max_concurrent`` caps in-flight judge requests per batch,
+        so with ``async_reward`` and ``num_workers`` > 1 the effective server
+        concurrency is ``num_workers * max_concurrent``.
         """
         async with self._async_openai_cls(
             base_url=self.api_base_url, api_key=self.api_key
         ) as client:
-            semaphore = asyncio.Semaphore(self.max_concurrent)
+            semaphore = asyncio.Semaphore(max(1, self.max_concurrent))
             return await self._async_score_batch(client, semaphore, images)
 
     async def _async_score_batch(

--- a/src/flow_factory/rewards/vllm_evaluate.py
+++ b/src/flow_factory/rewards/vllm_evaluate.py
@@ -34,21 +34,22 @@ Usage in YAML config:
         timeout: 60
         top_logprobs: 20
 """
+
 from __future__ import annotations
 
-import hashlib
 import asyncio
+import hashlib
 import logging
-from typing import Optional, List
+from typing import Any, List, Optional
 
-import torch
 import numpy as np
-from PIL import Image
+import torch
 from accelerate import Accelerator
+from PIL import Image
 
-from .abc import PointwiseRewardModel, RewardModelOutput
 from ..hparams import RewardArguments
 from ..utils.image import pil_image_to_base64
+from .abc import PointwiseRewardModel, RewardModelOutput
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,7 @@ logging.getLogger("openai").setLevel(logging.WARNING)
 # =====================================================================
 # Helper functions
 # =====================================================================
+
 
 def _get_yes_cond_prob(completion, canonicalize: bool = False) -> float:
     """
@@ -80,22 +82,18 @@ def _get_yes_cond_prob(completion, canonicalize: bool = False) -> float:
         return 0.0
 
     if not canonicalize:
-        token_logprobs = {
-            t.token: t.logprob for t in logprobs.content[0].top_logprobs
-        }
-        yes_logprob = token_logprobs.get('Yes', float('-inf'))
-        no_logprob = token_logprobs.get('No', float('-inf'))
+        token_logprobs = {t.token: t.logprob for t in logprobs.content[0].top_logprobs}
+        yes_logprob = token_logprobs.get("Yes", float("-inf"))
+        no_logprob = token_logprobs.get("No", float("-inf"))
 
-        if yes_logprob == float('-inf') and no_logprob == float('-inf'):
+        if yes_logprob == float("-inf") and no_logprob == float("-inf"):
             return 0.0
 
         diff = torch.tensor(yes_logprob - no_logprob, dtype=torch.float64)
         return torch.sigmoid(diff).item()
     else:
         # Aggregate all case variations
-        token_probs = {
-            t.token: np.exp(t.logprob) for t in logprobs.content[0].top_logprobs
-        }
+        token_probs = {t.token: np.exp(t.logprob) for t in logprobs.content[0].top_logprobs}
         tokens = np.array(list(token_probs.keys()))
         probs = np.array(list(token_probs.values()), dtype=np.float64)
         tokens_stripped = np.array([token.strip().lower() for token in tokens])
@@ -112,6 +110,7 @@ def _get_yes_cond_prob(completion, canonicalize: bool = False) -> float:
 # =====================================================================
 # VLMEvaluateRewardModel
 # =====================================================================
+
 
 class VLMEvaluateRewardModel(PointwiseRewardModel):
     """
@@ -179,12 +178,7 @@ class VLMEvaluateRewardModel(PointwiseRewardModel):
         self.canonicalize = config.extra_kwargs.get("canonicalize", False)
         self.max_cache_size = config.extra_kwargs.get("max_cache_size", 1024)
 
-        # Initialize async OpenAI client
-        self.client = AsyncOpenAI(
-            base_url=self.api_base_url,
-            api_key=self.api_key,
-        )
-        self.semaphore = asyncio.Semaphore(self.max_concurrent)
+        self._async_openai_cls = AsyncOpenAI
 
         # Simple FIFO cache: img_hash -> score
         self._cache: dict[str, float] = {}
@@ -224,28 +218,48 @@ class VLMEvaluateRewardModel(PointwiseRewardModel):
         if image is None:
             raise ValueError("Either 'image' or 'video' must be provided")
 
-        assert len(prompt) == len(image), (
-            f"Mismatch: {len(prompt)} prompts vs {len(image)} images"
-        )
+        assert len(prompt) == len(image), f"Mismatch: {len(prompt)} prompts vs {len(image)} images"
 
         # Run async scoring
-        rewards = asyncio.run(self._async_score_batch(image))
+        rewards = asyncio.run(self._run_batch(image))
 
         return RewardModelOutput(
             rewards=torch.tensor(rewards, dtype=torch.float32),
             extra_info={},
         )
 
-    async def _async_score_batch(
+    async def _run_batch(
         self,
         images: List[Image.Image],
     ) -> List[float]:
+        """Create a loop-local client + semaphore, then score the batch.
+
+        ``AsyncOpenAI`` and ``asyncio.Semaphore`` are event-loop-bound; each batch
+        runs in a fresh ``asyncio.run`` loop (and the async-reward path runs from a
+        thread pool), so they must be created inside the running loop and passed
+        down -- never cached on ``self`` -- to avoid
+        ``RuntimeError: ... bound to a different event loop``.
+        """
+        async with self._async_openai_cls(
+            base_url=self.api_base_url, api_key=self.api_key
+        ) as client:
+            semaphore = asyncio.Semaphore(self.max_concurrent)
+            return await self._async_score_batch(client, semaphore, images)
+
+    async def _async_score_batch(
+        self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
+        images: List[Image.Image],
+    ) -> List[float]:
         """Score all images in the batch concurrently."""
-        tasks = [self._score_single(img) for img in images]
+        tasks = [self._score_single(client, semaphore, img) for img in images]
         return list(await asyncio.gather(*tasks))
 
     async def _score_single(
         self,
+        client: Any,
+        semaphore: asyncio.Semaphore,
         image: Image.Image,
     ) -> float:
         """
@@ -269,8 +283,8 @@ class VLMEvaluateRewardModel(PointwiseRewardModel):
 
         for attempt in range(self.max_retries):
             try:
-                async with self.semaphore:
-                    completion = await self.client.chat.completions.create(
+                async with semaphore:
+                    completion = await client.chat.completions.create(
                         model=self.vlm_model,
                         messages=messages,
                         temperature=0.0,
@@ -285,11 +299,9 @@ class VLMEvaluateRewardModel(PointwiseRewardModel):
                 return score
 
             except Exception as e:
-                logger.warning(
-                    f"VLM API error on attempt {attempt + 1}/{self.max_retries}: {e}"
-                )
+                logger.warning(f"VLM API error on attempt {attempt + 1}/{self.max_retries}: {e}")
                 if attempt < self.max_retries - 1:
-                    await asyncio.sleep(2 ** attempt)
+                    await asyncio.sleep(2**attempt)
 
         # All retries exhausted, return default score (do not cache failures)
         return 0.0

--- a/tests/rewards/test_async_reward_event_loop.py
+++ b/tests/rewards/test_async_reward_event_loop.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Flow-Factory Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the OpenAI-compatible (API-based) reward models.
+
+Guards against the loop-binding bug where ``asyncio.Semaphore`` / ``AsyncOpenAI``
+were created once in ``__init__`` and then reused across the fresh event loop that
+``asyncio.run`` spins up on every ``__call__`` (and across ``ThreadPoolExecutor``
+workers in the async-reward path), which raised
+``RuntimeError: ... is bound to a different event loop`` on the second loop.
+
+No network is used: the OpenAI async client is replaced with a fake that returns
+empty content, so each reward falls back to its documented 0.0 reward. The tests
+only assert shapes and that no loop-binding error is raised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+from PIL import Image
+
+from flow_factory.hparams import RewardArguments
+
+
+class _FakeChoice:
+    def __init__(self, content: str):
+        self.message = types.SimpleNamespace(content=content)
+        self.logprobs = None
+
+
+class _FakeCompletion:
+    def __init__(self, content: str):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    async def create(self, **kwargs):
+        # Yield to the running loop so the semaphore is actually acquired here.
+        await asyncio.sleep(0)
+        # Empty content -> every text reward takes its "empty reply -> 0.0" path,
+        # and the vllm logprob parse fails fast into its 0.0 fallback. This keeps
+        # the test independent of each judge's response schema.
+        return _FakeCompletion("")
+
+
+class FakeAsyncOpenAI:
+    """Stand-in supporting ``async with`` and ``chat.completions.create``."""
+
+    def __init__(self, *args, **kwargs):
+        self.chat = types.SimpleNamespace(completions=_FakeCompletions())
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeTransportError(Exception):
+    pass
+
+
+@pytest.fixture
+def fake_openai(monkeypatch):
+    """Install a fake ``openai`` module and patch the symbol qwen bound at import."""
+    fake_module = types.ModuleType("openai")
+    fake_module.AsyncOpenAI = FakeAsyncOpenAI
+    fake_module.APIConnectionError = _FakeTransportError
+    fake_module.APITimeoutError = _FakeTransportError
+    fake_module.RateLimitError = _FakeTransportError
+    monkeypatch.setitem(sys.modules, "openai", fake_module)
+
+    # qwen imports ``AsyncOpenAI`` at module load, so patch the bound name too.
+    from flow_factory.rewards.qwen_image_bench import reward as qwen_reward
+
+    monkeypatch.setattr(qwen_reward, "AsyncOpenAI", FakeAsyncOpenAI)
+    return fake_module
+
+
+def _accelerator_stub():
+    return types.SimpleNamespace(device=torch.device("cpu"))
+
+
+def _config(reward_model: str, **extra) -> RewardArguments:
+    base = {
+        "name": "t",
+        "reward_model": reward_model,
+        "device": "cpu",
+        "dtype": "float32",
+        "batch_size": 4,
+        "max_retries": 1,
+        "max_concurrent": 2,
+        "timeout": 1,
+    }
+    base.update(extra)
+    return RewardArguments.from_dict(base)
+
+
+def _make_qwen():
+    from flow_factory.rewards.qwen_image_bench.reward import QwenImageBenchRewardModel
+
+    return QwenImageBenchRewardModel(_config("qwen_image_bench"), _accelerator_stub())
+
+
+def _make_t2i():
+    from flow_factory.rewards.rational_rewards_t2i import RationalRewardsT2IRewardModel
+
+    return RationalRewardsT2IRewardModel(_config("rational_rewards_t2i"), _accelerator_stub())
+
+
+def _make_edit():
+    from flow_factory.rewards.rational_rewards_edit import RationalRewardsEditRewardModel
+
+    return RationalRewardsEditRewardModel(_config("rational_rewards_edit"), _accelerator_stub())
+
+
+def _make_vllm():
+    from flow_factory.rewards.vllm_evaluate import VLMEvaluateRewardModel
+
+    return VLMEvaluateRewardModel(_config("vllm_evaluate"), _accelerator_stub())
+
+
+_FACTORIES = {
+    "qwen_image_bench": _make_qwen,
+    "rational_rewards_t2i": _make_t2i,
+    "rational_rewards_edit": _make_edit,
+    "vllm_evaluate": _make_vllm,
+}
+
+
+def _img() -> Image.Image:
+    return Image.new("RGB", (8, 8), color=(127, 127, 127))
+
+
+def _call(reward, n: int):
+    """Invoke ``reward`` on a batch of ``n`` (prompt, image) pairs."""
+    prompts = [f"a photo {i}" for i in range(n)]
+    images = [_img() for _ in range(n)]
+    kwargs = {}
+    # rational_rewards_edit additionally requires a source (condition) image.
+    if reward.__class__.__name__ == "RationalRewardsEditRewardModel":
+        kwargs["condition_images"] = [[_img()] for _ in range(n)]
+    return reward(prompt=prompts, image=images, **kwargs)
+
+
+@pytest.mark.parametrize("name", list(_FACTORIES))
+def test_no_loop_bound_state_cached_on_instance(name, fake_openai):
+    reward = _FACTORIES[name]()
+    # The fix: the loop-bound client/semaphore must not be cached on the
+    # instance (they are created per call, inside the event loop, instead).
+    assert not hasattr(reward, "client")
+    assert not hasattr(reward, "semaphore")
+
+
+@pytest.mark.parametrize("name", list(_FACTORIES))
+def test_sequential_calls_use_independent_loops(name, fake_openai):
+    reward = _FACTORIES[name]()
+    # Two consecutive __call__s each run their own asyncio.run() loop. The old
+    # code raised "bound to a different event loop" on the second one.
+    out1 = _call(reward, 2)
+    out2 = _call(reward, 3)
+    assert tuple(out1.rewards.shape) == (2,)
+    assert tuple(out2.rewards.shape) == (3,)
+
+
+@pytest.mark.parametrize("name", list(_FACTORIES))
+def test_concurrent_thread_pool_calls(name, fake_openai):
+    reward = _FACTORIES[name]()
+    # Mirrors the async-reward ThreadPoolExecutor path: several __call__s, each
+    # in its own worker thread + event loop, sharing one reward instance.
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(_call, reward, 2) for _ in range(6)]
+        outputs = [f.result() for f in futures]
+    assert all(tuple(o.rewards.shape) == (2,) for o in outputs)

--- a/tests/rewards/test_async_reward_event_loop.py
+++ b/tests/rewards/test_async_reward_event_loop.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Flow-Factory Team
+# Copyright 2026 Jayce-Ping
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Fixes `RuntimeError: <asyncio.locks.Semaphore ...> is bound to a different event loop` that crashed eval/training when using API-based rewards (e.g. `qwen_image_bench`). It surfaces immediately with `async_reward: true`, but also affects any multi-batch run.
- Root cause: the four OpenAI-compatible reward models created an `AsyncOpenAI` client and an `asyncio.Semaphore` once in `__init__`, then reused them across the fresh event loop that `asyncio.run()` spins up on every `__call__` (and across `ThreadPoolExecutor` workers in the async-reward path). Both objects are event-loop-bound and cannot be shared across loops.
- Fix: create the client + semaphore inside the per-call coroutine (`_run_batch`) so they bind to the running loop, and thread them through the async call chain instead of caching on `self`. Applied consistently to `qwen_image_bench`, `rational_rewards_t2i`, `rational_rewards_edit`, and `vllm_evaluate`.

## Changes
- `src/flow_factory/rewards/qwen_image_bench/reward.py`
- `src/flow_factory/rewards/rational_rewards_t2i.py`
- `src/flow_factory/rewards/rational_rewards_edit.py`
- `src/flow_factory/rewards/vllm_evaluate.py`
- `tests/rewards/test_async_reward_event_loop.py` (new regression test)

## Test plan
- [ ] `pytest tests/rewards/test_async_reward_event_loop.py -v` on a box with deps installed (covers: no cached `client`/`semaphore`; sequential calls; and `ThreadPoolExecutor` calls across independent loops for all four rewards)
- [ ] Re-run the failing config (GRPO + `qwen_image_bench`, `async_reward: true`) and confirm the initial `evaluate()` completes
- [x] `black --check` / `isort --check` clean on changed files
- [x] Syntax + editor lints clean

Note: the full pytest was not runnable in the dev environment (no `torch`/`flow_factory` installed); it needs the training/GPU box.

Made with [Cursor](https://cursor.com)