### PR TITLE
[docs,hparams] docs: sync agent harness (.agents/.cursor/guidance) with implementation

### DIFF
--- a/.agents/knowledge/architecture.md
+++ b/.agents/knowledge/architecture.md
@@ -35,7 +35,10 @@
 | `rewards/abc.py` | `hparams` | All reward models, `trainers/abc.py` |
 | `data_utils/` | `hparams` | `trainers/abc.py` |
 | `scheduler/` | (standalone) | `models/abc.py` |
-| `samples/` | (standalone) | `models/`, `rewards/` |
+| `samples/` | `utils/` | `models/`, `rewards/`, `advantage/`, `trainers/` |
+| `ema/` | `utils/` | `models/abc.py` |
+| `logger/` | `hparams` | `trainers/abc.py` |
+| `utils/` | (standalone) | Most modules |
 
 ---
 
@@ -50,9 +53,10 @@ Stage 1: Data Preprocessing (offline, cached)
   │  Result cached with hash fingerprint
   ▼
 Stage 2: K-Repeat Sampling
-  │  Two sampler strategies (see `topics/samplers.md`):
+  │  Three sampler strategies (see `topics/samplers.md`):
   │  - GroupContiguousSampler (preferred, auto-selected): keeps K copies on same rank
   │  - DistributedKRepeatSampler (fallback): shuffles K copies across ranks
+  │  - GroupDistributedSampler (DGPO): rank-identical prompt sequence, K/W copies per rank
   │  K = training_args.group_size
   ▼
 Stage 3: Trajectory Generation
@@ -66,7 +70,7 @@ Stage 4: Reward Computation
 Stage 5: Advantage Computation
   │  AdvantageProcessor (advantage/advantage_processor.py)
   │  Communication-aware: auto-selects gather vs local path
-  │  Strategies: weighted-sum (GRPO) or GDPO
+  │  Strategies: "sum" (weighted-sum, GRPO) or "gdpo"
   ▼
 Stage 6: Policy Optimization
   │  adapter.forward() — single-step denoising for loss computation
@@ -104,6 +108,7 @@ All three registries map string keys → lazy import paths. Resolution: registry
 | `nft` | `DiffusionNFTTrainer` | Decoupled | `BaseTrainer` |
 | `awm` | `AWMTrainer` | Decoupled | `BaseTrainer` |
 | `crd` | `CRDTrainer` | Decoupled | `BaseTrainer` |
+| `diffusion-opd` | `DiffusionOPDTrainer` | Distillation (on-policy) | `BaseTrainer` |
 
 **Flat hierarchy**: New trainers inherit from `BaseTrainer` directly. The sanctioned exceptions are `GRPOGuardTrainer → GRPOTrainer` and `DPPOTrainer → GRPOTrainer` (strict GRPO loss variants; see constraint #11).
 
@@ -131,12 +136,15 @@ All three registries map string keys → lazy import paths. Resolution: registry
 | `pickscore` | `PickScoreRewardModel` | Pointwise |
 | `pickscore_rank` | `PickScoreRankRewardModel` | Groupwise |
 | `clip` | `CLIPRewardModel` | Pointwise |
+| `clap` | `CLAPRewardModel` | Pointwise |
+| `imagebind` | `ImageBindRewardModel` | Pointwise |
 | `ocr` | `OCRRewardModel` | Pointwise |
+| `vllm_evaluate` | `VLMEvaluateRewardModel` | Pointwise |
+| `rational_rewards_t2i` | `RationalRewardsT2IRewardModel` | Pointwise |
+| `rational_rewards_edit` | `RationalRewardsEditRewardModel` | Pointwise |
+| `geneval` | `GenEvalRewardModel` | Pointwise |
 | `geneval2_soft_tifa` | `GenEval2SoftTIFARewardModel` | Pointwise |
 | `hpsv2` | `HPSv2RewardModel` | Pointwise |
-| `vllm_evaluate` | `VLMEvaluateRewardModel` | Pointwise |
-| `rational_rewards_t2i` | `RationalRewardsT2I` | Pointwise |
-| `rational_rewards_edit` | `RationalRewardsEdit` | Pointwise |
 | `qwen_image_bench` | `QwenImageBenchRewardModel` | Pointwise |
 
 ---
@@ -181,7 +189,7 @@ Two-layer structure (constraint #14): task-level samples (`T2ISample`, `I2VSampl
 - **Async**: optional non-blocking computation
 
 ### Advantage Computation
-`AdvantageProcessor` (`advantage/advantage_processor.py`): communication-aware, auto-selects gather vs local path. Strategies: `"sum"` (GRPO) and `"gdpo"`. All trainers delegate to `self.advantage_processor.compute_advantages()`.
+`AdvantageProcessor` (`advantage/advantage_processor.py`): communication-aware, auto-selects gather vs local path. Strategies: `"sum"` (GRPO) and `"gdpo"`. All reward-based trainers delegate to `self.advantage_processor.compute_advantages()`; the distillation trainer `diffusion-opd` is the exception (its `prepare_feedback()` is a no-op — no reward/advantage stage).
 
 ### Configuration Hierarchy
 ```

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -1,6 +1,6 @@
 # Hard Constraints
 
-Quick index: **#1-5** Registry | **#6-10** Training Pipeline | **#11-14** Base Classes | **#15-17** Config | **#18-20** Distributed | **#21-27** Code Quality
+Quick index: **#1-5** Registry | **#6-10** Training Pipeline | **#11-14** Base Classes | **#15-17** Config | **#18-20** Distributed | **#21-27** Code Quality | **#28-29** Agent Workflow
 
 These constraints MUST NOT be violated. Consult this file before making any code changes.
 
@@ -31,8 +31,9 @@ Every `BaseAdapter` subclass's `load_pipeline()` must return a `diffusers.Diffus
 The training loop executes: Data Preprocessing → K-Repeat Sampling → Trajectory Generation → Reward Computation → Advantage Computation → Policy Optimization. This order is invariant. Do not reorder or skip stages.
 
 ### 7. Coupled vs Decoupled Paradigm
-- **Coupled** (GRPO, GRPO-Guard): Training timesteps are coupled with SDE-based sampling. Requires log-probability computation. Must use SDE dynamics (`Flow-SDE`, `Dance-SDE`, `CPS`).
-- **Decoupled** (DPO, NFT, AWM): Training timesteps are decoupled from sampling. Can use any dynamics including `ODE`.
+- **Coupled** (GRPO, GRPO-Guard, DPPO): Training timesteps are coupled with SDE-based sampling. Requires log-probability computation. Must use SDE dynamics (`Flow-SDE`, `Dance-SDE`, `CPS`).
+- **Decoupled** (DPO, NFT, AWM, DGPO, CRD): Training timesteps are decoupled from sampling. Can use any dynamics including `ODE`.
+- **Distillation** (`diffusion-opd`): On-policy multi-teacher distillation; dynamics-agnostic (ODE or SDE) and has no reward/advantage stage.
 
 Mixing paradigms (e.g., using `ODE` dynamics with `GRPO`) will produce incorrect gradients silently.
 
@@ -46,18 +47,18 @@ Only **trainable modules** and the **optimizer** go through `accelerator.prepare
 `DistributedKRepeatSampler` and `GroupContiguousSampler` require `M * K ≡ 0 (mod W * B * G)` where M=unique_sample_num, K=group_size, W=world_size, B=per_device_batch_size, G=gradient_step_per_epoch — **unless** `gradient_accumulation_steps` is set manually, in which case the constraint reduces to `M * K ≡ 0 (mod W * B)`. **GroupContiguousSampler** adds: `M ≡ 0 (mod W)`. **GroupDistributedSampler** (DGPO) requires: `K % W == 0` and `(W * B) % K == 0`; auto-aligned by `_align_for_group_distributed`. See `topics/samplers.md` for full details.
 
 ### 10. DeepSpeed ZeRO-3 Is Unsupported
-Reward model sharding under ZeRO-3 is broken even with `GatherParameter` context manager (see `trainers/abc.py` line 119–123). Only ZeRO-1 and ZeRO-2 are safe. Document this if users ask.
+Reward model sharding under ZeRO-3 is broken even with `GatherParameter` context manager (see the ZeRO-3 guard comment in `trainers/abc.py`). Only ZeRO-1 and ZeRO-2 are safe. Document this if users ask.
 
 ---
 
 ## Base Class Interfaces (11–14)
 
 ### 11. BaseTrainer Abstract Contract
-`BaseTrainer.__init__` expects `(accelerator, config, adapter)`. Subclasses must implement `start()`, `prepare_feedback()`, `optimize()`, and `evaluate()`. The `_initialization()` method handles dataloader, optimizer, accelerator preparation, reward model loading, and `AdvantageProcessor` instantiation — do not duplicate this logic.
+`BaseTrainer.__init__` expects `(accelerator, config, adapter)`. Subclasses must implement the three abstract methods `start()`, `prepare_feedback()`, and `optimize()`. `evaluate()` is a **concrete** base method — override only to customize evaluation. The `_initialization()` method handles dataloader, optimizer, accelerator preparation, reward model loading, and `AdvantageProcessor` instantiation — do not duplicate this logic.
 
 **Per-epoch hook order**: `sample()` (Stages 2–3) → `prepare_feedback()` (Stages 4–5) → `optimize()` (Stage 6). `DPOTrainer` forms chosen/rejected pairs at the **start** of `optimize()` (not in `prepare_feedback()`).
 
-**Trainer hierarchy**: New trainers MUST inherit directly from `BaseTrainer`. The only sanctioned exceptions are strict behavioral variants of GRPO that change only the per-step loss while reusing GRPO's sampling/advantage/eval machinery: `GRPOGuardTrainer → GRPOTrainer` (adds ratio-normalization) and `DPPOTrainer → GRPOTrainer` (replaces the PPO ratio-clip with a KL trust-region mask). Trainer-to-trainer inheritance creates fragile coupling; when in doubt, inherit from `BaseTrainer` and extract shared logic into helper methods. All trainers delegate advantage computation to `self.advantage_processor.compute_advantages()`.
+**Trainer hierarchy**: New trainers MUST inherit directly from `BaseTrainer`. The only sanctioned exceptions are strict behavioral variants of GRPO that change only the per-step loss while reusing GRPO's sampling/advantage/eval machinery: `GRPOGuardTrainer → GRPOTrainer` (adds ratio-normalization) and `DPPOTrainer → GRPOTrainer` (replaces the PPO ratio-clip with a KL trust-region mask). Trainer-to-trainer inheritance creates fragile coupling; when in doubt, inherit from `BaseTrainer` and extract shared logic into helper methods. All reward-based trainers delegate advantage computation to `self.advantage_processor.compute_advantages()`; the distillation trainer `diffusion-opd` is the exception (its `prepare_feedback()` is a no-op with no reward/advantage stage).
 
 ### 12. BaseAdapter Abstract Methods
 Subclasses of `BaseAdapter` MUST implement these **4 abstract methods**:
@@ -100,7 +101,7 @@ All config dataclasses live in `hparams/`. The top-level `Arguments` aggregates 
 3. Any code that accesses `config.<field_name>`
 
 ### 16. Algorithm-Specific Training Args
-`TrainingArguments` has algorithm-specific subclasses (`GRPOTrainingArguments`, `DPOTrainingArguments`, `NFTTrainingArguments`, `AWMTrainingArguments`). The correct subclass is resolved by `get_training_args_class()`. Adding a new algorithm requires adding a corresponding subclass and updating the resolver.
+`TrainingArguments` has algorithm-specific subclasses (`GRPOTrainingArguments`, `DPPOTrainingArguments`, `DPOTrainingArguments`, `DGPOTrainingArguments`, `NFTTrainingArguments`, `AWMTrainingArguments`, `CRDTrainingArguments`, `DiffusionOPDTrainingArguments`). The correct subclass is resolved by `get_training_args_class()` (registry in `hparams/training_args/_registry.py`). Adding a new algorithm requires adding a corresponding subclass and updating the resolver.
 
 ### 17. YAML Config Structure
 Config keys must exactly match Pydantic field names. Typos fail silently with default values. See `examples/` for canonical config templates; structure defined in `hparams/args.py`.

--- a/.agents/knowledge/dependencies.md
+++ b/.agents/knowledge/dependencies.md
@@ -26,21 +26,28 @@ pyproject.toml
 │   ├── swanlab         SwanLab tracking
 │   ├── nvidia          xformers, nvidia-ml-py
 │   ├── bagel           flash-attn, opencv-python
+│   ├── geneval         mmcv, mmengine, mmdet, open_clip_torch
+│   ├── geneval2        scipy (exact GenEval2 GM parity)
 │   └── all             deepspeed + quantization
 └── [tool.*]            black, isort config
 ```
 
 ## Core Dependencies
 
+The authoritative list is `pyproject.toml` `[project.dependencies]` (20+ packages). Key ones:
+
 | Package | Min Version | Purpose |
 |---------|-------------|---------|
 | `torch` | >= 2.6.0 | PyTorch core |
 | `torchvision` | >= 0.19.0 | Vision utilities |
+| `torchaudio` | >= 2.4.0 | Audio I/O (audio / audio-video models, CLAP) |
 | `transformers` | >= 4.57.1 | Text encoders, tokenizers |
 | `diffusers` | >= 0.36.0 | Diffusion pipelines, schedulers |
 | `accelerate` | >= 1.11.0 | Distributed training, mixed precision |
 | `peft` | >= 0.17.0 | LoRA, parameter-efficient fine-tuning |
 | `datasets` | >= 3.3.2 | Dataset loading |
+| `huggingface-hub` | >= 0.35.3 | Model/dataset downloads |
+| `protobuf` / `sentencepiece` | >= 6.33.2 / >= 0.2.1 | T5 tokenizer (Flux, SD3.5) |
 | `pydantic` | >= 2.8.0 | Config dataclass validation |
 
 ## Key Compatibility Notes
@@ -58,6 +65,13 @@ pyproject.toml
 
 ### bagel extra
 - Bagel remains a registered model adapter, but its heavyweight runtime packages are optional. Install with `pip install -e ".[bagel]"` before using `model_type: "bagel"`.
+
+### geneval / geneval2 rewards
+- `geneval` needs `pip install -e ".[geneval]"` (mmcv / mmengine / mmdet + open_clip_torch) for Mask2Former detection.
+- `geneval2` (`geneval2_soft_tifa`) needs `pip install -e ".[geneval2]"` (scipy) for exact GenEval2 geometric-mean parity; Qwen3-VL ships with core `transformers`, and a pure-Python gmean is used when scipy is absent.
+
+### HPSv2 reward
+- The PyPI `hpsv2` package pins `protobuf<4`, conflicting with Flow-Factory's `protobuf>=6`. It is **not** an optional extra. Install it without dependencies after Flow-Factory: `uv pip install hpsv2 --no-deps` (runtime works with protobuf 6+).
 
 ### accelerate
 - Primary distributed backend. `accelerator.prepare()` is used for trainable modules and optimizer only (constraint #9).

--- a/.agents/knowledge/docs_maintenance.md
+++ b/.agents/knowledge/docs_maintenance.md
@@ -40,7 +40,7 @@ When modifying the knowledge system, verify these steps:
 |--------|-----------------|
 | New topic doc | Add row to `README.md` routing table with trigger condition |
 | New topic doc | Add cross-refs in relevant skills (`ff-develop`, `ff-debug`, `ff-review`, `ff-new-model`) |
-| New constraint | Update quick index range in `constraints.md` header + section header (e.g., `21-27` -> `21-28`) |
+| New constraint | Update quick index range in `constraints.md` header + section header (e.g., extend `#21-27` Code Quality or add a new category such as `#28-29` Agent Workflow) |
 | Append-only list | `Numbered Gotchas`, `FF-Specific Pitfalls` — only append, never reorder or remove |
 | Any doc change | All text in English (`constraints.md` #21) |
 | Moved detail | Replace inline content with pointer to the leaf that now holds it |

--- a/.agents/knowledge/philosophy.md
+++ b/.agents/knowledge/philosophy.md
@@ -2,8 +2,8 @@
 
 Flow-Factory is a simple, extensible RL fine-tuning framework for diffusion/flow-matching models.
 Models, algorithms, and rewards are decoupled via registries and base-class contracts.
-Both rollout and training use FSDP as backend. The single most important invariant is
-**train-inference consistency**.
+Both rollout and training run under Hugging Face Accelerate (DDP / DeepSpeed ZeRO-1-2 / FSDP
+backends). The single most important invariant is **train-inference consistency**.
 
 ## Principles
 
@@ -12,7 +12,7 @@ Both rollout and training use FSDP as backend. The single most important invaria
 | 1 | Train-inference consistency | Same inputs → same outputs across rollout and training | `topics/train_inference_consistency.md` |
 | 2 | Decoupled extensibility | Models, trainers, rewards independently pluggable via registries | `architecture.md` "Registry System" |
 | 3 | Fail-fast, no speculative code | Raise with context on invalid state; never silently correct | `constraints.md` #26 |
-| 4 | Top-down readability | `forward()` and `inference()` read linearly without utility tracing | `constraints.md` #27 |
+| 4 | Top-down readability | `forward()` and `inference()` read linearly without utility tracing | `.cursor/rules/no-section-divider-comments.mdc` |
 | 5 | Structural vs behavioral separation | Numerical correctness first, style cleanup second | `topics/adapter_conventions.md` |
 
 ## Coding Style Index

--- a/.agents/knowledge/topics/adapter_conventions.md
+++ b/.agents/knowledge/topics/adapter_conventions.md
@@ -24,7 +24,7 @@ All adapters that support CFG must follow a consistent two-stage pattern. Guidan
 
 ### Reference implementation
 
-`flux/flux2_klein.py` — `encode_prompt()` (line ~165) and `_forward()` (line ~769).
+`flux/flux2_klein.py` — `encode_prompt()` and `_forward()`.
 
 ### Models with model-specific CFG extensions
 
@@ -55,7 +55,7 @@ All adapters that support CFG must follow a consistent two-stage pattern. Guidan
 | Preprocessing | `preprocessing_modules` | yes | yes | `text_encoders`, `vae` |
 | Inference/Training | `inference_modules` | transformer: trainable; VAE: frozen | VAE: yes | `transformer`, `vae` |
 
-Defined in `models/abc.py` L380-387. Override in subclasses to add model-specific components (e.g., `connectors`, `image_encoder`).
+Defined in `models/abc.py` (`preprocessing_modules` / `inference_modules` properties). Override in subclasses to add model-specific components (e.g., `connectors`, `image_encoder`).
 
 ## Batch Dimension Convention
 

--- a/.agents/knowledge/topics/dtype_precision.md
+++ b/.agents/knowledge/topics/dtype_precision.md
@@ -14,11 +14,11 @@
 | Latent storage (trajectory) | `latent_storage_dtype` (configurable) | Memory vs. precision tradeoff |
 | Advantage computation | `float64` (numpy) | Normalization stability |
 
-Boundaries are set in `BaseAdapter._mix_precision()` (`models/abc.py` L818) and `BaseTrainer.__init__` (autocast context).
+Boundaries are set in `BaseAdapter._mix_precision()` (`models/abc.py`) and `BaseTrainer.__init__` (autocast context).
 
 ## `cast_latents()` Contract
 
-`BaseAdapter.cast_latents()` (`models/abc.py` L165) casts latents to `latent_storage_dtype` for trajectory storage.
+`BaseAdapter.cast_latents()` (`models/abc.py`) casts latents to `latent_storage_dtype` for trajectory storage.
 
 - **float16 overflow protection**: clamps values exceeding 65504.0 with a warning.
 - **Identity when no target**: returns latents unchanged if `latent_storage_dtype` is unset and no default provided.

--- a/.agents/knowledge/topics/parity_testing.md
+++ b/.agents/knowledge/topics/parity_testing.md
@@ -19,7 +19,7 @@ Test stages in dependency order. When a stage fails, fix it before testing downs
 
 1. **Prompt encoding** — `encode_prompt()` vs `pipeline._encode_prompt()`
 2. **Latent preparation** — `prepare_latents()` vs pipeline equivalent
-3. **Scheduler setup** — `set_timesteps()` output comparison
+3. **Scheduler setup** — `set_scheduler_timesteps()` output comparison
 4. **Single denoise step** — `forward()` with same input vs pipeline's inner loop body
 5. **Full denoising loop** — `inference()` vs `pipeline.__call__()` (seed-matched)
 6. **VAE decode** — `decode_latents()` vs `pipeline.vae.decode()`
@@ -27,7 +27,7 @@ Test stages in dependency order. When a stage fails, fix it before testing downs
 ## Flow-Factory Specific Pitfalls (append-only)
 
 1. **`cast_latents()` not applied**: Pipeline doesn't cast; adapter does. If `latent_storage_dtype` is set, parity requires applying `cast_latents()` to pipeline output too before comparison.
-2. **Scheduler state not reset**: `scheduler.set_timesteps()` must be called before each comparison run. Leftover `step_index` from a previous run causes different sigma lookups.
+2. **Scheduler state not reset**: `scheduler.set_scheduler_timesteps()` must be called before each comparison run. Leftover `step_index` from a previous run causes different sigma lookups.
 3. **`guidance_scale` embedding**: Some models (FLUX, SD3.5) embed `guidance_scale` as a conditioning input, not just a classifier-free guidance weight. Verify the adapter passes it to `forward()`.
 4. **Tokenizer padding mismatch**: Pipeline may use `max_length` padding while adapter uses `longest`. Compare `attention_mask` shape and values.
 5. **VAE scaling factor**: Pipeline applies `vae.config.scaling_factor` during encode/decode. Adapter must apply the same factor at the same point.
@@ -35,7 +35,9 @@ Test stages in dependency order. When a stage fails, fix it before testing downs
 7. **Timestep offset**: Some schedulers use `timestep_spacing="trailing"` — adapter must match the pipeline's scheduler config exactly.
 8. **Dual-modality scheduling**: Models with video+audio (e.g., LTX2-T2AV) need separate scheduler instances. Sharing one scheduler corrupts `step_index` for the second modality.
 
-## `compare_tensors()` Utility
+## Parity Helper: `compare_tensors()`
+
+> Self-contained helper to drop into a throwaway `.scratch/` parity script — it is **not** part of `flow_factory`; copy it where you need it.
 
 ```python
 def compare_tensors(name: str, a: torch.Tensor, b: torch.Tensor, atol: float = 1e-5):

--- a/.agents/knowledge/topics/sample_lifecycle.md
+++ b/.agents/knowledge/topics/sample_lifecycle.md
@@ -41,9 +41,9 @@ Three tiers, intentionally deviating from the strict ALL-YAML rule in `.cursor/r
 
 | Tier | Models | YAML field | Rationale |
 |------|--------|------------|-----------|
-| T1 | Wan video (T2V / I2V / V2V, 13 YAMLs) | explicit `true` | per-sample tensors are GB-scale; `sample()`/`optimize()` OOMs without offload |
-| T2 | Flux2 + Qwen-Image-Edit-Plus (13 YAMLs) | explicit `false` + multi-line pros/cons comment | moderate VRAM pressure; user-decision point with documentation co-located |
-| T3 | FLUX1 / SD3 / Qwen-Image / Z-Image / DPO / AWM-non-Flux2 / template (23 YAMLs) | not added; relies on code default `False` | low pressure; zero-migration cost |
+| T1 | Wan video (T2V / I2V / V2V) + LTX2 (T2AV / I2AV) | explicit `true` | per-sample tensors are GB-scale; `sample()`/`optimize()` OOMs without offload |
+| T2 | Flux2 / Flux2-Klein / Qwen-Image-Edit-Plus (+ OPD SD3.5) | explicit `false` + multi-line pros/cons comment | moderate VRAM pressure; user-decision point with documentation co-located |
+| T3 | FLUX1 / SD3 / Qwen-Image / Z-Image / DPO / template | not added; relies on code default `False` | low pressure; zero-migration cost |
 
 When in doubt, set `True` for any of: latent shape > FLUX1 1024², `num_batches_per_epoch` > 16, full finetune of a model > 7B params.
 

--- a/.agents/knowledge/topics/samplers.md
+++ b/.agents/knowledge/topics/samplers.md
@@ -63,7 +63,7 @@ Define the following variables:
 | `B` | Per-device batch size | `training_args.per_device_batch_size` |
 | `G` | Gradient steps per epoch | `training_args.gradient_step_per_epoch` |
 
-### Base Constraint (Both Samplers)
+### Base Constraint (All Samplers)
 
 The constraint depends on whether `gradient_accumulation_steps` is set manually or derived automatically.
 
@@ -148,7 +148,7 @@ gradient_accumulation_steps = max(1, num_batches_per_epoch // G)
 Then `Arguments.__post_init__` applies the per-timestep multiplier, also in **auto mode** only:
 
 ```python
-gradient_accumulation_steps *= num_train_timesteps  # GRPO, NFT, AWM, DPO
+gradient_accumulation_steps *= num_train_timesteps  # all trainers (via get_num_train_timesteps())
 ```
 
 #### Manual ``gradient_accumulation_steps``
@@ -182,31 +182,40 @@ The `sampler_type` field in `DataArguments` (`hparams/data_args.py`) allows user
 The `_resolve_sampler_type()` method in `hparams/args.py` resolves the final sampler type and writes it back to `data_args.sampler_type`:
 
 ```python
-# 1. Detect async rewards
+# 1. Detect async rewards (any reward config with async_reward=True)
 self._has_async_rewards = any(
     getattr(cfg, 'async_reward', False)
     for cfg in all_reward_configs
 )
-
-# 2. Resolve sampler type
 user_choice = self.data_args.sampler_type
-if user_choice != "auto":
-    # Only override if distributed_k_repeat + async rewards (hard conflict)
-    if user_choice == "distributed_k_repeat" and self._has_async_rewards:
-        self.data_args.sampler_type = "group_contiguous"
-else:
-    # Prefer group_contiguous; fall back if geometric constraints fail
-    if m % world_size == 0 and (m // world_size * K) % B == 0:
-        self.data_args.sampler_type = "group_contiguous"
-    else:
+trainer_type = str(training_args.trainer_type).lower()
+
+# 2. Async override: a user-requested distributed_k_repeat OR group_distributed
+#    is forced to group_contiguous when async rewards are on (DGPO is exempt).
+if (user_choice in {"distributed_k_repeat", "group_distributed"}
+        and self._has_async_rewards and trainer_type != "dgpo"):
+    self.data_args.sampler_type = "group_contiguous"
+
+# 3. "auto" (non-DGPO): default to group_contiguous; only pick distributed_k_repeat
+#    when groups-per-rank FAILS but local batch tiling holds. Otherwise stay on
+#    group_contiguous and let _align_batch_geometry() pad M to satisfy constraints.
+if user_choice == "auto" and trainer_type != "dgpo":
+    groups_per_rank_ok = (m % world_size == 0)
+    local_batch_tiling_ok = (m // world_size * K % B == 0)
+    if not groups_per_rank_ok and local_batch_tiling_ok:
         self.data_args.sampler_type = "distributed_k_repeat"
+    else:
+        self.data_args.sampler_type = "group_contiguous"
+
+# 4. DGPO always forces group_distributed.
+if trainer_type == "dgpo" and self.data_args.sampler_type != "group_distributed":
+    self.data_args.sampler_type = "group_distributed"
 ```
 
 **Key behaviors**:
 - DGPO trainer forces `group_distributed` regardless of user setting (via `_resolve_sampler_type`)
-- `"auto"` defaults to `group_contiguous` when constraints are met — minimises communication
-- Falls back to `distributed_k_repeat` only when `M % W != 0` or `(M/W)*K % B != 0`
-- Async rewards **always force** `group_contiguous`, even if user explicitly requests `distributed_k_repeat` (with a warning)
+- `"auto"` defaults to `group_contiguous`; it picks `distributed_k_repeat` **only** when groups-per-rank fails (`M % W != 0`) **but** local batch tiling holds (`(M/W)*K % B == 0`). When both fail it stays on `group_contiguous` and `_align_batch_geometry()` pads `M`.
+- Async rewards force `group_contiguous` when the user requested `distributed_k_repeat` **or** `group_distributed` (DGPO exempt), emitting a warning
 - User can manually select `group_contiguous` without async rewards (e.g., to reduce cross-rank communication)
 
 ### Sampler Factory (`data_utils/sampler_loader.py`)
@@ -265,13 +274,14 @@ Both samplers are **fully compatible** with existing gather/reduce/advantage log
 
 | Operation | `distributed_k_repeat` | `group_contiguous` | `group_distributed` |
 |-----------|----------------------|-------------------|---------------------|
-| Gather rewards | Single `accelerator.gather()` (packed tensor) | **Skipped** — local data used directly | Single `accelerator.gather()` |
-| Gather unique_ids | Packed into same gather call | **Skipped** — local `np.unique()` | **Skipped** — local `torch.unique()` (rank contract) |
-| Group construction | `np.unique()` over W×B items | `np.unique()` over B items only | `torch.unique()` over B items (identical across ranks) |
+| Gather rewards | Single `accelerator.gather()` (packed tensor) | **Skipped** — local data used directly | Single `accelerator.gather()` (same as `distributed_k_repeat`) |
+| Gather unique_ids | Packed into same gather call | **Skipped** — local `np.unique()` | Packed into same gather call |
+| Group construction | `np.unique()` over W×B items | `np.unique()` over B items only | `np.unique()` over W×B items |
 | Scatter advantages | `reshape(W, B)[rank]` | **Direct return** — already local | `reshape(W, B)[rank]` |
-| Group loss | N/A | N/A | `scatter_add` + `accelerator.reduce(SUM)` + `sigmoid` |
 
-The `AdvantageProcessor` is instantiated in `BaseTrainer._init_reward_model()` with `sampler_type=self.config.data_args.sampler_type`. All trainers (GRPO, GRPOGuard, NFT, AWM, DPO, DGPO) delegate advantage computation to `self.advantage_processor.compute_advantages()` via their own `compute_advantages()` method, invoked from `prepare_feedback()` after each `sample()` epoch (see `guidance/workflow.md` for `sample` → `prepare_feedback` → `optimize`). DPO forms chosen/rejected pairs at the start of `optimize()`, not in `prepare_feedback()`. DGPO handles group loss in its own `_compute_group_dgpo_loss()` via `scatter_add + reduce`.
+> `group_on_same_rank` is `True` **only** for `group_contiguous` (`advantage/advantage_processor.py`); `group_distributed` takes the **same gather path** as `distributed_k_repeat`. DGPO's rank-identical contract (local `torch.unique`, `scatter_add` + `accelerator.reduce(SUM)` + `sigmoid`) lives in the **DGPO loss** (`trainers/dgpo.py`), not in `AdvantageProcessor`.
+
+The `AdvantageProcessor` is instantiated in `BaseTrainer._init_reward_model()` with `sampler_type=self.config.data_args.sampler_type`. Reward-based trainers (GRPO, GRPOGuard, NFT, AWM, DPO, DGPO, CRD) delegate advantage computation to `self.advantage_processor.compute_advantages()` via their own `compute_advantages()` method, invoked from `prepare_feedback()` after each `sample()` epoch (see `guidance/workflow.md` for `sample` → `prepare_feedback` → `optimize`). The distillation trainer `diffusion-opd` is the exception: its `prepare_feedback()` is a no-op and it does not use `AdvantageProcessor`. DPO forms chosen/rejected pairs at the start of `optimize()`, not in `prepare_feedback()`. DGPO handles group loss in its own `_compute_group_dgpo_loss()` via `scatter_add + reduce`.
 
 When `GroupContiguousSampler` is used:
 1. **Groupwise Reward Computation** (`reward_processor.py`): `gather_samples()` → `group_samples()` → stride → compute → `all_reduce` → scatter — works correctly (gather collects redundant data but logic is sound)

--- a/.agents/knowledge/topics/train_inference_consistency.md
+++ b/.agents/knowledge/topics/train_inference_consistency.md
@@ -45,16 +45,16 @@ If rollout and training `forward()` diverge, `ratio` deviates from 1.0 at epoch 
 
 - Requires matched sampling and training `per_device_batch_size` (so contiguous chunks reproduce the rollout packs). These are the *same* field: rollout uses `training_args.per_device_batch_size` for the train DataLoader (`data_utils/loader.py`) and `optimize()` chunks by the same value, so they cannot drift unless a separate sampling batch size is introduced.
 - Default is `True` (per-inner-epoch shuffle); only pack-dependent adapters (Bagel) need `false`. The off-policy decorrelation cost is minor because the rollout order is already sampler-randomized. `BagelAdapter` warns at init if `shuffle_samples` is left `True`.
-- Wired via `BaseTrainer._order_samples_for_optimize(samples, inner_epoch)` (used by grpo/nft/awm/opd; dpo shuffles chosen/rejected pairs separately).
+- Wired via `BaseTrainer._order_samples_for_optimize(samples, inner_epoch)` (used by grpo/dppo/nft/awm/opd; dpo shuffles chosen/rejected pairs separately).
 
 ## Where in Code
 
 - Rollout: `adapter.inference()` -> `forward()` -> `scheduler.step()` -> `sample.log_probs[i]`
 - Training: `Trainer.optimize()` -> `adapter.forward()` -> `output.log_prob`
-- Ratio: `trainers/grpo.py` L264: `ratio = torch.exp(output.log_prob - old_log_prob)`
+- Ratio: `trainers/grpo.py` (`GRPOTrainer.optimize`): `ratio = torch.exp(output.log_prob - old_log_prob)`
 - PPO clip: `max(-adv * ratio, -adv * clamp(ratio, 1-eps, 1+eps))`
 - Dtype round-trip guard: `scheduler/*.py` — `next_latents = next_latents.to(_input_dtype).float()` ensures stored trajectory matches training replay (e.g., `scheduler/flow_match_euler_discrete.py` L362, `scheduler/unipc_multistep.py` L345)
-- `cast_latents()`: `models/abc.py` L165 — applied identically in `inference()` before/after each `forward()` call
+- `cast_latents()`: `BaseAdapter.cast_latents()` (`models/abc.py`) — applied identically in `inference()` before/after each `forward()` call
 
 ## Cross-refs
 

--- a/.agents/skills/ff-develop/SKILL.md
+++ b/.agents/skills/ff-develop/SKILL.md
@@ -16,8 +16,8 @@ description: "Feature development with cross-module impact analysis. Covers trai
 Before implementing features or refactoring, analyze impacts across these areas:
 
 ### 1. Trainer Hierarchy (`constraints.md` #11)
-- Changes to `BaseTrainer` affect all 6 concrete trainers; changed abstract methods must be implemented on every one
-- Changes to `AdvantageProcessor` affect all trainers (`architecture.md` "Advantage Computation")
+- Changes to `BaseTrainer` affect all 9 concrete trainers (grpo, grpo-guard, dppo, nft, awm, dgpo, dpo, crd, diffusion-opd); changed abstract methods must be implemented on every one
+- Changes to `AdvantageProcessor` affect all reward-based trainers (`architecture.md` "Advantage Computation"; `diffusion-opd` skips it)
 - Check: Does your change alter `_initialization()`, `_init_reward_model()`, or `_init_dataloader()`?
 
 ### 2. Model Adapter Hierarchy (`constraints.md` #12)
@@ -64,8 +64,9 @@ Before implementing features or refactoring, analyze impacts across these areas:
    - Run tests after each change
 
 4. **Cross-algorithm verification**
-   - Test with GRPO (coupled paradigm)
-   - Test with NFT or AWM (decoupled paradigm)
+   - Test with GRPO (coupled paradigm; also covers GRPO-Guard / DPPO variants)
+   - Test with NFT or AWM (decoupled paradigm; also DGPO / CRD / DPO)
+   - If the change touches the sample/optimize path, also test `diffusion-opd` (distillation; no reward/advantage stage)
    - Verify with at least two different model adapters
 
 ## Documentation

--- a/.agents/skills/ff-new-algorithm/SKILL.md
+++ b/.agents/skills/ff-new-algorithm/SKILL.md
@@ -125,9 +125,8 @@ class MyAlgoTrainer(BaseTrainer):
             self.adapter.ema_step(step=self.epoch)
             self.epoch += 1
 
-    def evaluate(self):
-        """Evaluation loop — reuse pattern from GRPO/NFT."""
-        pass
+    # NOTE: evaluate() is a CONCRETE BaseTrainer method (called by the loop above).
+    # Override it only to customize evaluation — it is NOT an abstract method.
 
     def sample(self):
         """Stages 2-3: K-repeat sampling + trajectory generation."""
@@ -150,7 +149,7 @@ class MyAlgoTrainer(BaseTrainer):
 ```
 
 > **Note**: `AdvantageProcessor` is auto-instantiated in `BaseTrainer._init_reward_model()`.
-> All trainers delegate via `self.advantage_processor.compute_advantages()` — see `architecture.md` "Advantage Computation".
+> Reward-based trainers delegate via `self.advantage_processor.compute_advantages()` — see `architecture.md` "Advantage Computation". (Pure-distillation trainers like `diffusion-opd` skip rewards/advantages with a no-op `prepare_feedback()`.)
 
 ### Step 4 — Register in Trainer Registry
 
@@ -167,7 +166,7 @@ Create example config `examples/my_algo/lora/flux1/default.yaml`:
 ```yaml
 model:
   model_type: "flux1"
-  model_path: "black-forest-labs/FLUX.1-dev"
+  model_name_or_path: "black-forest-labs/FLUX.1-dev"
   finetune_type: "lora"
   target_components: ["transformer"]
 
@@ -183,11 +182,19 @@ scheduler:
   dynamics_type: "ODE"          # Or appropriate dynamics
 
 data:
-  dataset: "path/to/dataset"
+  datasets:
+    - name: default
+      dataset_dir: "path/to/dataset"   # Folder with train.jsonl / test.jsonl
+      train:
+        weight: 1
+        max_dataset_size: 1024
+      eval: {}
 
 rewards:
-  reward_model: "PickScore"
-  batch_size: 16
+  - name: "pickscore"
+    reward_model: "pickscore"
+    weight: 1.0
+    batch_size: 16
 ```
 
 ## Phase 5: Verification

--- a/.agents/skills/ff-new-model/SKILL.md
+++ b/.agents/skills/ff-new-model/SKILL.md
@@ -28,7 +28,7 @@ Before starting, ensure you understand:
    - Text encoders → `encode_prompt()`, `preprocessing_modules`
    - VAE → `encode_image()` / `decode_latents()`, `preprocessing_modules`
    - Audio encoder/VAE (if any) → `encode_audio()`, `preprocessing_modules`
-   - Transformer/UNet → `forward()`, `target_module_map`, `inference_modules`
+   - Transformer/UNet → `forward()`, `default_target_modules` (LoRA target layer names), `inference_modules`
 4. **Also read**: `topics/adapter_conventions.md` for upstream alignment rules; `topics/dtype_precision.md` for precision handling in `cast_latents()`.
 
 ## Phase 2: Implementation
@@ -57,9 +57,13 @@ class MyModelAdapter(BaseAdapter):
         return ["vae"]  # Components needed at inference time
 
     @property
-    def target_module_map(self) -> Dict[str, str]:
-        return {"transformer": "transformer"}  # Trainable components
+    def default_target_modules(self) -> List[str]:
+        # LoRA target module names used when YAML sets `target_modules: default`.
+        # Override only if your transformer uses non-standard attention layer names.
+        return ["to_q", "to_k", "to_v", "to_out.0"]
 ```
+
+> Which components are trainable is **config-driven**: the YAML `target_components` / `target_modules` fields are resolved by `BaseAdapter._parse_target_modules()` into `self.target_module_map` (set in `__init__`). Adapters do **not** override `target_module_map`.
 
 ### Step 3 — Implement Required Methods
 
@@ -88,7 +92,7 @@ Create example YAML config in `examples/grpo/lora/<model>/default.yaml`:
 ```yaml
 model:
   model_type: "my-model"
-  model_path: "org/model-name"
+  model_name_or_path: "org/model-name"
   finetune_type: "lora"
   target_components: ["transformer"]
 ```
@@ -109,7 +113,7 @@ Also read: `topics/parity_testing.md` for the 4-layer verification protocol.
 ## Common Pitfalls
 
 1. **Forgetting to set `preprocessing_modules`** — causes text encoder to stay on GPU, OOM during training
-2. **Wrong `target_module_map`** — LoRA applied to wrong components, no training effect
+2. **Wrong `target_components` / `target_modules` (or `default_target_modules`)** — LoRA applied to wrong components/layers, no training effect
 3. **Mismatched `_shared_fields`** — data corruption during batch collation
 4. **Not handling `enable_preprocess=False`** — encoding components not loaded at inference time
 5. **Inconsistent custom field types across samples** — if a custom sample field is `Tensor` on some samples and `List[Tensor]` on others, `gather_samples` will fall back to slow pickle-based `gather_object`. Always canonicalize to a single type in `__post_init__`; prefer `List[Tensor]` for variable-length data.

--- a/.agents/skills/ff-new-reward/SKILL.md
+++ b/.agents/skills/ff-new-reward/SKILL.md
@@ -51,6 +51,7 @@ class MyRewardModel(PointwiseRewardModel):
         prompt: List[str],
         image: Optional[List[Image.Image]] = None,
         video: Optional[List[List[Image.Image]]] = None,
+        audio: Optional[List[torch.Tensor]] = None,
         condition_images=None,
         condition_videos=None,
         **kwargs,

--- a/.agents/skills/ff-review/SKILL.md
+++ b/.agents/skills/ff-review/SKILL.md
@@ -41,7 +41,7 @@ git status             # Modified files
 - [ ] Config fields synchronized with YAML examples (#15–17)
 
 ### Cross-Module Consistency
-- [ ] Changes to `abc.py` base classes reflected in ALL subclasses (GRPO, GRPOGuard, DPO, NFT, AWM)
+- [ ] Changes to `abc.py` base classes reflected in ALL subclasses (grpo, grpo-guard, dppo, nft, awm, dgpo, dpo, crd, diffusion-opd)
 - [ ] Changes to `hparams/` reflected in ALL example configs
 - [ ] Changes to `AdvantageProcessor` compatible with all trainers
 - [ ] Registry keys match actual import paths

--- a/.cursor/rules/skills-reusable-only.mdc
+++ b/.cursor/rules/skills-reusable-only.mdc
@@ -8,5 +8,5 @@ The `.agents/skills/` directory is for permanent, reusable agent workflows only.
 Rules:
 - Every skill folder must contain a `SKILL.md` with YAML frontmatter (`name` and `description`)
 - Skill names use lowercase letters and hyphens only
-- Skills must be registered in `CLAUDE.md` and `.agents/skills/README.md`
+- Skills must be registered in the `AGENTS.md` skills table and `.agents/skills/README.md`
 - Temporary automation, one-off scripts, or experimental code belongs in `scripts/` or `tests/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 Flow-Factory is a unified **online RL fine-tuning framework** for diffusion/flow-matching models. It provides a modular architecture where trainers, model adapters, and reward models are independently extensible via a registry-based plugin system.
 
-- **Algorithms**: GRPO, GRPO-Guard, DPPO, DPO, DGPO, DiffusionNFT, AWM
-- **Models**: FLUX.1/2, SD3.5, Wan2.1/2.2, Qwen-Image, Z-Image
-- **Rewards**: PickScore, CLIP, OCR, GenEval, VLM-Evaluate, and custom rewards
+- **Algorithms**: GRPO, GRPO-Guard, DPPO, DPO, DGPO, DiffusionNFT, AWM, CRD, DiffusionOPD
+- **Models**: FLUX.1 (+Kontext), FLUX.2 (+Klein), SD3.5, Qwen-Image (+Edit-Plus), Z-Image, Wan2 (T2V/I2V/V2V), LTX2 (T2AV/I2AV), Bagel
+- **Rewards**: PickScore (+Rank), CLIP, CLAP, ImageBind, OCR, GenEval/GenEval2, HPSv2, VLM-Evaluate, rational-rewards, and custom rewards
 - **Python**: >=3.10 | **PyTorch**: >=2.6.0 | **License**: Apache-2.0
 
 **Language**: Match user's language.
@@ -18,7 +18,7 @@ On session start, read **Tier 1** (see `.agents/knowledge/README.md`):
 - `.agents/knowledge/constraints.md` — hard rules, indexed by category
 - `.agents/knowledge/architecture.md` — module graph, pipeline stages, registries
 
-**Tier 2**: Topic docs triggered by change area. See `knowledge/README.md` for triggers.
+**Tier 2**: Topic docs triggered by change area. See `.agents/knowledge/README.md` for triggers.
 
 ## Core Operating Principles
 
@@ -27,7 +27,7 @@ On session start, read **Tier 1** (see `.agents/knowledge/README.md`):
 3. **Plan before implement** — Multi-file tasks -> TodoWrite. Plan must state which skills apply.
 4. **Challenge first, execute second** — Spot logic flaws or simpler alternatives? Raise before executing.
 5. **Escalation** — After three failed approaches, document findings and request review.
-6. **Fix capture** — After every bug fix, generate summary per `topics/fix_patterns.md` template.
+6. **Fix capture** — After every bug fix, generate summary per `.agents/knowledge/topics/fix_patterns.md` template.
 7. **English-only docs** — All code comments, docstrings, commit messages, and agent docs must be English.
 8. **Scratch files only** — All temporary/intermediate files (analysis reports, investigation notes, checklists) MUST go under `.scratch/` (git-ignored). Never pollute the project root or tracked directories.
 
@@ -53,14 +53,14 @@ pytest                          # Run tests
 
 ## Project Structure
 
-See `architecture.md` "Module Dependency Graph" for full details.
+See `.agents/knowledge/architecture.md` "Module Dependency Graph" for full details.
 
 ## Documentation Reference
 
 | Document | Purpose |
 |----------|---------|
 | `guidance/workflow.md` | 6-stage training pipeline with code examples |
-| `guidance/algorithms.md` | GRPO, DiffusionNFT, DGPO, AWM deep dive |
+| `guidance/algorithms.md` | All 9 algorithms (GRPO, GRPO-Guard, DPPO, DPO, DGPO, DiffusionNFT, AWM, CRD, DiffusionOPD) deep dive |
 | `guidance/rewards.md` | Reward system design, custom model creation |
 | `guidance/new_model.md` | Step-by-step model adapter integration |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-AGENTS.md
+@AGENTS.md
 
 # Hard Rules (always enforced, including sub-agents)
 

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -36,7 +36,7 @@ Flow-Factory provides unified implementations of state-of-the-art RL algorithms 
 At a high level, the supported algorithms fall into two paradigms:
 
 - **Coupled paradigm (GRPO and variants)**: Training timesteps are coupled with the SDE-based sampling dynamics, requiring tractable log-probability computation for policy gradient optimization.
-- **Decoupled paradigm (DPO, DiffusionNFT, AWM, DGPO)**: Training timesteps are decoupled from the actual sampling dynamics, making them inherently solver-agnostic — any ODE solver can be used for trajectory generation without modifying the training procedure.
+- **Decoupled paradigm (DPO, DiffusionNFT, AWM, DGPO, CRD, DiffusionOPD)**: Training timesteps are decoupled from the actual sampling dynamics, making them inherently solver-agnostic — any ODE solver can be used for trajectory generation without modifying the training procedure.
 
 ## GRPO
 
@@ -79,7 +79,7 @@ Flow-Factory implements multiple SDE dynamics through a unified `SDESchedulerMix
 To switch between these formulations, set:
 
 ```yaml
-train:
+scheduler:
     dynamics_type: 'Flow-SDE' # Options are ['Flow-SDE', 'Dance-SDE', 'CPS', 'ODE'].
 ```
 
@@ -95,16 +95,16 @@ Training with the original Flow-GRPO and DanceGRPO methods is computationally ex
 
 Subsequent works, such as MixGRPO [[3]](#ref3) and TempFlow-GRPO [[4]](#ref4), investigated the effects of mixing ODE and SDE denoising rules. They found that applying SDE updates for only $1\sim 2$ steps—and optimizing only those corresponding steps—is sufficient. This approach significantly reduces the cost of the optimization stage and results in faster performance improvements.
 
-To control this behavior, you can configure `train_steps` and `num_train_steps` as follows:
+To control this behavior, you can configure `sde_steps` and `num_sde_steps` as follows:
 
 ```yaml
-train:
+scheduler:
     # Candidate steps for SDE noise (early steps typically provide more sample diversity)
-    train_steps: [1, 2, 3] 
+    sde_steps: [1, 2, 3] 
     
-    # Randomly select `1` step from the specified `train_steps` list (e.g., step 2) 
+    # Randomly select `1` step from the specified `sde_steps` list (e.g., step 2) 
     # to use SDE denoising. All other steps will use the standard ODE solver.
-    num_train_steps: 1
+    num_sde_steps: 1
 ```
 
 #### Decoupled Training and Inference Resolution
@@ -157,6 +157,7 @@ To enable this reweighting strategy, switch the `trainer_type` to `grpo-guard`:
 ```yaml
 train:
     trainer_type: 'grpo-guard'
+scheduler:
     dynamics_type: 'Flow-SDE'
 ```
 > ‼️ **Note**: Currently, `grpo-guard` reweighting is only compatible with `Flow-GRPO` dynamics. Therefore, dynamics_type must be explicitly set to `Flow-SDE`.

--- a/guidance/new_model.md
+++ b/guidance/new_model.md
@@ -90,8 +90,13 @@ class MyModelSample(T2ISample):
 | `BaseSample` | Generic | `image`, `video`, `prompt`, `all_latents`, `log_probs`, ... |
 | `T2ISample` | Text-to-image | Alias of `BaseSample` |
 | `T2VSample` | Text-to-video | Alias of `BaseSample` |
+| `T2AVSample` | Text-to-audio-video | Alias of `BaseSample` |
 | `ImageConditionSample` | Image-conditioned generation | `condition_images`: per-sample `List[Tensor(C,H,W)]` (or `List[PIL.Image]` when the subclass sets `condition_images_as_pil=True`); always `List`, never batched tensor |
 | `VideoConditionSample` | Video-conditioned generation | `condition_videos`: per-sample `List[Tensor(T,C,H,W)]` (or `List[List[PIL.Image]]` when `condition_videos_as_pil=True`); always `List`, never batched tensor |
+| `I2ISample` | Image-to-image | `ImageConditionSample` subclass |
+| `I2VSample` | Image-to-video | `ImageConditionSample` subclass |
+| `I2AVSample` | Image-to-audio-video | `ImageConditionSample` subclass |
+| `V2VSample` | Video-to-video | `VideoConditionSample` subclass |
 
 > See [`src/flow_factory/samples/samples.py`](src/flow_factory/samples/samples.py) for all available classes.
 
@@ -575,7 +580,7 @@ def preprocess_func(
 
 Not all models have a diffusers pipeline. For models like [Bagel](https://github.com/ByteDance-Seed/Bagel) — a unified multimodal foundation model that combines LLM, ViT, and VAE in a single architecture — you can create a **pseudo-pipeline** that mimics the diffusers `Pipeline` interface just enough for `BaseAdapter` to work.
 
-> **Reference implementation**: See the [`bagel` branch](https://github.com/X-GenGroup/Flow-Factory/tree/bagel/src/flow_factory/models/bagel) for the complete working example.
+> **Reference implementation**: See [`src/flow_factory/models/bagel/`](../src/flow_factory/models/bagel) (registered as `bagel`) for the complete working example of a non-diffusers pseudo-pipeline adapter.
 
 ### Why a Pseudo-Pipeline?
 

--- a/guidance/rewards.md
+++ b/guidance/rewards.md
@@ -38,6 +38,9 @@ Flow-Factory supports two paradigms for computing rewards:
 | `PickScore` | Pointwise | CLIP-based aesthetic scoring | [PickScore](https://huggingface.co/yuvalkirstain/PickScore_v1) |
 | `CLIP` | Pointwise | Image-text cosine similarity | [CLIP](https://huggingface.co/openai/clip-vit-large-patch14) |
 | `PickScore_Rank` | Groupwise | Ranking-based reward using PickScore | [PickScore](https://huggingface.co/yuvalkirstain/PickScore_v1) |
+| `ocr` | Pointwise | Text-rendering accuracy via PP-OCRv5 (rewards correctly rendered text) | [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) |
+| `clap` | Pointwise | Audio-text cosine similarity via LAION CLAP (`transformers.ClapModel`); for audio / audio-video models | [CLAP](https://github.com/LAION-AI/CLAP) |
+| `imagebind` | Pointwise | Audio-video / text-audio / text-video alignment via Meta ImageBind (CC-BY-NC-SA, NonCommercial) | [ImageBind](https://github.com/facebookresearch/ImageBind) |
 | `GenEval` | Pointwise | Compositional T2I evaluation (object count, color, position) via Mask2Former + CLIP | [GenEval](https://github.com/djghosh13/geneval) |
 | `geneval2_soft_tifa` | Pointwise | GenEval2 Soft-TIFA: per-atom VQA soft-match via local Qwen3-VL, AM/GM aggregation; `vqa_list` from dataset `metadata` or a `data_path` JSONL. Needs `pip install -e ".[geneval2]"` for exact GM parity | [GenEval2](https://github.com/facebookresearch/GenEval2) |
 | `hpsv2` | Pointwise | Human Preference Score v2 (OpenCLIP ViT-H-14 + HPS checkpoint). Install with `uv pip install hpsv2 --no-deps` | [HPSv2](https://github.com/tgxs002/HPSv2) |
@@ -176,8 +179,10 @@ class MyPointwiseReward(PointwiseRewardModel):
         prompt: List[str],
         image: Optional[List[Image.Image]] = None,
         video: Optional[List[List[Image.Image]]] = None,
+        audio: Optional[List[torch.Tensor]] = None,
         condition_images: Optional[List[List[Image.Image]]] = None,
         condition_videos: Optional[List[List[List[Image.Image]]]] = None,
+        **kwargs,
     ) -> RewardModelOutput:
         # Input length equals self.config.batch_size
         rewards = torch.zeros(len(prompt), device=self.device)
@@ -211,8 +216,10 @@ class MyGroupwiseReward(GroupwiseRewardModel):
         prompt: List[str],
         image: Optional[List[Image.Image]] = None,
         video: Optional[List[List[Image.Image]]] = None,
+        audio: Optional[List[torch.Tensor]] = None,
         condition_images: Optional[List[List[Image.Image]]] = None,
         condition_videos: Optional[List[List[List[Image.Image]]]] = None,
+        **kwargs,
     ) -> RewardModelOutput:
         # Input length equals group_size (NOT batch_size)
         # Handle batching internally using self.config.batch_size
@@ -275,11 +282,13 @@ class TensorBasedReward(PointwiseRewardModel):
         prompt: List[str],
         image: Optional[List[torch.Tensor]] = None,  # List of (C, H, W) tensors, range in [0, 1]
         video: Optional[List[torch.Tensor]] = None, # List of (T, C, H, W) tensors, range in [0, 1]
+        audio: Optional[List[torch.Tensor]] = None, # List of (C, T) waveforms
         condition_images: Optional[List[Union[torch.Tensor, List[torch.Tensor]]]] = None, # A batch of condition image list
         condition_videos: Optional[List[Union[torch.Tensor, List[torch.Tensor]]]] = None, # A batch of condition video list
+        **kwargs,
     ) -> RewardModelOutput:
         # Stack and process directly on GPU
-        rewards = torch.zeros_like(prompt, dtype=torch.float32)
+        rewards = torch.zeros(len(prompt), dtype=torch.float32, device=self.device)
         return RewardModelOutput(rewards=rewards)
 ```
 
@@ -313,24 +322,25 @@ JSONL field → Dataset "metadata" column → sample.extra_kwargs → reward __c
 {"prompt": "a red car", "include": "[{\"class\":\"car\",\"count\":1,\"color\":\"red\"}]", "tag": "colors"}
 ```
 
-The reward model parses these strings internally:
+All non-preprocess JSONL columns (here `include`, `tag`) are packed into a **single** per-sample `metadata` JSON string and delivered to the reward as `metadata: List[str]` (see `data_utils/dataset.py` `_preprocess_batch` and `BaseTrainer._inject_batch_metadata`). Declare `metadata` in `required_fields` and parse it internally:
 
 ```python
 class MyMetadataReward(PointwiseRewardModel):
-    required_fields = ("image", "prompt", "include")  # Declare metadata fields
+    required_fields = ("image", "prompt", "metadata")  # Receive the packed metadata JSON
 
-    def __call__(self, prompt, image=None, include=None, **kwargs):
+    def __call__(self, prompt, image=None, metadata=None, **kwargs):
         for i in range(len(prompt)):
-            spec = json.loads(include[i]) if isinstance(include[i], str) else include[i]
+            meta = json.loads(metadata[i]) if isinstance(metadata[i], str) else metadata[i]
+            spec = meta.get("include", [])  # original JSONL fields live inside `metadata`
             # ... use spec for evaluation
 ```
 
 **Rules:**
 1. Flat scalars (`str`, `int`, `float`) can be stored directly in JSONL.
-2. Complex values (lists, nested dicts) → `json.dumps()` in JSONL, `json.loads()` in reward model.
-3. Fields listed in `required_fields` are checked during reward computation; missing fields raise errors.
+2. Complex values (lists, nested dicts) → `json.dumps()` in JSONL; the packed `metadata` string is `json.loads()`-ed in the reward model.
+3. Request `metadata` (not individual JSONL columns) in `required_fields`; missing fields raise errors during reward computation.
 
-See `src/flow_factory/rewards/geneval.py` for a complete example (GenEval uses `include`/`exclude`/`tag`).
+See `src/flow_factory/rewards/geneval.py` for a complete example (GenEval reads `include`/`exclude`/`tag` from the parsed `metadata`).
 
 ## Multi-Reward Training
 
@@ -357,7 +367,7 @@ When using multiple rewards, Flow-Factory supports the following aggregation str
 | `sum` | Advantage of the weighted sum of rewards |
 | `gdpo` | Weighted sum of advantages from each reward |
 
-> To use a customized aggregation algorithm, refer to and modify `src/flow_factory/trainer/grpo:GRPOTrainer.compute_advantages`.
+> To use a customized aggregation algorithm, refer to and modify `src/flow_factory/trainers/grpo.py` (`GRPOTrainer.compute_advantages`).
 
 **Weighted Sum (`sum`):**
 

--- a/guidance/workflow.md
+++ b/guidance/workflow.md
@@ -168,7 +168,7 @@ train:
 
 | | Description |
 |---|---|
-| **Input** | Batched **raw input** (`prompt`, `images`) or **encoded tensors** (`prompt_embedds`, `image_latents`) from the dataloader. |
+| **Input** | Batched **raw input** (`prompt`, `images`) or **encoded tensors** (`prompt_embeds`, `image_latents`) from the dataloader. |
 | **Output** | `List[BaseSample]` — each sample contains: generated image/video, denoising trajectory (`all_latents`), log-probabilities (`log_probs`), timestep schedule, and prompt info |
 
 ### How It Works
@@ -177,22 +177,19 @@ The trainer's `sample()` method switches the adapter to rollout mode and runs in
 
 ```python
 # src/flow_factory/trainers/grpo.py — GRPOTrainer.sample()
-def sample(self):
-    self.adapter.rollout()  # Disable grad, set eval mode
-    samples = []
+def sample(self) -> List[BaseSample]:
     trajectory_indices = compute_trajectory_indices(
         train_timestep_indices=self.adapter.scheduler.train_timesteps,
         num_inference_steps=self.training_args.num_inference_steps,
     )
-    with torch.no_grad(), self.autocast():
-        for batch in dataloader:
-            sample_batch = self.adapter.inference(
-                compute_log_prob=True,
-                trajectory_indices=trajectory_indices,
-                **batch,
-            )
-            samples.extend(sample_batch)
-    return samples
+    # generate_samples() (BaseTrainer) switches the adapter to rollout mode,
+    # loops the dataloader, runs adapter.inference() under no_grad + autocast,
+    # buffers rewards (reward_buffer), and returns the collected samples.
+    return self.generate_samples(
+        reward_buffer=self.reward_buffer,
+        compute_log_prob=True,
+        trajectory_indices=trajectory_indices,
+    )
 ```
 
 Inside `adapter.inference()`, the model runs a multi-step denoising loop (SDE or ODE), collecting latents and computing log-probabilities at each step. The result is packaged into `BaseSample` dataclass instances:
@@ -299,22 +296,20 @@ rewards:
 ### How It Works
 
 ```python
-# src/flow_factory/trainers/grpo.py — GRPOTrainer.compute_advantage_weighted_sum()
-def compute_advantage_weighted_sum(self, samples, rewards, store_to_samples=True):
-    # 1. Gather rewards from all ranks
-    gathered_rewards = {k: accelerator.gather(v).cpu().numpy() for k, v in rewards.items()}
-    # 2. Weighted sum of multiple rewards
-    aggregated = sum(arr * weight for arr, weight in ...)
-    # 3. Group by unique_id
-    unique_ids = [s.unique_id for s in samples]
-    gathered_ids = accelerator.gather(unique_ids)
-    _, group_indices = np.unique(gathered_ids, return_inverse=True)
-    # 4. Normalize within each group: (r - mean) / std
-    for group_id in np.unique(group_indices):
-        mask = (group_indices == group_id)
-        advantages[mask] = (aggregated[mask] - mean) / std
-    # 5. Scatter back to local rank
-    advantages = advantages.reshape(num_processes, -1)[process_index]
+# src/flow_factory/trainers/grpo.py — GRPOTrainer.compute_advantages()
+def compute_advantages(self, samples, rewards, store_to_samples=True, aggregation_func=None):
+    # Thin wrapper: resolve the aggregation strategy, then delegate to
+    # AdvantageProcessor (advantage/advantage_processor.py). The processor is
+    # communication-aware and auto-selects the gather-vs-local path; it performs
+    # the gather -> weighted-aggregate -> group-by-unique_id -> normalize ->
+    # scatter sequence summarized below.
+    aggregation_func = aggregation_func or self.training_args.advantage_aggregation
+    return self.advantage_processor.compute_advantages(
+        samples=samples,
+        rewards=rewards,
+        store_to_samples=store_to_samples,
+        aggregation_func=aggregation_func,
+    )
 ```
 
 ### Aggregation Strategies

--- a/src/flow_factory/hparams/model_args.py
+++ b/src/flow_factory/hparams/model_args.py
@@ -63,9 +63,14 @@ class ModelArguments(ArgABC):
         metadata={"help": "Which layers to fine-tune. Options are like ['all',  'default', 'to_q', ['to_q', 'to_k', 'to_v']]"}
     )
 
-    model_type: Literal["sd3", "flux1", "flux1-kontext", 'flux2', 'qwenimage', 'qwenimage-edit', 'z-image'] = field(
+    model_type: Literal[
+        "sd3-5", "flux1", "flux1-kontext", "flux2", "flux2-klein",
+        "qwen-image", "qwen-image-edit-plus", "z-image",
+        "wan2_t2v", "wan2_i2v", "wan2_v2v", "bagel",
+        "ltx2_t2av", "ltx2_i2av",
+    ] = field(
         default="flux1",
-        metadata={"help": "Type of model to use."},
+        metadata={"help": "Registered model adapter key (see models/registry.py), or a custom 'pkg.module.Adapter' python path."},
     )
 
     lora_rank : int = field(


### PR DESCRIPTION
## Summary

Resyncs the AI-agent harness with the current `src/flow_factory/` implementation after plugin growth (now **9 trainers, 14 model adapters, 13 reward models**). A full audit found ~40 discrepancies; this PR fixes registry drift, wrong config/API facts, and broken cross-references. Almost entirely docs/harness; one zero-risk type-hint correction in `hparams/model_args.py`.

### Registry drift
- `architecture.md` / `AGENTS.md`: add `diffusion-opd` trainer, `clap`/`imagebind`/`geneval` rewards, Bagel/LTX2 models; fix `RationalRewardsT2IRewardModel` / `RationalRewardsEditRewardModel` class names.

### Wrong facts that could mislead agents or break YAML
- `guidance/algorithms.md`: `train.dynamics_type`/`train_steps`/`num_train_steps` -> `scheduler.dynamics_type`/`sde_steps`/`num_sde_steps` (verified against `examples/`).
- `guidance/workflow.md`: real `sample()` (delegates to `generate_samples`) and `compute_advantages()` snippets (removed nonexistent `compute_advantage_weighted_sum`); fixed `prompt_embedds` typo.
- `guidance/rewards.md`: fixed `trainer/grpo` path, GenEval `metadata`-JSON convention, added `audio` param, added `ocr`/`clap`/`imagebind`.
- skills: `model_path` -> `model_name_or_path`; `target_module_map` -> config-driven + `default_target_modules`; `data.dataset` -> `data.datasets`; rewards single-dict -> list; removed `evaluate()` skeleton.
- `constraints.md` #11: `evaluate()` is concrete (not abstract).

### Cross-reference rot
- `constraints.md` index extended to `#28-29`; `philosophy.md` `#27` ref fixed and "FSDP" -> Accelerate (DDP/DeepSpeed ZeRO-1-2/FSDP).
- `topics/samplers.md`: corrected `_resolve_sampler_type` + AdvantageProcessor `group_distributed` path; `parity_testing.md` `set_timesteps` -> `set_scheduler_timesteps`; brittle line numbers -> symbol refs.
- `.cursor/rules/skills-reusable-only.mdc`: register skills in `AGENTS.md`; `CLAUDE.md` now imports `@AGENTS.md` so it can't drift to a stale subset.

### Code (1 line of intent)
- `hparams/model_args.py`: `model_type` `Literal` now matches the 14 registry keys. Zero-risk — `ArgABC` is a plain dataclass with no `Literal` enforcement (examples already use `sd3-5`/`bagel`/`ltx2_*`).

## Test plan
- [x] Registry tables in docs re-grepped against `trainers/`, `models/`, `rewards/` registries.
- [x] `model_args.py` parses (AST) and has no linter errors.
- [x] Re-grep confirms no stale tokens remain (`compute_advantage_weighted_sum`, `trainer/grpo`, `prompt_embedds`, bare `train_steps`, `set_timesteps(`).
- [ ] Docs-only render check on GitHub.

## Notes
- `black --check`/`isort --check` fail on `src/flow_factory/hparams/model_args.py`, but this is **pre-existing** (the whole file predates formatting); avoided a full-file reformat to keep this PR scoped. Can format separately if desired.
- Out of scope (code bug, not harness): `my_reward_remote.py` docstrings / `reward_server/example_server.py` reference `flow_factory.rewards.remote` instead of `my_reward_remote`.

Made with [Cursor](https://cursor.com)