### PR TITLE
[scripts] fix: add --trust-remote-code to vLLM judge server start scripts

### DIFF
--- a/scripts/start_vllm_qwen_image_bench.sh
+++ b/scripts/start_vllm_qwen_image_bench.sh
@@ -48,4 +48,5 @@ exec "${VLLM_BIN}" serve "${MODEL_PATH}" \
   --port "${PORT}" \
   --served-model-name "${SERVED_MODEL_NAME}" \
   --limit-mm-per-prompt '{"image": 1}' \
+  --trust-remote-code \
   "$@"

--- a/scripts/start_vllm_rational_reward.sh
+++ b/scripts/start_vllm_rational_reward.sh
@@ -61,4 +61,5 @@ exec "${VLLM_BIN}" serve "${MODEL_PATH}" \
   --host "${HOST}" \
   --port "${PORT}" \
   --served-model-name "${SERVED_MODEL_NAME}" \
+  --trust-remote-code \
   "$@"


### PR DESCRIPTION
## Summary
- Add `--trust-remote-code` to the `vllm serve` invocation in both judge-server start scripts: `scripts/start_vllm_rational_reward.sh` and `scripts/start_vllm_qwen_image_bench.sh`.
- The RationalRewards-8B and Qwen-Image-Bench (Qwen3-VL) checkpoints ship custom modeling code, which vLLM refuses to load without this flag. Both scripts already forward `"$@"`, so behavior is otherwise unchanged.

## Test plan
- [ ] `CUDA_VISIBLE_DEVICES=0,1 MODEL_PATH=TIGER-Lab/RationalRewards-8B-T2I ./scripts/start_vllm_rational_reward.sh --max-model-len 8192` boots and serves the model.
- [ ] `CUDA_VISIBLE_DEVICES=0,1,2,3 ./scripts/start_vllm_qwen_image_bench.sh --max-model-len 32768` boots and serves the model.

Made with [Cursor](https://cursor.com)