### PR TITLE
[models,docs] feat: run LTX2 audio latent through SDE as a video-scheduler twin

### DIFF
--- a/.agents/knowledge/topics/parity_testing.md
+++ b/.agents/knowledge/topics/parity_testing.md
@@ -33,7 +33,7 @@ Test stages in dependency order. When a stage fails, fix it before testing downs
 5. **VAE scaling factor**: Pipeline applies `vae.config.scaling_factor` during encode/decode. Adapter must apply the same factor at the same point.
 6. **`do_classifier_free_guidance` batching**: Pipeline concatenates conditional + unconditional embeddings along batch dim. Adapter must replicate this exactly if the model expects it.
 7. **Timestep offset**: Some schedulers use `timestep_spacing="trailing"` — adapter must match the pipeline's scheduler config exactly.
-8. **Dual-modality scheduling**: Models with video+audio (e.g., LTX2-T2AV) need separate scheduler instances. Sharing one scheduler corrupts `step_index` for the second modality.
+8. **Dual-modality scheduling**: Models with video+audio (e.g., LTX2-T2AV) need separate scheduler instances. Sharing one scheduler corrupts `step_index` for the second modality. The audio scheduler is a config twin of the video scheduler (built via `self.load_scheduler()`), so both modalities run the **same** SDE dynamics and form a single joint policy; their per-step log-probs are merged with an element-weighted mean (`models/ltx2/_common.py::combine_modality_log_prob`). The two instances differ only in their independent `step_index`.
 
 ## Parity Helper: `compare_tensors()`
 

--- a/src/flow_factory/models/ltx2/_common.py
+++ b/src/flow_factory/models/ltx2/_common.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# src/flow_factory/models/ltx2/_common.py
+"""Shared helpers for the LTX2 (T2AV / I2AV) adapters."""
+from __future__ import annotations
+
+import torch
+
+
+def combine_modality_log_prob(
+    video_log_prob: torch.Tensor,
+    audio_log_prob: torch.Tensor,
+    n_video: int,
+    n_audio: int,
+) -> torch.Tensor:
+    """Element-weighted mean of the per-step video/audio log-probs.
+
+    LTX2 steps video and audio with two scheduler instances, each returning a
+    per-sample log_prob already meaned over its own latent dims. Weighting by the
+    element counts ``n_video`` / ``n_audio`` reproduces the mean that a single
+    scheduler over the concatenated ``[video|audio]`` latent would produce (mean
+    over all latent dims), so the joint log_prob keeps the same scale as the
+    original video-only path.
+
+    Args:
+        video_log_prob: Per-sample video log_prob, shape ``(B,)``.
+        audio_log_prob: Per-sample audio log_prob, shape ``(B,)``.
+        n_video: Number of video latent elements per sample (the tensor passed to
+            the video ``step()``).
+        n_audio: Number of audio latent elements per sample.
+
+    Returns:
+        Per-sample joint log_prob, shape ``(B,)``.
+    """
+    total = n_video + n_audio
+    return (video_log_prob * n_video + audio_log_prob * n_audio) / total

--- a/src/flow_factory/models/ltx2/ltx2_i2av.py
+++ b/src/flow_factory/models/ltx2/ltx2_i2av.py
@@ -51,6 +51,7 @@ from ...utils.trajectory_collector import (
     create_trajectory_collector,
 )
 from ..abc import BaseAdapter
+from ._common import combine_modality_log_prob
 
 logger = setup_logger(__name__)
 
@@ -166,21 +167,18 @@ class LTX2_I2AV_Adapter(BaseAdapter):
         )
 
     def _create_audio_scheduler(self) -> FlowMatchEulerDiscreteSDEScheduler:
-        """Create a separate ODE-only scheduler for audio.
+        """Create a twin of the video scheduler for the audio modality.
 
-        A dedicated instance is needed because scheduler.step() mutates internal
-        state (step_index), which would conflict if shared with the video scheduler.
+        Audio is sampled with the same SDE dynamics as video so that both
+        modalities form a single joint policy whose per-step log_prob feeds the
+        GRPO objective. A dedicated instance is still required because
+        scheduler.step() mutates internal state (step_index), which would
+        conflict if shared with the video scheduler. ``load_scheduler`` rebuilds
+        an independent scheduler from the same pipeline scheduler + scheduler
+        args used for ``self.scheduler`` (which ``super().__init__`` has already
+        built at this point).
         """
-        base_config = {
-            k: v
-            for k, v in dict(self.pipeline.scheduler.config).items()
-            if k not in ("_class_name", "_diffusers_version")
-        }
-        return FlowMatchEulerDiscreteSDEScheduler(
-            dynamics_type="ODE",
-            noise_level=0.0,
-            **base_config,
-        )
+        return self.load_scheduler()
 
     @property
     def default_target_modules(self) -> List[str]:
@@ -988,6 +986,9 @@ class LTX2_I2AV_Adapter(BaseAdapter):
 
             gen_pred = video_pred_5d[:, :, 1:]
             gen_lats = video_latents_5d[:, :, 1:]
+            # Only the generated frames (1:) are stepped, so they are the video
+            # contribution to the joint log_prob (the conditioning frame is fixed).
+            n_video_stepped = gen_lats[0].numel()
 
             video_next_gen = None
             if video_next is not None:
@@ -1039,18 +1040,19 @@ class LTX2_I2AV_Adapter(BaseAdapter):
                 return_kwargs=return_kwargs,
                 noise_level=noise_level,
             )
+            n_video_stepped = video_latents[0].numel()
 
-        # --- 8. Audio: ODE scheduler step (deterministic, no log_prob) ---
+        # --- 8. Audio: SDE scheduler step (twin of video, with log_prob) ---
         audio_output = self.audio_scheduler.step(
             noise_pred=audio_pred,
             timestep=t,
             latents=audio_latents,
             timestep_next=t_next,
             next_latents=audio_next,
-            compute_log_prob=False,
+            compute_log_prob=compute_log_prob,
             return_dict=True,
-            return_kwargs=["next_latents"],
-            dynamics_type="ODE",
+            return_kwargs=return_kwargs,
+            noise_level=noise_level,
         )
 
         # --- 9. Concatenate back into unified latents ---
@@ -1071,6 +1073,23 @@ class LTX2_I2AV_Adapter(BaseAdapter):
             video_output.noise_pred = torch.cat(
                 [video_output.noise_pred, audio_pred],
                 dim=1,
+            )
+
+        # --- 10. Combine per-step log_prob across modalities ---
+        # Joint transition p(v,a|z_t) = p(v|z_t) p(a|z_t); the element-weighted mean
+        # reproduces what a single scheduler over the concatenated [video|audio] latent
+        # would return. `n_video_stepped` counts only the generated video frames (the
+        # conditioning frame is fixed and not stepped).
+        if (
+            compute_log_prob
+            and video_output.log_prob is not None
+            and audio_output.log_prob is not None
+        ):
+            video_output.log_prob = combine_modality_log_prob(
+                video_output.log_prob,
+                audio_output.log_prob,
+                n_video=n_video_stepped,
+                n_audio=audio_latents[0].numel(),
             )
 
         return video_output

--- a/src/flow_factory/models/ltx2/ltx2_t2av.py
+++ b/src/flow_factory/models/ltx2/ltx2_t2av.py
@@ -39,6 +39,7 @@ from ...utils.trajectory_collector import (
     create_trajectory_collector,
 )
 from ..abc import BaseAdapter
+from ._common import combine_modality_log_prob
 
 logger = setup_logger(__name__)
 
@@ -154,21 +155,18 @@ class LTX2_T2AV_Adapter(BaseAdapter):
         )
 
     def _create_audio_scheduler(self) -> FlowMatchEulerDiscreteSDEScheduler:
-        """Create a separate ODE-only scheduler for audio.
+        """Create a twin of the video scheduler for the audio modality.
 
-        A dedicated instance is needed because scheduler.step() mutates internal
-        state (step_index), which would conflict if shared with the video scheduler.
+        Audio is sampled with the same SDE dynamics as video so that both
+        modalities form a single joint policy whose per-step log_prob feeds the
+        GRPO objective. A dedicated instance is still required because
+        scheduler.step() mutates internal state (step_index), which would
+        conflict if shared with the video scheduler. ``load_scheduler`` rebuilds
+        an independent scheduler from the same pipeline scheduler + scheduler
+        args used for ``self.scheduler`` (which ``super().__init__`` has already
+        built at this point).
         """
-        base_config = {
-            k: v
-            for k, v in dict(self.pipeline.scheduler.config).items()
-            if k not in ("_class_name", "_diffusers_version")
-        }
-        return FlowMatchEulerDiscreteSDEScheduler(
-            dynamics_type="ODE",
-            noise_level=0.0,
-            **base_config,
-        )
+        return self.load_scheduler()
 
     # ============================== Module Properties ==============================
 
@@ -680,9 +678,10 @@ class LTX2_T2AV_Adapter(BaseAdapter):
 
         Accepts concatenated latents (B, video_seq + audio_seq, C) on the sequence dim.
         Internally splits into video/audio, runs the joint transformer, applies multi-level
-        guidance (CFG + STG + Modality Isolation) in x0-space, then steps video (SDE) and
-        audio (ODE) schedulers separately. The outputs are concatenated back so the caller
-        sees a single unified SDESchedulerOutput.
+        guidance (CFG + STG + Modality Isolation) in x0-space, then steps the video and audio
+        SDE schedulers separately (the audio scheduler is a twin of the video one, so both
+        modalities form a single joint policy). The outputs are concatenated back so the
+        caller sees a single unified SDESchedulerOutput.
 
         Guidance pipeline (matching official diffusers pipeline_ltx2.py):
             1. Main transformer forward (CFG: [uncond, cond] batch)
@@ -928,17 +927,17 @@ class LTX2_T2AV_Adapter(BaseAdapter):
             noise_level=noise_level,
         )
 
-        # --- 9. Audio: ODE scheduler step (deterministic, no log_prob) ---
+        # --- 9. Audio: SDE scheduler step (twin of video, with log_prob) ---
         audio_output = self.audio_scheduler.step(
             noise_pred=audio_pred,
             timestep=t,
             latents=audio_latents,
             timestep_next=t_next,
             next_latents=audio_next,
-            compute_log_prob=False,
+            compute_log_prob=compute_log_prob,
             return_dict=True,
-            return_kwargs=["next_latents"],
-            dynamics_type="ODE",
+            return_kwargs=return_kwargs,
+            noise_level=noise_level,
         )
 
         # --- 10. Concatenate back into unified latents ---
@@ -959,6 +958,22 @@ class LTX2_T2AV_Adapter(BaseAdapter):
             video_output.noise_pred = torch.cat(
                 [video_output.noise_pred, audio_pred],
                 dim=1,
+            )
+
+        # --- 11. Combine per-step log_prob across modalities ---
+        # Joint transition p(v,a|z_t) = p(v|z_t) p(a|z_t); the element-weighted mean
+        # reproduces what a single scheduler over the concatenated [video|audio] latent
+        # would return, keeping the log_prob scale consistent with the video-only path.
+        if (
+            compute_log_prob
+            and video_output.log_prob is not None
+            and audio_output.log_prob is not None
+        ):
+            video_output.log_prob = combine_modality_log_prob(
+                video_output.log_prob,
+                audio_output.log_prob,
+                n_video=video_latents[0].numel(),
+                n_audio=audio_latents[0].numel(),
             )
 
         return video_output


### PR DESCRIPTION
## Context

The framework drives RL rollouts with a single SDE scheduler whose `step()` turns the deterministic ODE into a stochastic transition kernel — that stochasticity is what gives each denoising step a Gaussian `log_prob`, which the GRPO/PPO ratio requires. LTX2 is the only model with **two** schedulers (video + audio) because `step()` mutates `step_index` and the modalities are stepped independently.

Until now the audio scheduler was hard-wired to ODE (`dynamics_type="ODE"`, `noise_level=0.0`, `compute_log_prob=False`), so **audio sampling contributed nothing to the policy gradient** — audio-aware rewards (CLAP / ImageBind-audio / AV-sync) could not be optimized; audio only drifted indirectly via shared transformer weights.

## Change

Make audio **always SDE** by building `audio_scheduler` as a config twin of the video scheduler (`self.load_scheduler()`). Both modalities now form a single joint policy `p(v,a|z_t) = p(v|z_t)·p(a|z_t)`:

- The audio `step()` mirrors the video `step()` — same `dynamics_type`, `noise_level`, and `compute_log_prob`.
- The two per-step log-probs are merged with an **element-weighted mean** (`models/ltx2/_common.py::combine_modality_log_prob`), which reproduces exactly what one scheduler over the concatenated `[video|audio]` latent would return (mean over all latent dims).
- No flag / no config field / no per-call branching — the dual-mode complexity is removed.

### Why it's consistent and minimal
`noise_level` is computed once per timestep from the **video** scheduler and passed into `forward()` (>0 only on the seed-selected SDE steps). Feeding that same value to the audio twin makes audio stochastic on exactly the same steps as video — so there is **no separate audio seed and no trainer change**. The same `forward()` runs in rollout and training, so the joint log-prob combination is automatically consistent. The separate audio instance is still required only for its independent `step_index`.

For **I2AV**, the video log-prob weight counts only the generated frames (`1:`), since the conditioning frame is fixed and not stepped.

## Trade-off (intentional)
With audio unconditionally SDE, a video-only reward also puts a policy gradient + KL on the audio branch (advantage-uncorrelated → unbiased on average but adds variance). Accepted for the cleaner, flag-free joint-policy formulation.

## Files
- `src/flow_factory/models/ltx2/_common.py` *(new)* — `combine_modality_log_prob()`
- `src/flow_factory/models/ltx2/ltx2_t2av.py` — twin audio scheduler, SDE audio step, log-prob combine, docstring
- `src/flow_factory/models/ltx2/ltx2_i2av.py` — same (video weight from stepped frames)
- `.agents/knowledge/topics/parity_testing.md` — dual-scheduler note updated

## Verification
- `py_compile` clean on all changed files.
- Numeric check: `combine_modality_log_prob` == mean over concatenated `[video|audio]` (max diff 5.6e-9).
- Confirmed CPS / Flow-SDE with `noise_level=0` reduce to a well-defined deterministic step (no NaN), so non-SDE-step behavior stays sane.
- End-to-end GRPO LTX2 training to be validated on GPU/cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)