### PR TITLE
[scheduler] fix: make SDE scheduler resolution idempotent for LTX2 audio twin

### DIFF
--- a/src/flow_factory/scheduler/registry.py
+++ b/src/flow_factory/scheduler/registry.py
@@ -20,6 +20,7 @@ Maps diffusers scheduler classes to custom SDE scheduler implementations.
 from typing import Type, Dict, Optional
 import importlib
 
+from .abc import SDESchedulerMixin
 from ..utils.logger_utils import setup_logger
 
 logger = setup_logger(__name__)
@@ -50,8 +51,14 @@ def get_sde_scheduler_class(scheduler) -> Type:
     Raises:
         ImportError: If no matching SDE scheduler is found
     """
-    class_name = scheduler.__class__.__name__ if not isinstance(scheduler, type) else scheduler.__name__
-    
+    cls = scheduler if isinstance(scheduler, type) else scheduler.__class__
+
+    # Idempotent: an already-wrapped SDE scheduler maps to itself, so callers
+    # building an independent twin via load_scheduler() can safely re-wrap.
+    if issubclass(cls, SDESchedulerMixin):
+        return cls
+
+    class_name = cls.__name__
     if class_name not in _SCHEDULER_REGISTRY:
         raise ImportError(
             f"No SDE scheduler registered for '{class_name}'. "


### PR DESCRIPTION
## Summary

- LTX2 (`ltx2_t2av` / `ltx2_i2av`) crashed at init with `ImportError: No SDE scheduler registered for 'FlowMatchEulerDiscreteSDEScheduler'`.
- Root cause: `_create_audio_scheduler()` builds the audio twin via a **second** `load_scheduler()` call, but `BaseAdapter.__init__` had already replaced `pipeline.scheduler` in place with the wrapped `FlowMatchEulerDiscreteSDEScheduler`. `get_sde_scheduler_class()` then looked that SDE class name up in `_SCHEDULER_REGISTRY` (keyed only by original diffusers names) and raised. Regression introduced by #187, where `_create_audio_scheduler` switched from building directly via `.config` to going through `load_scheduler()`.
- Fix: make `get_sde_scheduler_class()` **idempotent** — if the input is already an `SDESchedulerMixin` subclass, return its class directly, so `load_scheduler()` rebuilds an independent twin (own `step_index`) from its config. No adapter changes needed; both `t2av` and `i2av` are fixed, and the path is hardened for any future multi-scheduler adapter.

The change is purely additive: the original diffusers -> SDE registry path and the unknown-class `ImportError` are unchanged. Only caller is `loader.py::_load_scheduler`.

## Test plan

- [x] `get_sde_scheduler_class(FlowMatchEulerDiscreteSDEScheduler)` (class and instance) returns the same SDE class
- [x] `get_sde_scheduler_class(FlowMatchEulerDiscreteScheduler)` still resolves to the SDE class via the registry
- [x] Unknown class still raises `ImportError`
- [ ] Smoke-run LTX2 `t2av` / `i2av` adapter init on a GPU box to confirm the original crash is gone

Made with [Cursor](https://cursor.com)