### PR TITLE
[trainer,docs] fix: per-forward autocast to avoid stale weight cache (zero KL / frozen fp32 training)

### DIFF
--- a/.agents/knowledge/README.md
+++ b/.agents/knowledge/README.md
@@ -4,7 +4,8 @@
 |---------|------|
 | Session start | `philosophy.md`, `constraints.md`, `architecture.md` |
 | Touching `trainers/*.optimize`, `adapter.forward`/`inference`, `scheduler.step` | `topics/train_inference_consistency.md` |
-| Touching dtype/precision, debugging NaN/overflow | `topics/dtype_precision.md` |
+| Touching dtype/precision, mixed precision config, debugging NaN/overflow | `topics/dtype_precision.md` |
+| Editing a trainer `optimize()` loop / autocast scope, ref/EMA/named param swaps | `topics/autocast_param_swap.md` |
 | Adding or modifying a model adapter | `topics/adapter_conventions.md` |
 | Adding adapter, upgrading diffusers, debugging output quality | `topics/parity_testing.md` |
 | Touching `TimeSampler`, `adapter.forward(t=...)`, `timestep_range`, `flow_match_sigma` | `topics/timestep_sigma.md` |

--- a/.agents/knowledge/constraints.md
+++ b/.agents/knowledge/constraints.md
@@ -119,6 +119,9 @@ When using FSDP with CPU offloading, frozen components (text encoder, VAE) may b
 ### 20. Mixed Precision Consistency
 The adapter sets inference dtype for frozen components and training dtype for trainable parameters in `_mix_precision()`. Autocast context is configured in `BaseTrainer.__init__`. Do not manually cast tensors unless you understand the precision boundary. Details: `topics/dtype_precision.md`.
 
+### 20a. Autocast Weight Cache Must Not Span a Forward
+`torch.autocast`'s weight cache (keyed by tensor `data_ptr`) serves **stale** casts after any in-place weight change — `optimizer.step()` or a `use_ref/ema/named_parameters` swap (`param.data.copy_`). So wrap **each** forward (and its KL) in its own `with self.autocast():`; never one autocast around the optimize loop. Active for fp32 trainable weights (`master_weight_dtype: fp32`), dormant for the bf16 default, LoRA `disable_adapter()` safe. Details + DDP/DeepSpeed caveat: `topics/autocast_param_swap.md`.
+
 ---
 
 ## Code Quality (21–27)

--- a/.agents/knowledge/topics/autocast_param_swap.md
+++ b/.agents/knowledge/topics/autocast_param_swap.md
@@ -1,0 +1,40 @@
+# Autocast Weight Cache & Parameter Swaps
+
+**Read when**: editing a trainer `optimize()` loop / autocast scope, the param-swap contexts (`use_ref_parameters` / `use_ema_parameters` / `use_named_parameters`), or any KL / ref / EMA / teacher forward.
+
+---
+
+## Invariant: autocast must not span a forward (#20a)
+
+`torch.autocast`'s weight cache (default `cache_enabled=True`) caches each fp32→bf16 weight cast keyed by tensor `data_ptr`, assuming weights are constant in the region. An **in-place** weight change is invisible to it and serves a **stale** cast. Two triggers:
+
+- **Ref/EMA/named swap** — `copy_ema_to` does `param.data.copy_` (same `data_ptr`); a ref forward after the policy forward in one region reuses the policy cast → KL ≈ 0.
+- **`optimizer.step()`** — updates weights in place; if the region spans steps, later forwards reuse the pre-step cast → training frozen (loss flat).
+
+**Bites only** for fp32 trainable weights (`master_weight_dtype: fp32`); dormant for the bf16 default (nothing cached); LoRA's `disable_adapter()` ref path is safe (no `.data.copy_`).
+
+**Rule**: wrap **each** forward (and its KL math) in its own `with self.autocast():`; never one autocast around the optimize loop. Per-forward (not `cache_enabled=False`) keeps the legit intra-forward reuse of two-pass-CFG adapters (e.g. `qwen_image_edit_plus.py` calls the transformer twice per forward). Precompute / sampling regions keep their outer autocast (weights constant).
+
+```python
+with self.autocast():
+    output = self.adapter.forward(**forward_inputs)
+if self.enable_kl_loss:
+    with self.autocast():
+        with torch.no_grad(), self.adapter.use_ref_parameters():
+            ref_output = self.adapter.forward(**ref_forward_inputs)
+        kl_div = ...; loss = loss + kl_loss
+```
+
+## DDP/DeepSpeed caveat (separate mechanism)
+
+`.data.copy_` may not reach the params a wrapped forward reads: vanilla DDP shares params (swap reflected); DeepSpeed may hold a working copy. If a ref/EMA forward returns the policy output even with per-forward autocast, run the no-grad swap forward on the unwrapped component (`get_component_unwrapped` / `set_component`). ZeRO-3 unsupported (#10).
+
+## In-place swap, not separate modules
+
+Ref/EMA/named snapshots share **one** model and swap in place via `EMAModuleWrapper.copy_ema_to`; do not replace with a separate frozen module. Full-FT is often partial (`_freeze_components` unfreezes only `target_modules`), so the swap duplicates only the trainable subset T and shares frozen F in place — memory-optimal; a `deepcopy` module would hold T+F (wastes F). `named_parameters` also stores N snapshots cheaply (flat CPU tensors, one GPU swap at a time). Cost: `copy_ema_to` does ~3×T copies per KL step (incl. a D2H temp clone) — if it bottlenecks, optimize the swap, not the architecture.
+
+## Cross-refs
+
+- `constraints.md` #20a, #20, #10
+- `topics/dtype_precision.md`, `train_inference_consistency.md`
+- `models/abc.py` `use_ref_parameters` / `use_ema_parameters` / `use_named_parameters`; `ema/ema.py` `EMAModuleWrapper`

--- a/.agents/knowledge/topics/dtype_precision.md
+++ b/.agents/knowledge/topics/dtype_precision.md
@@ -14,7 +14,7 @@
 | Latent storage (trajectory) | `latent_storage_dtype` (configurable) | Memory vs. precision tradeoff |
 | Advantage computation | `float64` (numpy) | Normalization stability |
 
-Boundaries are set in `BaseAdapter._mix_precision()` (`models/abc.py`) and `BaseTrainer.__init__` (autocast context).
+Boundaries are set in `BaseAdapter._mix_precision()` (`models/abc.py`) and `BaseTrainer.__init__` (autocast context). Autocast weight-cache invariant + in-place ref/EMA/named swaps: `topics/autocast_param_swap.md` (#20a).
 
 ## `cast_latents()` Contract
 
@@ -68,5 +68,6 @@ The round-trip ensures that the precision of stored latents matches what trainin
 
 - `constraints.md` #18 (all-rank synchronization — precision errors may manifest differently per rank)
 - `constraints.md` #20 (mixed precision consistency)
+- `topics/autocast_param_swap.md` (#20a)
 - `train_inference_consistency.md` (log_prob mismatch from precision)
 - `topics/timestep_sigma.md` (scheduler math always float32)

--- a/.agents/knowledge/topics/sample_lifecycle.md
+++ b/.agents/knowledge/topics/sample_lifecycle.md
@@ -79,8 +79,8 @@ for each micro-batch:
                   _old_v_pred_list / _old_log_probs) for THIS batch only
   3. train under current policy:
        adapter.train()
-       with self.autocast():
-         per-timestep forward / backward / optimizer step
+       per-timestep: each forward (and KL) in its OWN `with self.autocast():`
+                     (constraint #20a); backward / optimizer step outside autocast
 ```
 
 Compared with the previous "eager precompute over ALL batches, then train all batches" design, this caps the precompute footprint to a single batch (`_old_v_pred_list` was 5+ GB on FLUX1 1024² 32-batch in the eager design; tens of GB on Wan).
@@ -109,3 +109,4 @@ If a future custom adapter stores large GPU tensors in `extra_kwargs`, either ha
 - `constraints.md` #15 + `.cursor/rules/examples-yaml-sync.mdc` (the three-tier strategy is an intentional deviation)
 - `topics/train_inference_consistency.md` item #4 (EMA swap without restore — preserved by per-batch interleave)
 - `topics/dtype_precision.md` (device-move never changes dtype; orthogonal to autocast)
+- `topics/autocast_param_swap.md` (#20a)

--- a/.agents/skills/ff-debug/SKILL.md
+++ b/.agents/skills/ff-debug/SKILL.md
@@ -9,6 +9,7 @@ description: "Bug fixing and debugging for ANY error, crash, loss divergence, gr
 
 - NaN, loss divergence, wrong gradients -> `topics/train_inference_consistency.md`
 - Dtype mismatch, overflow, precision -> `topics/dtype_precision.md`
+- Frozen/flat loss or KL ≈ 0 -> `topics/autocast_param_swap.md` (#20a)
 
 ## Two Pathways
 

--- a/.agents/skills/ff-develop/SKILL.md
+++ b/.agents/skills/ff-develop/SKILL.md
@@ -9,6 +9,7 @@ description: "Feature development with cross-module impact analysis. Covers trai
 
 - Adapter changes -> `topics/adapter_conventions.md`
 - Trainer/scheduler changes -> `topics/train_inference_consistency.md`
+- Trainer `optimize()` loop, autocast scope, ref/EMA/named param swaps -> `topics/autocast_param_swap.md`
 - Precision changes -> `topics/dtype_precision.md`
 
 ## Impact Analysis Checklist

--- a/.agents/skills/ff-new-algorithm/SKILL.md
+++ b/.agents/skills/ff-new-algorithm/SKILL.md
@@ -143,7 +143,8 @@ class MyAlgoTrainer(BaseTrainer):
 
     def optimize(self, samples):
         """Stage 6: Policy update."""
-        # Use self.adapter.forward() for single-step denoising
+        # Use self.adapter.forward() for single-step denoising.
+        # Per-forward autocast — never one outer autocast around the loop (#20a).
         # Compute loss, backprop, step
         pass
 ```

--- a/.agents/skills/ff-review/SKILL.md
+++ b/.agents/skills/ff-review/SKILL.md
@@ -99,10 +99,10 @@ Additionally, read based on diff scope:
 | Diff touches... | Also read |
 |----------------|-----------|
 | `models/` | `topics/adapter_conventions.md`, `topics/parity_testing.md` |
-| `trainers/` | `topics/train_inference_consistency.md` |
+| `trainers/` | `topics/train_inference_consistency.md`, `topics/autocast_param_swap.md` |
 | `scheduler/` | `topics/train_inference_consistency.md`, `topics/dtype_precision.md` |
 | New adapter | `topics/adapter_conventions.md`, `topics/parity_testing.md` |
-| dtype/precision | `topics/dtype_precision.md` |
+| dtype/precision | `topics/dtype_precision.md`, `topics/autocast_param_swap.md` |
 
 ## Common Issues Found in Review
 
@@ -113,3 +113,4 @@ Additionally, read based on diff scope:
 5. **Missing `wait_for_everyone()`** — Distributed deadlock risk
 6. **Reward shape mismatch** — Pointwise returning wrong batch dim
 7. **License header missing** — New files without Apache 2.0 header
+8. **Autocast spans a forward** — flat loss / KL ≈ 0 (fp32 master); see #20a / `topics/autocast_param_swap.md`

--- a/src/flow_factory/trainers/awm.py
+++ b/src/flow_factory/trainers/awm.py
@@ -398,42 +398,43 @@ class AWMTrainer(BaseTrainer):
                 adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
                 ratio_clip_range = self.training_args.clip_range
 
-                with self.autocast():
-                    for t_idx in tqdm(
-                        range(self.num_train_timesteps),
-                        desc=f'Epoch {self.epoch} Timestep',
-                        position=1,
-                        leave=False,
-                        disable=not self.show_progress_bar,
-                    ):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            # 1. Prepare inputs for current timestep
-                            t_flat = all_timesteps[t_idx]  # (B,) [0, 1000]
-                            sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
-                            
-                            noise = all_random_noise[t_idx]
-                            noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
-                            old_log_prob = old_log_probs_list[t_idx]  # (B,)
-                            
-                            # 2. Forward pass for current policy
+                for t_idx in tqdm(
+                    range(self.num_train_timesteps),
+                    desc=f'Epoch {self.epoch} Timestep',
+                    position=1,
+                    leave=False,
+                    disable=not self.show_progress_bar,
+                ):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        # 1. Prepare inputs for current timestep
+                        t_flat = all_timesteps[t_idx]  # (B,) [0, 1000]
+                        sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
+
+                        noise = all_random_noise[t_idx]
+                        noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
+                        old_log_prob = old_log_probs_list[t_idx]  # (B,)
+
+                        # 2. Forward pass for current policy
+                        with self.autocast():
                             current_output = self._compute_awm_output(
                                 batch, t_flat, noised_latents, clean_latents, noise
                             )
-                            
-                            log_prob = current_output['log_prob']  # (B,)
-                            
-                            # 3. Compute PPO-style clipped loss
-                            ratio = torch.exp(log_prob - old_log_prob)
-                            unclipped_loss = -adv * ratio
-                            clipped_loss = -adv * torch.clamp(
-                                ratio, 1.0 + ratio_clip_range[0], 1.0 + ratio_clip_range[1]
-                            )
-                            policy_loss = torch.mean(torch.maximum(unclipped_loss, clipped_loss))
-                            
-                            loss = policy_loss
-                            
-                            # 4. KL regularization with reference model
-                            if self.enable_kl_loss:
+
+                        log_prob = current_output['log_prob']  # (B,)
+
+                        # 3. Compute PPO-style clipped loss
+                        ratio = torch.exp(log_prob - old_log_prob)
+                        unclipped_loss = -adv * ratio
+                        clipped_loss = -adv * torch.clamp(
+                            ratio, 1.0 + ratio_clip_range[0], 1.0 + ratio_clip_range[1]
+                        )
+                        policy_loss = torch.mean(torch.maximum(unclipped_loss, clipped_loss))
+
+                        loss = policy_loss
+
+                        # 4. KL regularization with reference model
+                        if self.enable_kl_loss:
+                            with self.autocast():
                                 with torch.no_grad(), self.adapter.use_ref_parameters():
                                     ref_output = self._compute_awm_output(
                                         batch, t_flat, noised_latents, clean_latents, noise
@@ -448,9 +449,10 @@ class AWMTrainer(BaseTrainer):
                                 loss = loss + kl_loss
                                 loss_info['kl_div'].append(kl_div.detach())
                                 loss_info['kl_loss'].append(kl_loss.detach())
-                            
-                            # 5. EMA-based KL regularization
-                            if self.enable_ema_kl_loss:
+
+                        # 5. EMA-based KL regularization
+                        if self.enable_ema_kl_loss:
+                            with self.autocast():
                                 with torch.no_grad(), self.adapter.use_ema_parameters():
                                     ema_output = self._compute_awm_output(
                                         batch, t_flat, noised_latents, clean_latents, noise
@@ -458,37 +460,37 @@ class AWMTrainer(BaseTrainer):
                                 # KL-div in velocity space
                                 noise_pred = current_output['noise_pred']
                                 ema_noise_pred = ema_output['noise_pred']
-                                
+
                                 ema_kl = ((noise_pred - ema_noise_pred) ** 2).mean(dim=tuple(range(1, noise_pred.ndim)))
                                 ema_kl_loss = self.ema_kl_beta * ema_kl.mean()
                                 loss = loss + ema_kl_loss
                                 loss_info['ema_kl_div'].append(ema_kl.detach())
                                 loss_info['ema_kl_loss'].append(ema_kl_loss.detach())
 
-                            # 6. Log per-timestep info
-                            loss_info['ratio'].append(ratio.detach())
-                            loss_info['unclipped_loss'].append(unclipped_loss.detach())
-                            loss_info['clipped_loss'].append(clipped_loss.detach())
-                            loss_info['policy_loss'].append(policy_loss.detach())
-                            loss_info['loss'].append(loss.detach())
-                            clip_frac_high = torch.mean((ratio > 1.0 + ratio_clip_range[1]).float())
-                            clip_frac_low = torch.mean((ratio < 1.0 + ratio_clip_range[0]).float())
-                            loss_info["clip_frac_high"].append(clip_frac_high.detach())
-                            loss_info["clip_frac_low"].append(clip_frac_low.detach())
-                            loss_info['clip_frac_total'].append((clip_frac_high + clip_frac_low).detach())
+                        # 6. Log per-timestep info
+                        loss_info['ratio'].append(ratio.detach())
+                        loss_info['unclipped_loss'].append(unclipped_loss.detach())
+                        loss_info['clipped_loss'].append(clipped_loss.detach())
+                        loss_info['policy_loss'].append(policy_loss.detach())
+                        loss_info['loss'].append(loss.detach())
+                        clip_frac_high = torch.mean((ratio > 1.0 + ratio_clip_range[1]).float())
+                        clip_frac_low = torch.mean((ratio < 1.0 + ratio_clip_range[0]).float())
+                        loss_info["clip_frac_high"].append(clip_frac_high.detach())
+                        loss_info["clip_frac_low"].append(clip_frac_low.detach())
+                        loss_info['clip_frac_total'].append((clip_frac_high + clip_frac_low).detach())
 
-                            # 6. Backward pass and optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                # Log loss info
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info['grad_norm'] = grad_norm
-                                self.log_data({f'train/{k}': v for k, v in loss_info.items()}, step=self.step)
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # 6. Backward pass and optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            # Log loss info
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info['grad_norm'] = grad_norm
+                            self.log_data({f'train/{k}': v for k, v in loss_info.items()}, step=self.step)
+                            self.step += 1
+                            loss_info = defaultdict(list)

--- a/src/flow_factory/trainers/crd.py
+++ b/src/flow_factory/trainers/crd.py
@@ -634,110 +634,111 @@ class CRDTrainer(BaseTrainer):
             self.adapter.train()
             loss_info = defaultdict(list)
 
-            with self.autocast():
-                for batch in tqdm(
-                    sample_batches,
-                    total=len(sample_batches),
-                    desc=f'Epoch {self.epoch} Training',
-                    position=0,
+            for batch in tqdm(
+                sample_batches,
+                total=len(sample_batches),
+                desc=f'Epoch {self.epoch} Training',
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                # Retrieve pre-computed data
+                batch_size = batch['all_latents'].shape[0]
+                clean_latents = batch['all_latents'][:, -1]
+                all_timesteps = batch['_all_timesteps']
+                all_random_noise = batch['_all_random_noise']
+                old_v_pred_list = batch['_old_v_pred_list']
+                # Iterate through timesteps
+                for t_idx in tqdm(
+                    range(self.num_train_timesteps),
+                    desc=f'Epoch {self.epoch} Timestep',
+                    position=1,
+                    leave=False,
                     disable=not self.show_progress_bar,
                 ):
-                    # Retrieve pre-computed data
-                    batch_size = batch['all_latents'].shape[0]
-                    clean_latents = batch['all_latents'][:, -1]
-                    all_timesteps = batch['_all_timesteps']
-                    all_random_noise = batch['_all_random_noise']
-                    old_v_pred_list = batch['_old_v_pred_list']
-                    # Iterate through timesteps
-                    for t_idx in tqdm(
-                        range(self.num_train_timesteps),
-                        desc=f'Epoch {self.epoch} Timestep',
-                        position=1,
-                        leave=False,
-                        disable=not self.show_progress_bar,
-                    ):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            # 1. Prepare inputs
-                            t_flat = all_timesteps[t_idx]  # (B,) scheduler scale [0, 1000]
-                            sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
-                            noise = all_random_noise[t_idx]
-                            noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
-                            old_v_pred = old_v_pred_list[t_idx]
-                            v_target = noise - clean_latents
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        # 1. Prepare inputs
+                        t_flat = all_timesteps[t_idx]  # (B,) scheduler scale [0, 1000]
+                        sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
+                        noise = all_random_noise[t_idx]
+                        noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
+                        old_v_pred = old_v_pred_list[t_idx]
+                        v_target = noise - clean_latents
 
-                            # 2. Current model forward pass
+                        # 2. Current model forward pass
+                        with self.autocast():
                             output = self._compute_crd_output(batch, t_flat, noised_latents)
-                            forward_pred = output['noise_pred']
+                        forward_pred = output['noise_pred']
 
-                            # 3. Reference model forward pass (for KL)
-                            # If kl_cfg > 1.0, the adapter's forward() will do CFG automatically:
-                            # it concatenates [neg_embeds, pos_embeds] and computes:
-                            #   noise_pred = uncond + kl_cfg * (cond - uncond)
-                            # The negative embeddings come from the batch (negative_prompt_embeds,
-                            # negative_pooled_prompt_embeds stored by SD3_5Sample during rollout).
-                            with torch.no_grad(), self.adapter.use_ref_parameters():
-                                cfg = self.kl_cfg if self.kl_cfg > 1.0 else None
-                                ref_output = self._compute_crd_output(batch, t_flat, noised_latents, guidance_scale=cfg)
-                                ref_pred = ref_output['noise_pred']
+                        # 3. Reference model forward pass (for KL)
+                        # If kl_cfg > 1.0, the adapter's forward() will do CFG automatically:
+                        # it concatenates [neg_embeds, pos_embeds] and computes:
+                        #   noise_pred = uncond + kl_cfg * (cond - uncond)
+                        # The negative embeddings come from the batch (negative_prompt_embeds,
+                        # negative_pooled_prompt_embeds stored by SD3_5Sample during rollout).
+                        with torch.no_grad(), self.adapter.use_ref_parameters(), self.autocast():
+                            cfg = self.kl_cfg if self.kl_cfg > 1.0 else None
+                            ref_output = self._compute_crd_output(batch, t_flat, noised_latents, guidance_scale=cfg)
+                            ref_pred = ref_output['noise_pred']
 
-                            # 4. Compute implicit reward: r_theta = -(||pred_theta - v_target||^2 - ||pred_old - v_target||^2)
-                            if self.adaptive_logp:
-                                with torch.no_grad():
-                                    weight_theta = (
-                                        torch.abs(forward_pred.double() - v_target.double())
-                                        .mean(dim=tuple(range(1, forward_pred.ndim)), keepdim=True)
-                                        .clip(min=1e-5)
-                                    )
-                                    weight_old = (
-                                        torch.abs(old_v_pred.double() - v_target.double())
-                                        .mean(dim=tuple(range(1, old_v_pred.ndim)), keepdim=True)
-                                        .clip(min=1e-5)
-                                    )
-                                r_theta = -(
-                                    (forward_pred - v_target) ** 2 / weight_theta
-                                    - (old_v_pred - v_target) ** 2 / weight_old
+                        # 4. Compute implicit reward: r_theta = -(||pred_theta - v_target||^2 - ||pred_old - v_target||^2)
+                        if self.adaptive_logp:
+                            with torch.no_grad():
+                                weight_theta = (
+                                    torch.abs(forward_pred.double() - v_target.double())
+                                    .mean(dim=tuple(range(1, forward_pred.ndim)), keepdim=True)
+                                    .clip(min=1e-5)
                                 )
-                            else:
-                                r_theta = -(
-                                    (forward_pred - v_target) ** 2
-                                    - (old_v_pred - v_target) ** 2
+                                weight_old = (
+                                    torch.abs(old_v_pred.double() - v_target.double())
+                                    .mean(dim=tuple(range(1, old_v_pred.ndim)), keepdim=True)
+                                    .clip(min=1e-5)
                                 )
-
-                            # Reduce spatial dims to per-sample scalar
-                            r_theta_local = r_theta.mean(dim=tuple(range(1, r_theta.ndim)))
-
-                            # Gather r_theta across all GPUs for centering
-                            r_theta_gathered = self.accelerator.gather(r_theta_local.detach()).to(
-                                self.accelerator.device
+                            r_theta = -(
+                                (forward_pred - v_target) ** 2 / weight_theta
+                                - (old_v_pred - v_target) ** 2 / weight_old
+                            )
+                        else:
+                            r_theta = -(
+                                (forward_pred - v_target) ** 2
+                                - (old_v_pred - v_target) ** 2
                             )
 
-                            # 5. Compute advantages for CRD centering
-                            adv = batch['advantage']
-                            adv_clip_range = self.training_args.adv_clip_range
-                            adv_clipped = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
+                        # Reduce spatial dims to per-sample scalar
+                        r_theta_local = r_theta.mean(dim=tuple(range(1, r_theta.ndim)))
 
-                            # Normalize to [0, 1]
-                            normalized_adv = (adv_clipped / max(adv_clip_range)) / 2.0 + 0.5
-                            adv_cur_rank = torch.clamp(normalized_adv, 0, 1)
+                        # Gather r_theta across all GPUs for centering
+                        r_theta_gathered = self.accelerator.gather(r_theta_local.detach()).to(
+                            self.accelerator.device
+                        )
 
-                            # Gather advantages across all GPUs
-                            adv_cur = self.accelerator.gather(adv_cur_rank.detach()).to(
-                                self.accelerator.device
-                            )
+                        # 5. Compute advantages for CRD centering
+                        adv = batch['advantage']
+                        adv_clip_range = self.training_args.adv_clip_range
+                        adv_clipped = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
 
-                            # 6. Centered Reward Distillation loss (supports dual-direction centering)
-                            ori_policy_loss = self._compute_crd_loss(
-                                adv_cur=adv_cur,
-                                adv_cur_rank=adv_cur_rank,
-                                r_theta_gathered=r_theta_gathered,
-                                r_theta_local=r_theta_local,
-                            )
+                        # Normalize to [0, 1]
+                        normalized_adv = (adv_clipped / max(adv_clip_range)) / 2.0 + 0.5
+                        adv_cur_rank = torch.clamp(normalized_adv, 0, 1)
 
-                            # Scale by adv_clip_max / beta for gradient magnitude normalization
-                            policy_loss = (ori_policy_loss * adv_clip_range[1] / max(self.crd_beta, 1e-8)).mean()
-                            loss = policy_loss
+                        # Gather advantages across all GPUs
+                        adv_cur = self.accelerator.gather(adv_cur_rank.detach()).to(
+                            self.accelerator.device
+                        )
 
-                            # 7. KL regularization against reference model
+                        # 6. Centered Reward Distillation loss (supports dual-direction centering)
+                        ori_policy_loss = self._compute_crd_loss(
+                            adv_cur=adv_cur,
+                            adv_cur_rank=adv_cur_rank,
+                            r_theta_gathered=r_theta_gathered,
+                            r_theta_local=r_theta_local,
+                        )
+
+                        # Scale by adv_clip_max / beta for gradient magnitude normalization
+                        policy_loss = (ori_policy_loss * adv_clip_range[1] / max(self.crd_beta, 1e-8)).mean()
+                        loss = policy_loss
+
+                        # 7. KL regularization against reference model
+                        with self.autocast():
                             kl_div = ((forward_pred - ref_pred) ** 2).mean(
                                 dim=tuple(range(1, forward_pred.ndim))
                             )
@@ -753,37 +754,37 @@ class CRDTrainer(BaseTrainer):
 
                             loss = loss + kl_loss
 
-                            # 8. Logging
-                            loss_info['policy_loss'].append(policy_loss.detach())
-                            loss_info['unweighted_policy_loss'].append(ori_policy_loss.mean().detach())
-                            loss_info['kl_div'].append(kl_div.mean().detach())
-                            loss_info['kl_loss'].append(kl_loss.detach())
-                            loss_info['r_theta_mean'].append(r_theta_local.mean().detach())
-                            loss_info['loss'].append(loss.detach())
+                        # 8. Logging
+                        loss_info['policy_loss'].append(policy_loss.detach())
+                        loss_info['unweighted_policy_loss'].append(ori_policy_loss.mean().detach())
+                        loss_info['kl_div'].append(kl_div.mean().detach())
+                        loss_info['kl_loss'].append(kl_loss.detach())
+                        loss_info['r_theta_mean'].append(r_theta_local.mean().detach())
+                        loss_info['loss'].append(loss.detach())
 
-                            if self.use_old_for_loss:
-                                old_kl = ((old_v_pred - ref_pred) ** 2).mean(
-                                    dim=tuple(range(1, old_v_pred.ndim))
-                                ).mean()
-                                loss_info['old_kl_div'].append(old_kl.detach())
-                                old_deviate = ((forward_pred - old_v_pred) ** 2).mean()
-                                loss_info['old_deviate'].append(old_deviate.detach())
+                        if self.use_old_for_loss:
+                            old_kl = ((old_v_pred - ref_pred) ** 2).mean(
+                                dim=tuple(range(1, old_v_pred.ndim))
+                            ).mean()
+                            loss_info['old_kl_div'].append(old_kl.detach())
+                            old_deviate = ((forward_pred - old_v_pred) ** 2).mean()
+                            loss_info['old_deviate'].append(old_deviate.detach())
 
-                            # 9. Backward and optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                # Log accumulated loss info
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info['grad_norm'] = grad_norm
-                                self.log_data(
-                                    {f'train/{k}': v for k, v in loss_info.items()},
-                                    step=self.step,
-                                )
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # 9. Backward and optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            # Log accumulated loss info
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info['grad_norm'] = grad_norm
+                            self.log_data(
+                                {f'train/{k}': v for k, v in loss_info.items()},
+                                step=self.step,
+                            )
+                            self.step += 1
+                            loss_info = defaultdict(list)

--- a/src/flow_factory/trainers/dgpo.py
+++ b/src/flow_factory/trainers/dgpo.py
@@ -601,17 +601,18 @@ class DGPOTrainer(BaseTrainer):
 
         old_v: Optional[torch.Tensor] = None
         if compute_old_v:
-            with torch.no_grad(), self._ema_ref_forward_context():
+            with torch.no_grad(), self._ema_ref_forward_context(), self.autocast():
                 old_v = self._compute_dgpo_output(
                     batch, t_flat, noised, guidance_scale=1.0
                 ).detach()
 
-        model_v = self._compute_dgpo_output(batch, t_flat, noised, guidance_scale=1.0)
+        with self.autocast():
+            model_v = self._compute_dgpo_output(batch, t_flat, noised, guidance_scale=1.0)
 
         ref_v: Optional[torch.Tensor] = None
         if self.enable_kl_loss or (not self.use_ema_ref):
             ref_cfg = self.kl_cfg if self.kl_cfg > 1.0 else 1.0
-            with torch.no_grad(), self.adapter.use_ref_parameters():
+            with torch.no_grad(), self.adapter.use_ref_parameters(), self.autocast():
                 ref_v = self._compute_dgpo_output(batch, t_flat, noised, guidance_scale=ref_cfg)
 
         if self.use_ema_ref:
@@ -693,11 +694,12 @@ class DGPOTrainer(BaseTrainer):
                     "enabled, but got None."
                 )
             batch_size = model_v.shape[0]
-            kl_div = (model_v - ref_v).square().reshape(batch_size, -1).mean(dim=1)
-            if self.clip_kl and should_clip is not None:
-                kl_div = torch.where(should_clip, kl_div.detach(), kl_div)
-            kl_loss = self.kl_beta * kl_div.mean()
-            loss = loss + kl_loss
+            with self.autocast():
+                kl_div = (model_v - ref_v).square().reshape(batch_size, -1).mean(dim=1)
+                if self.clip_kl and should_clip is not None:
+                    kl_div = torch.where(should_clip, kl_div.detach(), kl_div)
+                kl_loss = self.kl_beta * kl_div.mean()
+                loss = loss + kl_loss
             loss_info["kl_div"].append(kl_div.mean().detach())
             loss_info["kl_loss"].append(kl_loss.detach())
 
@@ -873,54 +875,54 @@ class DGPOTrainer(BaseTrainer):
         """
         loss_info: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
-        with self.autocast():
-            for tb in tqdm(
-                training_batches,
-                desc=f"Epoch {self.epoch} Training",
-                position=0,
+        # No loop-level autocast: forwards are wrapped in `_forward_velocities` (#20a).
+        for tb in tqdm(
+            training_batches,
+            desc=f"Epoch {self.epoch} Training",
+            position=0,
+            disable=not self.show_progress_bar,
+        ):
+            p = self._prep_training_batch(tb)
+            batch = p["batch"]
+            adv = p["adv"]
+            group_info = p["group_info"]
+
+            for t_idx in tqdm(
+                range(self.num_train_timesteps),
+                desc=f"Epoch {self.epoch} Timestep",
+                position=1,
+                leave=False,
                 disable=not self.show_progress_bar,
             ):
-                p = self._prep_training_batch(tb)
-                batch = p["batch"]
-                adv = p["adv"]
-                group_info = p["group_info"]
-
-                for t_idx in tqdm(
-                    range(self.num_train_timesteps),
-                    desc=f"Epoch {self.epoch} Timestep",
-                    position=1,
-                    leave=False,
-                    disable=not self.show_progress_bar,
-                ):
-                    with self.accelerator.accumulate(*self.adapter.trainable_components):
-                        noised = self._build_noised_inputs(p, t_idx)
-                        vels = self._forward_velocities(
-                            batch, noised["t_flat"], noised["noised"]
-                        )
-                        dsm_loss = self._compute_dsm_loss(noised["target_v"], vels["model_v"])
-                        should_clip, dsm_loss = self._maybe_clip_dsm(
-                            dsm_loss=dsm_loss,
-                            old_v=vels["old_v"],
-                            target_v=noised["target_v"],
-                            adv=adv,
-                            loss_info=loss_info,
-                        )
-                        ref_dgpo_v = vels["ref_dgpo_v"]
-                        dgpo_loss = self._compute_group_dgpo_loss(
-                            ref_v=ref_dgpo_v,
-                            target_v=noised["target_v"],
-                            advantages=adv,
-                            group_info=group_info,
-                            dsm_loss=dsm_loss,
-                        )
-                        loss_info["dsm_loss"].append(dsm_loss.mean().detach())
-                        loss_info = self._apply_total_loss_and_backward(
-                            dgpo_loss=dgpo_loss,
-                            model_v=vels["model_v"],
-                            ref_v=vels["ref_v"],
-                            should_clip=should_clip,
-                            loss_info=loss_info,
-                        )
+                with self.accelerator.accumulate(*self.adapter.trainable_components):
+                    noised = self._build_noised_inputs(p, t_idx)
+                    vels = self._forward_velocities(
+                        batch, noised["t_flat"], noised["noised"]
+                    )
+                    dsm_loss = self._compute_dsm_loss(noised["target_v"], vels["model_v"])
+                    should_clip, dsm_loss = self._maybe_clip_dsm(
+                        dsm_loss=dsm_loss,
+                        old_v=vels["old_v"],
+                        target_v=noised["target_v"],
+                        adv=adv,
+                        loss_info=loss_info,
+                    )
+                    ref_dgpo_v = vels["ref_dgpo_v"]
+                    dgpo_loss = self._compute_group_dgpo_loss(
+                        ref_v=ref_dgpo_v,
+                        target_v=noised["target_v"],
+                        advantages=adv,
+                        group_info=group_info,
+                        dsm_loss=dsm_loss,
+                    )
+                    loss_info["dsm_loss"].append(dsm_loss.mean().detach())
+                    loss_info = self._apply_total_loss_and_backward(
+                        dgpo_loss=dgpo_loss,
+                        model_v=vels["model_v"],
+                        ref_v=vels["ref_v"],
+                        should_clip=should_clip,
+                        loss_info=loss_info,
+                    )
 
     # =========================== Optimizer Step Finalization ============================
     def _finalize_step(

--- a/src/flow_factory/trainers/dpo.py
+++ b/src/flow_factory/trainers/dpo.py
@@ -449,128 +449,128 @@ class DPOTrainer(BaseTrainer):
             self.adapter.train()
             loss_info = defaultdict(list)
 
-            with self.autocast():
-                for pair_batch in tqdm(
-                    pair_batches,
-                    total=len(pair_batches),
-                    desc=f'Epoch {self.epoch} DPO Training',
-                    position=0,
-                    disable=not self.show_progress_bar,
-                ):
-                    # Stack chosen and rejected latents (shared across timesteps).
-                    # Lazy reload: when samples are GPU-resident `sample.to(device)` is
-                    # a no-op; when they are CPU-resident (offload pipeline) this is
-                    # the H2D point.
-                    device = self.accelerator.device
-                    chosen_samples = [p[0].to(device) for p in pair_batch]
-                    rejected_samples = [p[1].to(device) for p in pair_batch]
+            for pair_batch in tqdm(
+                pair_batches,
+                total=len(pair_batches),
+                desc=f'Epoch {self.epoch} DPO Training',
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                # Stack chosen and rejected latents (shared across timesteps).
+                # Lazy reload: when samples are GPU-resident `sample.to(device)` is
+                # a no-op; when they are CPU-resident (offload pipeline) this is
+                # the H2D point.
+                device = self.accelerator.device
+                chosen_samples = [p[0].to(device) for p in pair_batch]
+                rejected_samples = [p[1].to(device) for p in pair_batch]
 
-                    chosen_batch = BaseSample.stack(chosen_samples)
-                    rejected_batch = BaseSample.stack(rejected_samples)
+                chosen_batch = BaseSample.stack(chosen_samples)
+                rejected_batch = BaseSample.stack(rejected_samples)
 
-                    # Get clean latents (final step from trajectory, index -1)
-                    chosen_latents = chosen_batch['all_latents'][:, -1]
-                    rejected_latents = rejected_batch['all_latents'][:, -1]
+                # Get clean latents (final step from trajectory, index -1)
+                chosen_latents = chosen_batch['all_latents'][:, -1]
+                rejected_latents = rejected_batch['all_latents'][:, -1]
 
-                    current_batch_size = chosen_latents.shape[0]
+                current_batch_size = chosen_latents.shape[0]
 
-                    # Pre-sample T×B timesteps for this pair batch
-                    all_timesteps = self._sample_timesteps(
-                        batch_size=current_batch_size,
-                        num_timesteps=self.num_train_timesteps,
-                        timestep_range=self.training_args.timestep_range,
-                    )  # (T, B)
+                # Pre-sample T×B timesteps for this pair batch
+                all_timesteps = self._sample_timesteps(
+                    batch_size=current_batch_size,
+                    num_timesteps=self.num_train_timesteps,
+                    timestep_range=self.training_args.timestep_range,
+                )  # (T, B)
 
-                    # Build static forward kwargs (shared across timesteps)
-                    _excluded_batch_keys = {'all_latents', 'timesteps', 'advantage'}
-                    static_kwargs = {
-                        **self.training_args,
-                        'compute_log_prob': False,
-                        'return_kwargs': ['noise_pred'],
-                        'noise_level': 0.0,
-                        **{k: v for k, v in chosen_batch.items()
-                           if k not in _excluded_batch_keys},
-                    }
+                # Build static forward kwargs (shared across timesteps)
+                _excluded_batch_keys = {'all_latents', 'timesteps', 'advantage'}
+                static_kwargs = {
+                    **self.training_args,
+                    'compute_log_prob': False,
+                    'return_kwargs': ['noise_pred'],
+                    'noise_level': 0.0,
+                    **{k: v for k, v in chosen_batch.items()
+                       if k not in _excluded_batch_keys},
+                }
 
-                    for t_idx in range(self.num_train_timesteps):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            t = all_timesteps[t_idx]  # (B,), scheduler scale [0, 1000]
-                            sigma = flow_match_sigma(t)  # σ ∈ [0, 1]
-                            noise = randn_tensor(
-                                chosen_latents.shape,
-                                device=chosen_latents.device,
-                                dtype=chosen_latents.dtype,
-                            )
+                for t_idx in range(self.num_train_timesteps):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        t = all_timesteps[t_idx]  # (B,), scheduler scale [0, 1000]
+                        sigma = flow_match_sigma(t)  # σ ∈ [0, 1]
+                        noise = randn_tensor(
+                            chosen_latents.shape,
+                            device=chosen_latents.device,
+                            dtype=chosen_latents.dtype,
+                        )
 
-                            sigma_broadcast = to_broadcast_tensor(sigma, chosen_latents)
+                        sigma_broadcast = to_broadcast_tensor(sigma, chosen_latents)
 
-                            # Noise both at same σ: x_t = (1 - σ) * x_0 + σ * noise
-                            noised_chosen = (1 - sigma_broadcast) * chosen_latents + sigma_broadcast * noise
-                            noised_rejected = (1 - sigma_broadcast) * rejected_latents + sigma_broadcast * noise
+                        # Noise both at same σ: x_t = (1 - σ) * x_0 + σ * noise
+                        noised_chosen = (1 - sigma_broadcast) * chosen_latents + sigma_broadcast * noise
+                        noised_rejected = (1 - sigma_broadcast) * rejected_latents + sigma_broadcast * noise
 
-                            # Per-timestep forward kwargs (adapter expects scheduler scale)
-                            base_kwargs = {
-                                **static_kwargs,
-                                't': t,
-                                't_next': torch.zeros_like(t),
-                            }
+                        # Per-timestep forward kwargs (adapter expects scheduler scale)
+                        base_kwargs = {
+                            **static_kwargs,
+                            't': t,
+                            't_next': torch.zeros_like(t),
+                        }
 
-                            # Policy forward
+                        # Policy forward
+                        with self.autocast():
                             theta_w_pred = self._forward_noise_pred(noised_chosen, base_kwargs)
                             theta_l_pred = self._forward_noise_pred(noised_rejected, base_kwargs)
 
-                            # Reference forward (frozen)
-                            with torch.no_grad(), self.adapter.use_ref_parameters():
-                                ref_w_pred = self._forward_noise_pred(noised_chosen, base_kwargs)
-                                ref_l_pred = self._forward_noise_pred(noised_rejected, base_kwargs)
+                        # Reference forward (frozen)
+                        with torch.no_grad(), self.adapter.use_ref_parameters(), self.autocast():
+                            ref_w_pred = self._forward_noise_pred(noised_chosen, base_kwargs)
+                            ref_l_pred = self._forward_noise_pred(noised_rejected, base_kwargs)
 
-                            # MSE errors per sample — target is flow-matching velocity (noise - x_0), same as
-                            # flow_grpo train_sd3_dpo.py: target = noise - model_input
-                            target_w = noise - chosen_latents
-                            target_l = noise - rejected_latents
-                            spatial_dims = tuple(range(1, theta_w_pred.ndim))
-                            theta_w_err = ((theta_w_pred.float() - target_w.float()) ** 2).mean(dim=spatial_dims)
-                            theta_l_err = ((theta_l_pred.float() - target_l.float()) ** 2).mean(dim=spatial_dims)
-                            ref_w_err = ((ref_w_pred.float() - target_w.float()) ** 2).mean(dim=spatial_dims)
-                            ref_l_err = ((ref_l_pred.float() - target_l.float()) ** 2).mean(dim=spatial_dims)
+                        # MSE errors per sample — target is flow-matching velocity (noise - x_0), same as
+                        # flow_grpo train_sd3_dpo.py: target = noise - model_input
+                        target_w = noise - chosen_latents
+                        target_l = noise - rejected_latents
+                        spatial_dims = tuple(range(1, theta_w_pred.ndim))
+                        theta_w_err = ((theta_w_pred.float() - target_w.float()) ** 2).mean(dim=spatial_dims)
+                        theta_l_err = ((theta_l_pred.float() - target_l.float()) ** 2).mean(dim=spatial_dims)
+                        ref_w_err = ((ref_w_pred.float() - target_w.float()) ** 2).mean(dim=spatial_dims)
+                        ref_l_err = ((ref_l_pred.float() - target_l.float()) ** 2).mean(dim=spatial_dims)
 
-                            # DPO loss
-                            beta = self.training_args.beta
-                            w_diff = theta_w_err - ref_w_err
-                            l_diff = theta_l_err - ref_l_err
-                            w_l_diff = w_diff - l_diff
-                            inside_term = -0.5 * beta * w_l_diff
-                            loss = -F.logsigmoid(inside_term).mean()
+                        # DPO loss
+                        beta = self.training_args.beta
+                        w_diff = theta_w_err - ref_w_err
+                        l_diff = theta_l_err - ref_l_err
+                        w_l_diff = w_diff - l_diff
+                        inside_term = -0.5 * beta * w_l_diff
+                        loss = -F.logsigmoid(inside_term).mean()
 
-                            # Logging metrics
-                            with torch.no_grad():
-                                implicit_reward_chosen = -0.5 * beta * w_diff
-                                implicit_reward_rejected = -0.5 * beta * l_diff
-                                implicit_accuracy = (implicit_reward_chosen > implicit_reward_rejected).float().mean()
+                        # Logging metrics
+                        with torch.no_grad():
+                            implicit_reward_chosen = -0.5 * beta * w_diff
+                            implicit_reward_rejected = -0.5 * beta * l_diff
+                            implicit_accuracy = (implicit_reward_chosen > implicit_reward_rejected).float().mean()
 
-                            loss_info['loss'].append(loss.detach())
-                            loss_info['theta_w_err'].append(theta_w_err.mean().detach())
-                            loss_info['theta_l_err'].append(theta_l_err.mean().detach())
-                            loss_info['ref_w_err'].append(ref_w_err.mean().detach())
-                            loss_info['ref_l_err'].append(ref_l_err.mean().detach())
-                            loss_info['implicit_accuracy'].append(implicit_accuracy.detach())
-                            loss_info['implicit_reward_chosen'].append(implicit_reward_chosen.mean().detach())
-                            loss_info['implicit_reward_rejected'].append(implicit_reward_rejected.mean().detach())
+                        loss_info['loss'].append(loss.detach())
+                        loss_info['theta_w_err'].append(theta_w_err.mean().detach())
+                        loss_info['theta_l_err'].append(theta_l_err.mean().detach())
+                        loss_info['ref_w_err'].append(ref_w_err.mean().detach())
+                        loss_info['ref_l_err'].append(ref_l_err.mean().detach())
+                        loss_info['implicit_accuracy'].append(implicit_accuracy.detach())
+                        loss_info['implicit_reward_chosen'].append(implicit_reward_chosen.mean().detach())
+                        loss_info['implicit_reward_rejected'].append(implicit_reward_rejected.mean().detach())
 
-                            # Backward + optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info['grad_norm'] = grad_norm
-                                self.log_data(
-                                    {f'train/{k}': v for k, v in loss_info.items()},
-                                    step=self.step,
-                                )
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # Backward + optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info['grad_norm'] = grad_norm
+                            self.log_data(
+                                {f'train/{k}': v for k, v in loss_info.items()},
+                                step=self.step,
+                            )
+                            self.step += 1
+                            loss_info = defaultdict(list)

--- a/src/flow_factory/trainers/dppo.py
+++ b/src/flow_factory/trainers/dppo.py
@@ -121,114 +121,111 @@ class DPPOTrainer(GRPOTrainer):
             self.adapter.train()
             loss_info = defaultdict(list)
 
-            with self.autocast():
-                for batch_idx in tqdm(
-                    range(num_batches),
-                    total=num_batches,
-                    desc=f"Epoch {self.epoch} Training",
-                    position=0,
+            for batch_idx in tqdm(
+                range(num_batches),
+                total=num_batches,
+                desc=f"Epoch {self.epoch} Training",
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                start = batch_idx * per_device_batch_size
+                batch_samples = [
+                    sample.to(device)
+                    for sample in shuffled_samples[start : start + per_device_batch_size]
+                ]
+                batch = BaseSample.stack(batch_samples)
+                latents_index_map = batch["latent_index_map"]  # (T+1,) LongTensor
+                log_probs_index_map = batch["log_prob_index_map"]  # (T,) LongTensor
+                callback_index_map = batch["callback_index_map"][0]  # (T,) LongTensor, shared
+                for timestep_index in tqdm(
+                    self.adapter.scheduler.train_timesteps,
+                    desc=f"Epoch {self.epoch} Timestep",
+                    position=1,
+                    leave=False,
                     disable=not self.show_progress_bar,
                 ):
-                    start = batch_idx * per_device_batch_size
-                    batch_samples = [
-                        sample.to(device)
-                        for sample in shuffled_samples[start : start + per_device_batch_size]
-                    ]
-                    batch = BaseSample.stack(batch_samples)
-                    latents_index_map = batch["latent_index_map"]  # (T+1,) LongTensor
-                    log_probs_index_map = batch["log_prob_index_map"]  # (T,) LongTensor
-                    callback_index_map = batch["callback_index_map"][0]  # (T,) LongTensor, shared
-                    for timestep_index in tqdm(
-                        self.adapter.scheduler.train_timesteps,
-                        desc=f"Epoch {self.epoch} Timestep",
-                        position=1,
-                        leave=False,
-                        disable=not self.show_progress_bar,
-                    ):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            # 1. Prepare inputs
-                            old_log_prob = batch["log_probs"][
-                                :, log_probs_index_map[timestep_index]
-                            ]
-                            # Rollout-old policy in mask space (the only stored callback tensor).
-                            old_mask_tensor = batch[mask_field][
-                                :, callback_index_map[timestep_index]
-                            ]
-                            num_timesteps = batch["timesteps"].shape[1]
-                            t = batch["timesteps"][:, timestep_index]
-                            t_next = (
-                                batch["timesteps"][:, timestep_index + 1]
-                                if timestep_index + 1 < num_timesteps
-                                else torch.tensor(0, device=self.accelerator.device)
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        # 1. Prepare inputs
+                        old_log_prob = batch["log_probs"][:, log_probs_index_map[timestep_index]]
+                        # Rollout-old policy in mask space (the only stored callback tensor).
+                        old_mask_tensor = batch[mask_field][:, callback_index_map[timestep_index]]
+                        num_timesteps = batch["timesteps"].shape[1]
+                        t = batch["timesteps"][:, timestep_index]
+                        t_next = (
+                            batch["timesteps"][:, timestep_index + 1]
+                            if timestep_index + 1 < num_timesteps
+                            else torch.tensor(0, device=self.accelerator.device)
+                        )
+                        latents = batch["all_latents"][:, latents_index_map[timestep_index]]
+                        next_latents = batch["all_latents"][
+                            :, latents_index_map[timestep_index + 1]
+                        ]
+                        forward_inputs = {
+                            **self.training_args,
+                            "t": t,
+                            "t_next": t_next,
+                            "latents": latents,
+                            "next_latents": next_latents,
+                            "compute_log_prob": True,
+                            "noise_level": self.adapter.scheduler.noise_level,
+                            **batch,
+                        }
+                        forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
+                        # 2. Forward pass — request only what the mask (and optional ref KL) need.
+                        # The mask uses kl_mask_type; the ref penalty uses kl_type. std_dev_t/dt
+                        # feed the x-based mask's variance scaling only.
+                        return_kwargs = {"log_prob"}
+                        if kl_mask_type == "v-based":
+                            return_kwargs.add("noise_pred")
+                        else:
+                            return_kwargs.update(("next_latents_mean", "std_dev_t", "dt"))
+                        if self.enable_kl_loss:
+                            return_kwargs.add(
+                                "noise_pred" if kl_type == "v-based" else "next_latents_mean"
                             )
-                            latents = batch["all_latents"][:, latents_index_map[timestep_index]]
-                            next_latents = batch["all_latents"][
-                                :, latents_index_map[timestep_index + 1]
-                            ]
-                            forward_inputs = {
-                                **self.training_args,
-                                "t": t,
-                                "t_next": t_next,
-                                "latents": latents,
-                                "next_latents": next_latents,
-                                "compute_log_prob": True,
-                                "noise_level": self.adapter.scheduler.noise_level,
-                                **batch,
-                            }
-                            forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
-                            # 2. Forward pass — request only what the mask (and optional ref KL) need.
-                            # The mask uses kl_mask_type; the ref penalty uses kl_type. std_dev_t/dt
-                            # feed the x-based mask's variance scaling only.
-                            return_kwargs = {"log_prob"}
-                            if kl_mask_type == "v-based":
-                                return_kwargs.add("noise_pred")
-                            else:
-                                return_kwargs.update(("next_latents_mean", "std_dev_t", "dt"))
-                            if self.enable_kl_loss:
-                                return_kwargs.add(
-                                    "noise_pred" if kl_type == "v-based" else "next_latents_mean"
-                                )
-                            forward_inputs["return_kwargs"] = list(return_kwargs)
+                        forward_inputs["return_kwargs"] = list(return_kwargs)
+                        with self.autocast():
                             output = self.adapter.forward(**forward_inputs)
 
-                            # 3. Compute loss
-                            adv = batch["advantage"]
-                            adv_clip_range = self.training_args.adv_clip_range
-                            adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
-                            ratio = torch.exp(output.log_prob - old_log_prob)
+                        # 3. Compute loss
+                        adv = batch["advantage"]
+                        adv_clip_range = self.training_args.adv_clip_range
+                        adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
+                        ratio = torch.exp(output.log_prob - old_log_prob)
 
-                            # Per-step KL(current || old) for the trust-region mask. The x-based mask
-                            # uses the exact variance-scaled Gaussian KL; the v-based mask and the
-                            # ref-KL penalty below use unscaled squared error (GRPO convention).
-                            if kl_mask_type == "v-based":
-                                sq = (output.noise_pred - old_mask_tensor) ** 2
-                                kl_new_old = sq.mean(dim=tuple(range(1, sq.ndim)))
-                            else:
-                                sigma_t = self._effective_sigma(output.std_dev_t, output.dt)
-                                kl_elem = gaussian_kl_div(
-                                    output.next_latents_mean, old_mask_tensor, sigma_t
-                                )
-                                kl_new_old = kl_elem.mean(dim=tuple(range(1, kl_elem.ndim)))
-
-                            # DPPO mask: zero gradient for trust-region violators that
-                            # push the wrong way (ratio>1 & adv>0, or ratio<1 & adv<0).
-                            unclipped_loss = -adv * ratio
-                            violate = kl_new_old >= kl_mask_threshold
-                            pos_rm = violate & (ratio > 1.0) & (adv > 0)
-                            neg_rm = violate & (ratio < 1.0) & (adv < 0)
-                            keep_mask = (
-                                torch.logical_not(pos_rm | neg_rm)
-                                .to(dtype=unclipped_loss.dtype)
-                                .detach()
+                        # Per-step KL(current || old) for the trust-region mask. The x-based mask
+                        # uses the exact variance-scaled Gaussian KL; the v-based mask and the
+                        # ref-KL penalty below use unscaled squared error (GRPO convention).
+                        if kl_mask_type == "v-based":
+                            sq = (output.noise_pred - old_mask_tensor) ** 2
+                            kl_new_old = sq.mean(dim=tuple(range(1, sq.ndim)))
+                        else:
+                            sigma_t = self._effective_sigma(output.std_dev_t, output.dt)
+                            kl_elem = gaussian_kl_div(
+                                output.next_latents_mean, old_mask_tensor, sigma_t
                             )
-                            policy_loss = torch.mean(unclipped_loss * keep_mask)
+                            kl_new_old = kl_elem.mean(dim=tuple(range(1, kl_elem.ndim)))
 
-                            loss = policy_loss
+                        # DPPO mask: zero gradient for trust-region violators that
+                        # push the wrong way (ratio>1 & adv>0, or ratio<1 & adv<0).
+                        unclipped_loss = -adv * ratio
+                        violate = kl_new_old >= kl_mask_threshold
+                        pos_rm = violate & (ratio > 1.0) & (adv > 0)
+                        neg_rm = violate & (ratio < 1.0) & (adv < 0)
+                        keep_mask = (
+                            torch.logical_not(pos_rm | neg_rm)
+                            .to(dtype=unclipped_loss.dtype)
+                            .detach()
+                        )
+                        policy_loss = torch.mean(unclipped_loss * keep_mask)
 
-                            # 4. Optional KL-vs-reference penalty (run at kl_guidance_scale CFG).
-                            # negative_* embeds already rode `sample.to(device)` into `batch`, so the
-                            # ref forward reuses them on-device without an extra move.
-                            if self.enable_kl_loss:
+                        loss = policy_loss
+
+                        # 4. Optional KL-vs-reference penalty (run at kl_guidance_scale CFG).
+                        # negative_* embeds already rode `sample.to(device)` into `batch`, so the
+                        # ref forward reuses them on-device without an extra move.
+                        if self.enable_kl_loss:
+                            with self.autocast():
                                 with torch.no_grad(), self.adapter.use_ref_parameters():
                                     ref_forward_inputs = forward_inputs.copy()
                                     ref_forward_inputs["compute_log_prob"] = False
@@ -265,30 +262,30 @@ class DPPOTrainer(GRPOTrainer):
                                 loss_info["kl_div"].append(kl_div.detach())
                                 loss_info["kl_loss"].append(kl_loss.detach())
 
-                            # 5. Log per-timestep info
-                            keep_frac = keep_mask.mean().detach()
-                            loss_info["ratio"].append(ratio.detach())
-                            loss_info["kl_new_old"].append(kl_new_old.detach())
-                            loss_info["unclipped_loss"].append(unclipped_loss.detach())
-                            loss_info["policy_loss"].append(policy_loss.detach())
-                            loss_info["loss"].append(loss.detach())
-                            loss_info["keep_ratio"].append(keep_frac)
-                            loss_info["masked_ratio"].append(1.0 - keep_frac)
+                        # 5. Log per-timestep info
+                        keep_frac = keep_mask.mean().detach()
+                        loss_info["ratio"].append(ratio.detach())
+                        loss_info["kl_new_old"].append(kl_new_old.detach())
+                        loss_info["unclipped_loss"].append(unclipped_loss.detach())
+                        loss_info["policy_loss"].append(policy_loss.detach())
+                        loss_info["loss"].append(loss.detach())
+                        loss_info["keep_ratio"].append(keep_frac)
+                        loss_info["masked_ratio"].append(1.0 - keep_frac)
 
-                            # 6. Backward and optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info["grad_norm"] = grad_norm
-                                self.log_data(
-                                    {f"train/{k}": v for k, v in loss_info.items()},
-                                    step=self.step,
-                                )
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # 6. Backward and optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info["grad_norm"] = grad_norm
+                            self.log_data(
+                                {f"train/{k}": v for k, v in loss_info.items()},
+                                step=self.step,
+                            )
+                            self.step += 1
+                            loss_info = defaultdict(list)

--- a/src/flow_factory/trainers/grpo.py
+++ b/src/flow_factory/trainers/grpo.py
@@ -128,86 +128,87 @@ class GRPOTrainer(BaseTrainer):
             # Lazy per-batch reload: only the current micro-batch lives on GPU.
             # When samples are GPU-resident `sample.to(device)` is a no-op; when
             # they are CPU-resident (offload pipeline) this is the H2D point.
-            with self.autocast():
-                for batch_idx in tqdm(
-                    range(num_batches),
-                    total=num_batches,
-                    desc=f'Epoch {self.epoch} Training',
-                    position=0,
+            for batch_idx in tqdm(
+                range(num_batches),
+                total=num_batches,
+                desc=f'Epoch {self.epoch} Training',
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                start = batch_idx * per_device_batch_size
+                batch_samples = [
+                    sample.to(device)
+                    for sample in shuffled_samples[start:start + per_device_batch_size]
+                ]
+                batch = BaseSample.stack(batch_samples)
+                latents_index_map = batch['latent_index_map']  # (T+1,) LongTensor
+                log_probs_index_map = batch['log_prob_index_map']  # (T,) LongTensor
+                # Iterate through timesteps
+                for idx, timestep_index in enumerate(tqdm(
+                    self.adapter.scheduler.train_timesteps,
+                    desc=f'Epoch {self.epoch} Timestep',
+                    position=1,
+                    leave=False,
                     disable=not self.show_progress_bar,
-                ):
-                    start = batch_idx * per_device_batch_size
-                    batch_samples = [
-                        sample.to(device)
-                        for sample in shuffled_samples[start:start + per_device_batch_size]
-                    ]
-                    batch = BaseSample.stack(batch_samples)
-                    latents_index_map = batch['latent_index_map']  # (T+1,) LongTensor
-                    log_probs_index_map = batch['log_prob_index_map']  # (T,) LongTensor
-                    # Iterate through timesteps
-                    for idx, timestep_index in enumerate(tqdm(
-                        self.adapter.scheduler.train_timesteps,
-                        desc=f'Epoch {self.epoch} Timestep',
-                        position=1,
-                        leave=False,
-                        disable=not self.show_progress_bar,
-                    )):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            # 1. Prepare inputs
-                            # Get old log prob
-                            old_log_prob = batch['log_probs'][:, log_probs_index_map[timestep_index]]
-                            # Get current timestep data
-                            num_timesteps = batch['timesteps'].shape[1]
-                            t = batch['timesteps'][:, timestep_index]
-                            t_next = (
-                                batch['timesteps'][:, timestep_index + 1]
-                                if timestep_index + 1 < num_timesteps
-                                else torch.tensor(0, device=self.accelerator.device)
-                            )
-                            # Get latents
-                            latents = batch['all_latents'][:, latents_index_map[timestep_index]]
-                            next_latents = batch['all_latents'][:, latents_index_map[timestep_index + 1]]
-                            # Prepare forward input
-                            forward_inputs = {
-                                **self.training_args, # Pass kwargs like `guidance_scale` and `do_classifier_free_guidance`
-                                't': t,
-                                't_next': t_next,
-                                'latents': latents,
-                                'next_latents': next_latents,
-                                'compute_log_prob': True,
-                                'noise_level': self.adapter.scheduler.noise_level,
-                                **batch
-                            }
-                            forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
-                            # 2. Forward pass
-                            if self.enable_kl_loss:
-                                if self.training_args.kl_type == 'v-based':
-                                    return_kwargs = ['log_prob', 'noise_pred', 'dt']
-                                elif self.training_args.kl_type == 'x-based':
-                                    return_kwargs = ['log_prob', 'next_latents', 'next_latents_mean', 'dt']
-                            else:
-                                return_kwargs = ['log_prob', 'dt']
-                            
-                            forward_inputs['return_kwargs'] = return_kwargs
+                )):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        # 1. Prepare inputs
+                        # Get old log prob
+                        old_log_prob = batch['log_probs'][:, log_probs_index_map[timestep_index]]
+                        # Get current timestep data
+                        num_timesteps = batch['timesteps'].shape[1]
+                        t = batch['timesteps'][:, timestep_index]
+                        t_next = (
+                            batch['timesteps'][:, timestep_index + 1]
+                            if timestep_index + 1 < num_timesteps
+                            else torch.tensor(0, device=self.accelerator.device)
+                        )
+                        # Get latents
+                        latents = batch['all_latents'][:, latents_index_map[timestep_index]]
+                        next_latents = batch['all_latents'][:, latents_index_map[timestep_index + 1]]
+                        # Prepare forward input
+                        forward_inputs = {
+                            **self.training_args, # Pass kwargs like `guidance_scale` and `do_classifier_free_guidance`
+                            't': t,
+                            't_next': t_next,
+                            'latents': latents,
+                            'next_latents': next_latents,
+                            'compute_log_prob': True,
+                            'noise_level': self.adapter.scheduler.noise_level,
+                            **batch
+                        }
+                        forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
+                        # 2. Forward pass
+                        if self.enable_kl_loss:
+                            if self.training_args.kl_type == 'v-based':
+                                return_kwargs = ['log_prob', 'noise_pred', 'dt']
+                            elif self.training_args.kl_type == 'x-based':
+                                return_kwargs = ['log_prob', 'next_latents', 'next_latents_mean', 'dt']
+                        else:
+                            return_kwargs = ['log_prob', 'dt']
+
+                        forward_inputs['return_kwargs'] = return_kwargs
+                        with self.autocast():
                             output = self.adapter.forward(**forward_inputs)
 
-                            # 3. Compute loss
-                            # Clip advantages
-                            adv = batch['advantage']
-                            adv_clip_range = self.training_args.adv_clip_range
-                            adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
-                            # PPO-style clipped loss
-                            ratio = torch.exp(output.log_prob - old_log_prob)
-                            ratio_clip_range = self.training_args.clip_range
+                        # 3. Compute loss
+                        # Clip advantages
+                        adv = batch['advantage']
+                        adv_clip_range = self.training_args.adv_clip_range
+                        adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
+                        # PPO-style clipped loss
+                        ratio = torch.exp(output.log_prob - old_log_prob)
+                        ratio_clip_range = self.training_args.clip_range
 
-                            unclipped_loss = -adv * ratio
-                            clipped_loss = -adv * torch.clamp(ratio, 1.0 + ratio_clip_range[0], 1.0 + ratio_clip_range[1])
-                            policy_loss = torch.mean(torch.maximum(unclipped_loss, clipped_loss))
+                        unclipped_loss = -adv * ratio
+                        clipped_loss = -adv * torch.clamp(ratio, 1.0 + ratio_clip_range[0], 1.0 + ratio_clip_range[1])
+                        policy_loss = torch.mean(torch.maximum(unclipped_loss, clipped_loss))
 
-                            loss = policy_loss
+                        loss = policy_loss
 
-                            # 4. Compute KL-div
-                            if self.enable_kl_loss:
+                        # 4. Compute KL-div
+                        if self.enable_kl_loss:
+                            with self.autocast():
                                 with torch.no_grad(), self.adapter.use_ref_parameters():
                                     ref_forward_inputs = forward_inputs.copy()
                                     ref_forward_inputs['compute_log_prob'] = False
@@ -232,43 +233,43 @@ class GRPOTrainer(BaseTrainer):
                                         ((output.next_latents_mean - ref_output.next_latents_mean) ** 2),
                                         dim=tuple(range(1, output.next_latents_mean.ndim)), keepdim=True
                                     )
-                                
+
                                 kl_div = torch.mean(kl_div)
                                 kl_loss = self.training_args.kl_beta * kl_div
                                 loss += kl_loss
                                 loss_info['kl_div'].append(kl_div.detach())
                                 loss_info['kl_loss'].append(kl_loss.detach())
 
-                            # 5. Log per-timestep info
-                            loss_info['ratio'].append(ratio.detach())
-                            loss_info['unclipped_loss'].append(unclipped_loss.detach())
-                            loss_info['clipped_loss'].append(clipped_loss.detach())
-                            loss_info['policy_loss'].append(policy_loss.detach())
-                            loss_info['loss'].append(loss.detach())
-                            clip_frac_high = torch.mean((ratio > 1.0 + ratio_clip_range[1]).float())
-                            clip_frac_low = torch.mean((ratio < 1.0 + ratio_clip_range[0]).float())
-                            loss_info["clip_frac_high"].append(clip_frac_high.detach())
-                            loss_info["clip_frac_low"].append(clip_frac_low.detach())
-                            loss_info['clip_frac_total'].append((clip_frac_high + clip_frac_low).detach())
+                        # 5. Log per-timestep info
+                        loss_info['ratio'].append(ratio.detach())
+                        loss_info['unclipped_loss'].append(unclipped_loss.detach())
+                        loss_info['clipped_loss'].append(clipped_loss.detach())
+                        loss_info['policy_loss'].append(policy_loss.detach())
+                        loss_info['loss'].append(loss.detach())
+                        clip_frac_high = torch.mean((ratio > 1.0 + ratio_clip_range[1]).float())
+                        clip_frac_low = torch.mean((ratio < 1.0 + ratio_clip_range[0]).float())
+                        loss_info["clip_frac_high"].append(clip_frac_high.detach())
+                        loss_info["clip_frac_low"].append(clip_frac_low.detach())
+                        loss_info['clip_frac_total'].append((clip_frac_high + clip_frac_low).detach())
 
-                            # 6. Backward and optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                # Communicate and log losses
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info['grad_norm'] = grad_norm
-                                self.log_data(
-                                    {f'train/{k}': v for k, v in loss_info.items()},
-                                    step=self.step,
-                                )
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # 6. Backward and optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            # Communicate and log losses
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info['grad_norm'] = grad_norm
+                            self.log_data(
+                                {f'train/{k}': v for k, v in loss_info.items()},
+                                step=self.step,
+                            )
+                            self.step += 1
+                            loss_info = defaultdict(list)
 
     # =========================== Advantage Computation ============================
     def compute_advantages(
@@ -356,90 +357,91 @@ class GRPOGuardTrainer(GRPOTrainer):
             loss_info = defaultdict(list)
 
             # Lazy per-batch reload: only the current micro-batch lives on GPU.
-            with self.autocast():
-                for batch_idx in tqdm(
-                    range(num_batches),
-                    total=num_batches,
-                    desc=f'Epoch {self.epoch} Training',
-                    position=0,
+            for batch_idx in tqdm(
+                range(num_batches),
+                total=num_batches,
+                desc=f'Epoch {self.epoch} Training',
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                start = batch_idx * per_device_batch_size
+                batch_samples = [
+                    sample.to(device)
+                    for sample in shuffled_samples[start:start + per_device_batch_size]
+                ]
+                batch = BaseSample.stack(batch_samples)
+                latents_index_map = batch['latent_index_map']  # (T+1,) LongTensor
+                log_probs_index_map = batch['log_prob_index_map']  # (T,) LongTensor
+                callback_index_map = batch['callback_index_map'][0]  # (T,) LongTensor, shared across batch.
+                # Iterate through timesteps
+                for idx, timestep_index in enumerate(tqdm(
+                    self.adapter.scheduler.train_timesteps,
+                    desc=f'Epoch {self.epoch} Timestep',
+                    position=1,
+                    leave=False,
                     disable=not self.show_progress_bar,
-                ):
-                    start = batch_idx * per_device_batch_size
-                    batch_samples = [
-                        sample.to(device)
-                        for sample in shuffled_samples[start:start + per_device_batch_size]
-                    ]
-                    batch = BaseSample.stack(batch_samples)
-                    latents_index_map = batch['latent_index_map']  # (T+1,) LongTensor
-                    log_probs_index_map = batch['log_prob_index_map']  # (T,) LongTensor
-                    callback_index_map = batch['callback_index_map'][0]  # (T,) LongTensor, shared across batch.
-                    # Iterate through timesteps
-                    for idx, timestep_index in enumerate(tqdm(
-                        self.adapter.scheduler.train_timesteps,
-                        desc=f'Epoch {self.epoch} Timestep',
-                        position=1,
-                        leave=False,
-                        disable=not self.show_progress_bar,
-                    )):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            # 1. Prepare inputs
-                            # Get old log prob
-                            old_log_prob = batch['log_probs'][:, log_probs_index_map[timestep_index]]
-                            # Get current timestep data
-                            num_timesteps = batch['timesteps'].shape[1]
-                            t = batch['timesteps'][:, timestep_index]
-                            t_next = (
-                                batch['timesteps'][:, timestep_index + 1]
-                                if timestep_index + 1 < num_timesteps
-                                else torch.tensor(0, device=self.accelerator.device)
-                            )
-                            # Get latents
-                            latents = batch['all_latents'][:, latents_index_map[timestep_index]]
-                            next_latents = batch['all_latents'][:, latents_index_map[timestep_index + 1]]
-                            # Prepare forward input
-                            forward_inputs = {
-                                **self.training_args, # Pass kwargs like `guidance_scale` and `do_classifier_free_guidance`
-                                't': t,
-                                't_next': t_next,
-                                'latents': latents,
-                                'next_latents': next_latents,
-                                'compute_log_prob': True,
-                                'noise_level': self.adapter.scheduler.noise_level,
-                                **batch
-                            }
-                            forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
-                            # 2. Forward pass
-                            return_kwargs = set(['log_prob', 'next_latents_mean', 'std_dev_t', 'dt'])
-                            if self.enable_kl_loss:
-                                if self.training_args.kl_type == 'v-based':
-                                    return_kwargs.add('noise_pred')
-                                elif self.training_args.kl_type == 'x-based':
-                                    return_kwargs.add('next_latents_mean')
-                            
-                            forward_inputs['return_kwargs'] = list(return_kwargs)
+                )):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        # 1. Prepare inputs
+                        # Get old log prob
+                        old_log_prob = batch['log_probs'][:, log_probs_index_map[timestep_index]]
+                        # Get current timestep data
+                        num_timesteps = batch['timesteps'].shape[1]
+                        t = batch['timesteps'][:, timestep_index]
+                        t_next = (
+                            batch['timesteps'][:, timestep_index + 1]
+                            if timestep_index + 1 < num_timesteps
+                            else torch.tensor(0, device=self.accelerator.device)
+                        )
+                        # Get latents
+                        latents = batch['all_latents'][:, latents_index_map[timestep_index]]
+                        next_latents = batch['all_latents'][:, latents_index_map[timestep_index + 1]]
+                        # Prepare forward input
+                        forward_inputs = {
+                            **self.training_args, # Pass kwargs like `guidance_scale` and `do_classifier_free_guidance`
+                            't': t,
+                            't_next': t_next,
+                            'latents': latents,
+                            'next_latents': next_latents,
+                            'compute_log_prob': True,
+                            'noise_level': self.adapter.scheduler.noise_level,
+                            **batch
+                        }
+                        forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
+                        # 2. Forward pass
+                        return_kwargs = set(['log_prob', 'next_latents_mean', 'std_dev_t', 'dt'])
+                        if self.enable_kl_loss:
+                            if self.training_args.kl_type == 'v-based':
+                                return_kwargs.add('noise_pred')
+                            elif self.training_args.kl_type == 'x-based':
+                                return_kwargs.add('next_latents_mean')
+
+                        forward_inputs['return_kwargs'] = list(return_kwargs)
+                        with self.autocast():
                             output = self.adapter.forward(**forward_inputs)
 
-                            # 3. Compute loss
-                            # Clip advantages
-                            adv = batch['advantage']
-                            adv_clip_range = self.training_args.adv_clip_range
-                            adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
-                            # Reweighted ratio
-                            scale_factor = torch.sqrt(-output.dt) * output.std_dev_t
-                            old_next_latents_mean = batch['next_latents_mean'][:, callback_index_map[timestep_index]]
-                            mse = (output.next_latents_mean - old_next_latents_mean).flatten(1).pow(2).mean(dim=1)
-                            ratio = torch.exp((output.log_prob - old_log_prob) * scale_factor + mse / (2 * scale_factor))
-                            # PPO-style clipped loss
-                            ratio_clip_range = self.training_args.clip_range
+                        # 3. Compute loss
+                        # Clip advantages
+                        adv = batch['advantage']
+                        adv_clip_range = self.training_args.adv_clip_range
+                        adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
+                        # Reweighted ratio
+                        scale_factor = torch.sqrt(-output.dt) * output.std_dev_t
+                        old_next_latents_mean = batch['next_latents_mean'][:, callback_index_map[timestep_index]]
+                        mse = (output.next_latents_mean - old_next_latents_mean).flatten(1).pow(2).mean(dim=1)
+                        ratio = torch.exp((output.log_prob - old_log_prob) * scale_factor + mse / (2 * scale_factor))
+                        # PPO-style clipped loss
+                        ratio_clip_range = self.training_args.clip_range
 
-                            unclipped_loss = -adv * ratio
-                            clipped_loss = -adv * torch.clamp(ratio, 1.0 + ratio_clip_range[0], 1.0 + ratio_clip_range[1])
-                            policy_loss = torch.mean(torch.maximum(unclipped_loss, clipped_loss))
+                        unclipped_loss = -adv * ratio
+                        clipped_loss = -adv * torch.clamp(ratio, 1.0 + ratio_clip_range[0], 1.0 + ratio_clip_range[1])
+                        policy_loss = torch.mean(torch.maximum(unclipped_loss, clipped_loss))
 
-                            loss = policy_loss
+                        loss = policy_loss
 
-                            # 4. Compute KL-div
-                            if self.enable_kl_loss:
+                        # 4. Compute KL-div
+                        if self.enable_kl_loss:
+                            with self.autocast():
                                 with torch.no_grad(), self.adapter.use_ref_parameters():
                                     ref_forward_inputs = forward_inputs.copy()
                                     ref_forward_inputs['compute_log_prob'] = False
@@ -471,33 +473,33 @@ class GRPOGuardTrainer(GRPOTrainer):
                                 loss_info['kl_div'].append(kl_div.detach())
                                 loss_info['kl_loss'].append(kl_loss.detach())
 
-                            # 5. Log per-timestep info
-                            loss_info['ratio'].append(ratio.detach())
-                            loss_info['unclipped_loss'].append(unclipped_loss.detach())
-                            loss_info['clipped_loss'].append(clipped_loss.detach())
-                            loss_info['policy_loss'].append(policy_loss.detach())
-                            loss_info['loss'].append(loss.detach())
-                            clip_frac_high = torch.mean((ratio > 1.0 + ratio_clip_range[1]).float())
-                            clip_frac_low = torch.mean((ratio < 1.0 + ratio_clip_range[0]).float())
-                            loss_info["clip_frac_high"].append(clip_frac_high.detach())
-                            loss_info["clip_frac_low"].append(clip_frac_low.detach())
-                            loss_info['clip_frac_total'].append((clip_frac_high + clip_frac_low).detach())
+                        # 5. Log per-timestep info
+                        loss_info['ratio'].append(ratio.detach())
+                        loss_info['unclipped_loss'].append(unclipped_loss.detach())
+                        loss_info['clipped_loss'].append(clipped_loss.detach())
+                        loss_info['policy_loss'].append(policy_loss.detach())
+                        loss_info['loss'].append(loss.detach())
+                        clip_frac_high = torch.mean((ratio > 1.0 + ratio_clip_range[1]).float())
+                        clip_frac_low = torch.mean((ratio < 1.0 + ratio_clip_range[0]).float())
+                        loss_info["clip_frac_high"].append(clip_frac_high.detach())
+                        loss_info["clip_frac_low"].append(clip_frac_low.detach())
+                        loss_info['clip_frac_total'].append((clip_frac_high + clip_frac_low).detach())
 
-                            # 6. Backward and optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                # Communicate and log losses
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info['grad_norm'] = grad_norm
-                                self.log_data(
-                                    {f'train/{k}': v for k, v in loss_info.items()},
-                                    step=self.step,
-                                )
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # 6. Backward and optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            # Communicate and log losses
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info['grad_norm'] = grad_norm
+                            self.log_data(
+                                {f'train/{k}': v for k, v in loss_info.items()},
+                                step=self.step,
+                            )
+                            self.step += 1
+                            loss_info = defaultdict(list)

--- a/src/flow_factory/trainers/nft.py
+++ b/src/flow_factory/trainers/nft.py
@@ -304,62 +304,63 @@ class DiffusionNFTTrainer(BaseTrainer):
 
                 # ---------- Train this batch under current policy ----------
                 self.adapter.train()
-                with self.autocast():
-                    for t_idx in tqdm(
-                        range(self.num_train_timesteps),
-                        desc=f'Epoch {self.epoch} Timestep',
-                        position=1,
-                        leave=False,
-                        disable=not self.show_progress_bar,
-                    ):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
-                            # 1. Prepare inputs
-                            t_flat = all_timesteps[t_idx]  # (B,) [0, 1000]
-                            sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
-                            noise = all_random_noise[t_idx]
-                            noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
-                            old_v_pred = old_v_pred_list[t_idx]
+                for t_idx in tqdm(
+                    range(self.num_train_timesteps),
+                    desc=f'Epoch {self.epoch} Timestep',
+                    position=1,
+                    leave=False,
+                    disable=not self.show_progress_bar,
+                ):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        # 1. Prepare inputs
+                        t_flat = all_timesteps[t_idx]  # (B,) [0, 1000]
+                        sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
+                        noise = all_random_noise[t_idx]
+                        noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
+                        old_v_pred = old_v_pred_list[t_idx]
 
-                            # 2. Forward pass for current policy
+                        # 2. Forward pass for current policy
+                        with self.autocast():
                             output = self._compute_nft_output(batch, t_flat, noised_latents)
-                            new_v_pred = output['noise_pred']
-                            
-                            # 3. Compute NFT loss
-                            adv = batch['advantage']
-                            adv_clip_range = self.training_args.adv_clip_range
-                            adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
-                            
-                            # Normalize advantage to [0, 1]
-                            normalized_adv = (adv / max(adv_clip_range)) / 2.0 + 0.5
-                            r = torch.clamp(normalized_adv, 0, 1).view(-1, *([1] * (new_v_pred.dim() - 1)))
-                            
-                            # Positive/negative predictions
-                            positive_pred = self.nft_beta * new_v_pred + (1 - self.nft_beta) * old_v_pred
-                            negative_pred = (1.0 + self.nft_beta) * old_v_pred - self.nft_beta * new_v_pred
-                            
-                            # Positive loss
-                            x0_pred = noised_latents - sigma_broadcast * positive_pred
-                            with torch.no_grad():
-                                weight = torch.abs(x0_pred.double() - clean_latents.double()).mean(
-                                    dim=tuple(range(1, clean_latents.ndim)), keepdim=True
-                                ).clip(min=1e-5)
-                            positive_loss = ((x0_pred - clean_latents) ** 2 / weight).mean(dim=tuple(range(1, clean_latents.ndim)))
-                            
-                            # Negative loss
-                            neg_x0_pred = noised_latents - sigma_broadcast * negative_pred
-                            with torch.no_grad():
-                                neg_weight = torch.abs(neg_x0_pred.double() - clean_latents.double()).mean(
-                                    dim=tuple(range(1, clean_latents.ndim)), keepdim=True
-                                ).clip(min=1e-5)
-                            negative_loss = ((neg_x0_pred - clean_latents) ** 2 / neg_weight).mean(dim=tuple(range(1, clean_latents.ndim)))
-                            
-                            # Combined loss
-                            ori_policy_loss = (r.squeeze() * positive_loss + (1.0 - r.squeeze()) * negative_loss) / self.nft_beta
-                            policy_loss = (ori_policy_loss * adv_clip_range[1]).mean()
-                            loss = policy_loss
-                            
-                            # 4. KL penalty
-                            if self.enable_kl_loss:
+                        new_v_pred = output['noise_pred']
+
+                        # 3. Compute NFT loss
+                        adv = batch['advantage']
+                        adv_clip_range = self.training_args.adv_clip_range
+                        adv = torch.clamp(adv, adv_clip_range[0], adv_clip_range[1])
+
+                        # Normalize advantage to [0, 1]
+                        normalized_adv = (adv / max(adv_clip_range)) / 2.0 + 0.5
+                        r = torch.clamp(normalized_adv, 0, 1).view(-1, *([1] * (new_v_pred.dim() - 1)))
+
+                        # Positive/negative predictions
+                        positive_pred = self.nft_beta * new_v_pred + (1 - self.nft_beta) * old_v_pred
+                        negative_pred = (1.0 + self.nft_beta) * old_v_pred - self.nft_beta * new_v_pred
+
+                        # Positive loss
+                        x0_pred = noised_latents - sigma_broadcast * positive_pred
+                        with torch.no_grad():
+                            weight = torch.abs(x0_pred.double() - clean_latents.double()).mean(
+                                dim=tuple(range(1, clean_latents.ndim)), keepdim=True
+                            ).clip(min=1e-5)
+                        positive_loss = ((x0_pred - clean_latents) ** 2 / weight).mean(dim=tuple(range(1, clean_latents.ndim)))
+
+                        # Negative loss
+                        neg_x0_pred = noised_latents - sigma_broadcast * negative_pred
+                        with torch.no_grad():
+                            neg_weight = torch.abs(neg_x0_pred.double() - clean_latents.double()).mean(
+                                dim=tuple(range(1, clean_latents.ndim)), keepdim=True
+                            ).clip(min=1e-5)
+                        negative_loss = ((neg_x0_pred - clean_latents) ** 2 / neg_weight).mean(dim=tuple(range(1, clean_latents.ndim)))
+
+                        # Combined loss
+                        ori_policy_loss = (r.squeeze() * positive_loss + (1.0 - r.squeeze()) * negative_loss) / self.nft_beta
+                        policy_loss = (ori_policy_loss * adv_clip_range[1]).mean()
+                        loss = policy_loss
+
+                        # 4. KL penalty
+                        if self.enable_kl_loss:
+                            with self.autocast():
                                 with torch.no_grad(), self.adapter.use_ref_parameters():
                                     ref_output = self._compute_nft_output(batch, t_flat, noised_latents)
                                 # KL-loss in v-space
@@ -372,23 +373,23 @@ class DiffusionNFTTrainer(BaseTrainer):
                                 loss_info['kl_div'].append(kl_div.detach())
                                 loss_info['kl_loss'].append(kl_loss.detach())
 
-                            # 5. Log per-timestep info
-                            loss_info['policy_loss'].append(policy_loss.detach())
-                            loss_info['unweighted_policy_loss'].append(ori_policy_loss.mean().detach())
-                            loss_info['loss'].append(loss.detach())
-                                
-                            # 6. Backward and optimizer step
-                            self.accelerator.backward(loss)
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                # Log loss info
-                                loss_info = reduce_loss_info(self.accelerator, loss_info)
-                                loss_info['grad_norm'] = grad_norm
-                                self.log_data({f'train/{k}': v for k, v in loss_info.items()}, step=self.step)
-                                self.step += 1
-                                loss_info = defaultdict(list)
+                        # 5. Log per-timestep info
+                        loss_info['policy_loss'].append(policy_loss.detach())
+                        loss_info['unweighted_policy_loss'].append(ori_policy_loss.mean().detach())
+                        loss_info['loss'].append(loss.detach())
+
+                        # 6. Backward and optimizer step
+                        self.accelerator.backward(loss)
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            # Log loss info
+                            loss_info = reduce_loss_info(self.accelerator, loss_info)
+                            loss_info['grad_norm'] = grad_norm
+                            self.log_data({f'train/{k}': v for k, v in loss_info.items()}, step=self.step)
+                            self.step += 1
+                            loss_info = defaultdict(list)

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -293,46 +293,46 @@ class DiffusionOPDTrainer(BaseTrainer):
             teacher_kl_count = torch.zeros(num_teachers, device=device)
             grad_norm = None
 
-            with self.autocast():
-                for batch_idx in tqdm(
-                    range(num_batches),
-                    total=num_batches,
-                    desc=f"Epoch {self.epoch} Distill",
-                    position=0,
-                    disable=not self.show_progress_bar,
-                ):
-                    start = batch_idx * per_device_batch_size
-                    batch_samples = [
-                        s.to(device)
-                        for s in shuffled_samples[start : start + per_device_batch_size]
-                    ]
-                    # Teacher index per sample in this (possibly source-mixed) micro-batch.
-                    teacher_idx = torch.tensor(
-                        [self._teacher_index_for_sample(s) for s in batch_samples],
-                        device=device,
-                        dtype=torch.long,
-                    )  # (B,)
-                    batch = BaseSample.stack(batch_samples)
-                    # extra_kwargs tensors are not moved by BaseSample.to(); move explicitly.
-                    mu_teacher_all = batch["mu_teacher"]
-                    if not isinstance(mu_teacher_all, torch.Tensor):
-                        raise RuntimeError(
-                            "Expected cached teacher means `mu_teacher` (a tensor) on every "
-                            f"sample, got {type(mu_teacher_all).__name__}. PASS 1 "
-                            "(_precompute_teacher_targets) must run before PASS 2."
-                        )
-                    mu_teacher_all = mu_teacher_all.to(device)
+            for batch_idx in tqdm(
+                range(num_batches),
+                total=num_batches,
+                desc=f"Epoch {self.epoch} Distill",
+                position=0,
+                disable=not self.show_progress_bar,
+            ):
+                start = batch_idx * per_device_batch_size
+                batch_samples = [
+                    s.to(device)
+                    for s in shuffled_samples[start : start + per_device_batch_size]
+                ]
+                # Teacher index per sample in this (possibly source-mixed) micro-batch.
+                teacher_idx = torch.tensor(
+                    [self._teacher_index_for_sample(s) for s in batch_samples],
+                    device=device,
+                    dtype=torch.long,
+                )  # (B,)
+                batch = BaseSample.stack(batch_samples)
+                # extra_kwargs tensors are not moved by BaseSample.to(); move explicitly.
+                mu_teacher_all = batch["mu_teacher"]
+                if not isinstance(mu_teacher_all, torch.Tensor):
+                    raise RuntimeError(
+                        "Expected cached teacher means `mu_teacher` (a tensor) on every "
+                        f"sample, got {type(mu_teacher_all).__name__}. PASS 1 "
+                        "(_precompute_teacher_targets) must run before PASS 2."
+                    )
+                mu_teacher_all = mu_teacher_all.to(device)
 
-                    for idx, timestep_index in enumerate(
-                        tqdm(
-                            train_timesteps,
-                            desc=f"Epoch {self.epoch} Timestep",
-                            position=1,
-                            leave=False,
-                            disable=not self.show_progress_bar,
-                        )
-                    ):
-                        with self.accelerator.accumulate(*self.adapter.trainable_components):
+                for idx, timestep_index in enumerate(
+                    tqdm(
+                        train_timesteps,
+                        desc=f"Epoch {self.epoch} Timestep",
+                        position=1,
+                        leave=False,
+                        disable=not self.show_progress_bar,
+                    )
+                ):
+                    with self.accelerator.accumulate(*self.adapter.trainable_components):
+                        with self.autocast():
                             # mu_S: (B, *latent) student transition mean at this step.
                             mu_S, std_dev_t, dt = self._forward_step(
                                 batch,
@@ -359,28 +359,28 @@ class DiffusionOPDTrainer(BaseTrainer):
                             per_sample_kl = 0.5 * (per_sample_mse / denom)  # (B,)
                             loss = per_sample_kl.mean()  # scalar (mean over batch)
 
-                            self.accelerator.backward(loss)
+                        self.accelerator.backward(loss)
 
-                            # Accumulate per-teacher KL sums/counts for logging (detached).
-                            with torch.no_grad():
-                                teacher_kl_sum.index_add_(0, teacher_idx, per_sample_kl.detach())
-                                teacher_kl_count.index_add_(
-                                    0, teacher_idx, torch.ones_like(per_sample_kl)
-                                )
+                        # Accumulate per-teacher KL sums/counts for logging (detached).
+                        with torch.no_grad():
+                            teacher_kl_sum.index_add_(0, teacher_idx, per_sample_kl.detach())
+                            teacher_kl_count.index_add_(
+                                0, teacher_idx, torch.ones_like(per_sample_kl)
+                            )
 
-                            if self.accelerator.sync_gradients:
-                                grad_norm = self.accelerator.clip_grad_norm_(
-                                    self.adapter.get_trainable_parameters(),
-                                    self.training_args.max_grad_norm,
-                                )
-                                self.optimizer.step()
-                                self.optimizer.zero_grad()
-                                self._log_distill_metrics(
-                                    teacher_kl_sum, teacher_kl_count, grad_norm
-                                )
-                                self.step += 1
-                                teacher_kl_sum.zero_()
-                                teacher_kl_count.zero_()
+                        if self.accelerator.sync_gradients:
+                            grad_norm = self.accelerator.clip_grad_norm_(
+                                self.adapter.get_trainable_parameters(),
+                                self.training_args.max_grad_norm,
+                            )
+                            self.optimizer.step()
+                            self.optimizer.zero_grad()
+                            self._log_distill_metrics(
+                                teacher_kl_sum, teacher_kl_count, grad_norm
+                            )
+                            self.step += 1
+                            teacher_kl_sum.zero_()
+                            teacher_kl_count.zero_()
 
     # =============================== Helpers ===============================
     def _log_distill_metrics(


### PR DESCRIPTION
## Summary
- `torch.autocast`'s weight cache (keyed by tensor `data_ptr`) serves **stale** fp32->bf16 casts after any in-place weight change. A single outer `with self.autocast()` around an `optimize()` loop masked both `optimizer.step()` updates and ref/EMA parameter swaps (`param.data.copy_`). For `master_weight_dtype: fp32` runs this froze training (flat loss) and collapsed KL to ~0. Dormant for the bf16-master default (nothing cached) and for LoRA's `disable_adapter()` ref path.
- Move autocast to **per-forward** across all trainers (GRPO, GRPO-Guard, DPPO, NFT, AWM, CRD, DGPO, DPO, DiffusionOPD): each policy / ref / EMA / old / teacher forward (and its KL math) gets its own `with self.autocast():`; precompute/sampling regions keep their outer autocast (weights constant). Per-forward (rather than `cache_enabled=False`) preserves the intra-forward cast reuse that two-pass-CFG adapters (e.g. qwen-image-edit) rely on.
- Document the invariant as constraint **#20a** + new `topics/autocast_param_swap.md`, and route the relevant knowledge docs / skills to it.

## Test plan
- [ ] Full-finetune `master_weight_dtype: fp32` + `kl_beta>0`: loss now descends and KL is non-zero (was flat / ~0 before).
- [ ] bf16-master default and LoRA runs unchanged (cache never activated).
- [ ] Micro-check: an in-place ref swap inside the new per-forward autocast yields a different ref output (no longer identical to the policy forward).
- [ ] Distributed: under DDP and DeepSpeed ZeRO-2, confirm the ref/EMA forward reflects the swap (see DDP/DeepSpeed caveat in `topics/autocast_param_swap.md`); port `bypass_ddp_for_weight_swap` only if a ref forward still returns the policy output.
- [ ] `black --check` / `isort --check` with the repo's pinned versions (changes match existing per-file style; `dppo.py` kept black-clean).

Made with [Cursor](https://cursor.com)