### PR TITLE
[models,docs] feat: add model-agnostic latent geometry abstraction

### DIFF
--- a/.agents/knowledge/topics/adapter_conventions.md
+++ b/.agents/knowledge/topics/adapter_conventions.md
@@ -67,6 +67,40 @@ Defined in `models/abc.py` (`preprocessing_modules` / `inference_modules` proper
 - **Image-column persistence (HF Image feature)**: the raw `images` column and any `encode_image` output listed in `python_format_columns` (ClassVar on `BaseAdapter`, empty by default) are stored via the HuggingFace `Image` feature (PNG bytes) instead of raw tensors, and **read back as PIL** (`List[List[PIL.Image]]`). This is what lets ragged multi-reference batches (variable size/count) serialize — raw tensors are only Arrow-serializable when uniform. Opt in per adapter only for genuine RGB images (e.g. Bagel `condition_images`); never declare preprocessed/non-RGB tensors (VAE-ready video tensors, latents) — PIL conversion is lossy and breaks tensor consumers (e.g. LTX2-I2AV `condition_images` stays a tensor). Consumers must normalize via `_standardize_image_input` / `standardize_image_batch` before any tensor op. To keep PIL on the **sample** too (not just the dataset cache), the adapter's `ImageConditionSample` subclass must set `condition_images_as_pil = True` (else `__post_init__` re-canonicalizes to `List[Tensor(C,H,W)]` [0,1]); e.g. `BagelI2ISample`.
 - Single-condition adapters must flatten internally via `_standardize_image_input` / `_standardize_video_input` using `is_multi_image_batch` / `is_multi_video_batch` to extract the first element per sample (e.g. `Wan2_I2V._standardize_image_input`, `Wan2_V2V._standardize_video_input`, `LTX2_I2AV._standardize_image_input`). Multi-condition adapters (e.g. `Flux2`) consume the nested structure directly.
 
+## Latent Geometry
+
+Model-agnostic description of latent tensor **axis roles** on `BaseAdapter`. Defined in `models/latent_geometry.py` + `models/abc.py`. Additive and information-preserving — it only locates axes; it does not summarize or pool latents (a future consumer, e.g. a critic/value head, will add task-specific encoders on top).
+
+### API
+
+| Member | Role |
+|---|---|
+| `LATENT_AXES` (ClassVar) | Optional static `LatentAxes` override; `None` -> infer from ndim |
+| `resolve_latent_axes(latents)` | Returns `LatentAxes` (override, else ndim-inferred) |
+| `infer_latent_axes(ndim)` (module fn) | Maps rank 3/4/5 to canonical `LatentAxes`; fail-fasts on unsupported ranks |
+
+### Layouts (axis roles, resolution-invariant)
+
+| Layout | ndim | shape | channel | sequence | temporal | spatial |
+|---|---|---|---|---|---|---|
+| PACKED | 3 | `(B, Seq, C)` | -1 | 1 | - | () |
+| CONV | 4 | `(B, C, H, W)` | 1 | - | - | (2,3) |
+| VIDEO | 5 | `(B, C, T, H, W)` | 1 | - | 2 | (3,4) |
+
+Only axis roles are stored, never dynamic sizes (Seq/H/W/T). Packed models fold H/W(/T) into `Seq` via patchify, so their spatial/temporal are empty by design.
+
+### Per-adapter
+
+All 14 adapters resolve correctly via default ndim inference — none override `LATENT_AXES`:
+
+| Adapter(s) | Layout |
+|---|---|
+| FLUX.1/Kontext/2/Klein, Qwen-Image/Edit-Plus, Bagel, LTX2 T2AV/I2AV | PACKED |
+| SD3.5, Z-Image | CONV |
+| Wan2 T2V/I2V/V2V | VIDEO |
+
+LTX2 packs `[video|audio]` into one `(B, Seq, C)` sequence, so it resolves as PACKED (the split point lives in the adapter's own `forward` via `video_seq_len`, not in the geometry layer). I2I/I2V/Edit store only the generated latent in `all_latents` (condition is concatenated inside `forward()` / kept in separate fields), so the standard layout applies and reference-image count is irrelevant. Override `LATENT_AXES` only for a genuinely non-standard rank/channel layout.
+
 ## Numbered Gotchas (append-only)
 
 1. Never call `pipeline.__call__()` from `inference()` — decompose it into individual pipeline steps.
@@ -78,6 +112,7 @@ Defined in `models/abc.py` (`preprocessing_modules` / `inference_modules` proper
 7. **CFG two-stage consistency** — `encode_prompt()` and `forward()` must use the same threshold for CFG activation (`guidance_scale > 1.0`, or `> 0.0` for Z-Image). `forward()` must gracefully handle the case where `guidance_scale > threshold` but negative embeds are `None` (warn + fallback, never error). See "Classifier-Free Guidance (CFG) Convention" section above.
 8. **Bagel batch handling (NaViT subset-round packing)** — Bagel uses sequence packing, not a leading batch dim. **Both T2I and I2I** pack all B samples into one block-diagonal forward (`_build_gen_context` + `_forward_packed`; the framework's `(B, num_tokens, dim)` latents reshape to packed `(B*num_tokens, dim)` and back). For I2I, reference images are added in per-image rounds (`num_rounds = max per-sample count`); a sample without an r-th image is passed as `None` to `prepare_vae_images` / `prepare_vit_images`, which keep its cached KV and add a **zero-length query segment**. So a **variable per-sample reference-image count** (and varying sizes) is handled by packing directly — there is no per-sample (`batch_size=1`) fallback. The cache merge requires every sample to remain on the key/value side, so only the query may be a subset. The prefill is `@torch.no_grad` and every round has >=1 active image (`max_seqlen_q > 1`), avoiding flash-attn zero-length pitfalls (no backward, no `max_seqlen_q==1`). `_is_i2i(condition_images)` depends only on condition-image presence (distributed-safe). CFG global renorm is computed **per sample** over `packed_seqlens - 2`, and `forward()` returns per-sample `(B,)` log-prob (not per-token). **Distributed**: the prefill makes a data-dependent number of `language_model` forward calls (`2*num_rounds + 2`); `language_model` is the only FSDP-sharded module (frozen ViT/VAE are unsharded, so they don't count). Under FSDP FULL_SHARD/HYBRID (and ZeRO-3) each call AllGathers `language_model`'s shard, so per-rank counts mismatch and deadlock — `_assert_variable_count_supported` fails fast there (`@torch.no_grad` does not help; FSDP still all-gathers to compute). DDP / DeepSpeed ZeRO-1/2 (the Bagel I2I backends) replicate params (local forward, fixed grad sync at backward), so variable counts are safe. The FSDP-safe alternative is to gather `language_model` once for the generation (`summon_full_params` / `reshard_after_forward=False`).
 9. **Image columns persist via HF Image feature (variable-size/count I2I)** — preprocessing stores image data as PIL via the HF `Image` feature, not raw tensors; ragged tensor columns (multi-reference images of varying size/count) are NOT Arrow-serializable and otherwise crash in `Dataset.map` with `TypeError: a bytes-like object is required, not 'Tensor'` / `OverflowError`. The raw `images` column is always stored this way; an `encode_image` output is stored this way only when its name is listed in the adapter's `python_format_columns` ClassVar (default empty — opt in for RGB images only, e.g. Bagel `condition_images`). These columns **read back as PIL** (`List[List[PIL.Image]]`); the `torch` format excludes them (`_apply_torch_format` in `dataset.py`), and `collate_fn` keeps them as a `MultiImageBatch`. To keep PIL end-to-end on the **sample** (not just the cache), the adapter's `ImageConditionSample` subclass must also set `condition_images_as_pil=True` (else `ImageConditionSample.__post_init__` re-canonicalizes to `List[Tensor(C,H,W)]` [0,1]); e.g. `BagelI2ISample`. Bump `_PREPROCESS_FORMAT_VERSION` if the on-disk image format changes again.
+10. **Latent geometry override is rarely needed** — `resolve_latent_axes` infers axis roles from latent ndim (3=packed, 4=conv, 5=video), correct for all 14 adapters. Set the `LATENT_AXES` ClassVar only for a genuinely non-standard rank/channel layout. LTX2's packed `[video|audio]` resolves as PACKED; its modality split lives in the adapter `forward` (`video_seq_len`), not the geometry layer. See "Latent Geometry".
 
 ## Cross-refs
 

--- a/src/flow_factory/models/__init__.py
+++ b/src/flow_factory/models/__init__.py
@@ -21,20 +21,23 @@ with a registry-based loading system for easy extensibility.
 """
 
 from .abc import BaseAdapter
+from .latent_geometry import LatentAxes, LatentLayout, infer_latent_axes
+from .loader import load_model
 from .registry import (
     get_model_adapter_class,
     list_registered_models,
 )
-from .loader import load_model
 
 __all__ = [
     # Core classes
     "BaseAdapter",
-
+    # Latent geometry
+    "LatentAxes",
+    "LatentLayout",
+    "infer_latent_axes",
     # Registry functions
     "get_model_adapter_class",
     "list_registered_models",
-    
     # Factory function
     "load_model",
 ]

--- a/src/flow_factory/models/abc.py
+++ b/src/flow_factory/models/abc.py
@@ -64,6 +64,7 @@ from ..utils.checkpoint import (
     HF_PATH_PREFIX,
 )
 from ..samples import BaseSample
+from .latent_geometry import LatentAxes, infer_latent_axes
 from ..ema import EMAModuleWrapper
 from ..scheduler import (
     load_scheduler as _load_scheduler,
@@ -128,6 +129,12 @@ class BaseAdapter(ABC):
     # The raw modality column ``images`` is always handled as images by the dataset
     # itself, independent of this declaration.
     python_format_columns: ClassVar[frozenset[str]] = frozenset()
+
+    # Resolution-invariant latent axis roles for the model-agnostic latent state
+    # API (see `latent_geometry.py`). ``None`` means "infer from latent ndim" via
+    # `resolve_latent_axes`, which covers every standard 3D/4D/5D layout. Adapters
+    # with a non-standard layout may override this with an explicit `LatentAxes`.
+    LATENT_AXES: ClassVar[Optional[LatentAxes]] = None
 
     def __init__(self, config: Arguments, accelerator : Accelerator):
         super().__init__()
@@ -2229,6 +2236,23 @@ class BaseAdapter(ABC):
         Decodes latent representations back into images/videos if applicable.
         """
         pass
+
+    # ======================================= Latent Geometry =======================================
+    def resolve_latent_axes(self, latents: torch.Tensor) -> LatentAxes:
+        """Resolve the :class:`LatentAxes` (axis roles) for ``latents``.
+
+        Returns the adapter's static ``LATENT_AXES`` override when set, otherwise
+        infers from the latent ndim (3=packed, 4=conv, 5=video). Resolution-invariant.
+
+        Args:
+            latents: A batched latent tensor.
+
+        Returns:
+            The :class:`LatentAxes` describing ``latents``.
+        """
+        if self.LATENT_AXES is not None:
+            return self.LATENT_AXES
+        return infer_latent_axes(latents.ndim)
 
     # ======================================= Sampling & Training =======================================
     @abstractmethod

--- a/src/flow_factory/models/latent_geometry.py
+++ b/src/flow_factory/models/latent_geometry.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# src/flow_factory/models/latent_geometry.py
+"""Model-agnostic latent geometry.
+
+Describes the *axis roles* of an adapter's latent tensor (:class:`LatentAxes`) so
+model-agnostic consumers can locate the batch / channel / spatial / temporal /
+sequence axes across every adapter layout:
+
+- ``PACKED`` ``(B, Seq, C)``     -- FLUX*, Qwen-Image*, LTX2*, Bagel
+- ``CONV``   ``(B, C, H, W)``    -- SD3.5, Z-Image
+- ``VIDEO``  ``(B, C, T, H, W)`` -- Wan2 T2V/I2V/V2V
+
+The geometry records *which axis plays which role*, never concrete sizes, so it
+stays valid as resolution, frame count, or reference-image count change at runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+
+class LatentLayout(str, Enum):
+    """Canonical latent tensor layouts across adapters."""
+
+    PACKED = "packed"  # (B, Seq, C)
+    CONV = "conv"  # (B, C, H, W)
+    VIDEO = "video"  # (B, C, T, H, W)
+
+
+@dataclass(frozen=True)
+class LatentAxes:
+    """Resolution-invariant axis roles for a latent tensor.
+
+    Records only *which axis plays which role*, never concrete sizes. Dynamic
+    dims (sequence length, height, width, frames) change with resolution / frame
+    count and are intentionally not stored.
+
+    Attributes:
+        layout: The canonical :class:`LatentLayout`.
+        batch: Index of the batch axis (always 0 in this codebase).
+        channel: Index of the latent-channel axis (``-1`` packed, ``1`` conv/video).
+        spatial: Indices of spatial axes (``()`` for packed -- H/W are folded into
+            the sequence dim by patchify; ``(2, 3)`` conv; ``(3, 4)`` video).
+        temporal: Index of the temporal axis if present (``2`` for video) else ``None``.
+        sequence: Index of the packed-token axis if present (``1`` for packed) else ``None``.
+    """
+
+    layout: LatentLayout
+    batch: int = 0
+    channel: int = -1
+    spatial: Tuple[int, ...] = ()
+    temporal: Optional[int] = None
+    sequence: Optional[int] = None
+
+
+# Canonical axis descriptors per supported ndim.
+_PACKED_AXES = LatentAxes(layout=LatentLayout.PACKED, batch=0, channel=-1, sequence=1)
+_CONV_AXES = LatentAxes(layout=LatentLayout.CONV, batch=0, channel=1, spatial=(2, 3))
+_VIDEO_AXES = LatentAxes(layout=LatentLayout.VIDEO, batch=0, channel=1, temporal=2, spatial=(3, 4))
+
+_NDIM_TO_AXES = {3: _PACKED_AXES, 4: _CONV_AXES, 5: _VIDEO_AXES}
+
+
+def infer_latent_axes(ndim: int) -> LatentAxes:
+    """Infer :class:`LatentAxes` from a (batched) latent tensor's ndim.
+
+    Args:
+        ndim: Number of dimensions of the batched latent tensor.
+
+    Returns:
+        The canonical :class:`LatentAxes` for ``ndim``.
+
+    Raises:
+        ValueError: If ``ndim`` is not one of the supported ranks (3 / 4 / 5).
+    """
+    axes = _NDIM_TO_AXES.get(ndim)
+    if axes is None:
+        raise ValueError(
+            f"Cannot infer LatentAxes for latents with ndim={ndim}; supported "
+            f"ranks are {sorted(_NDIM_TO_AXES)} (3=packed (B,Seq,C), "
+            f"4=conv (B,C,H,W), 5=video (B,C,T,H,W)). Override `LATENT_AXES` on "
+            f"the adapter for non-standard layouts."
+        )
+    return axes

--- a/tests/models/test_latent_geometry.py
+++ b/tests/models/test_latent_geometry.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Jayce-Ping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the model-agnostic latent geometry abstraction.
+
+Covers axis-role inference (rank 3/4/5 + fail-fast) and the ``BaseAdapter``
+resolution hook (ndim inference + ``LATENT_AXES`` override) via a lightweight
+stub adapter that never loads a real pipeline (constructed with ``object.__new__``
+to bypass ``__init__``).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flow_factory.models.abc import BaseAdapter
+from flow_factory.models.latent_geometry import (
+    LatentAxes,
+    LatentLayout,
+    infer_latent_axes,
+)
+
+# ============================== infer_latent_axes ==============================
+
+
+def test_infer_latent_axes_packed():
+    axes = infer_latent_axes(3)
+    assert axes.layout is LatentLayout.PACKED
+    assert axes.batch == 0
+    assert axes.channel == -1
+    assert axes.sequence == 1
+    assert axes.spatial == ()
+    assert axes.temporal is None
+
+
+def test_infer_latent_axes_conv():
+    axes = infer_latent_axes(4)
+    assert axes.layout is LatentLayout.CONV
+    assert axes.channel == 1
+    assert axes.spatial == (2, 3)
+    assert axes.temporal is None
+    assert axes.sequence is None
+
+
+def test_infer_latent_axes_video():
+    axes = infer_latent_axes(5)
+    assert axes.layout is LatentLayout.VIDEO
+    assert axes.channel == 1
+    assert axes.temporal == 2
+    assert axes.spatial == (3, 4)
+    assert axes.sequence is None
+
+
+@pytest.mark.parametrize("ndim", [2, 6])
+def test_infer_latent_axes_rejects_unsupported(ndim):
+    with pytest.raises(ValueError, match="ndim"):
+        infer_latent_axes(ndim)
+
+
+# ============================== BaseAdapter.resolve_latent_axes ==============================
+
+
+class _StubAdapter(BaseAdapter):
+    """Minimal concrete adapter implementing abstractmethods (never ``__init__``'d).
+
+    Only ``resolve_latent_axes`` (inherited from ``BaseAdapter``) is exercised; it
+    touches no instance state beyond the ``LATENT_AXES`` class var, so a
+    pipeline-free instance built via ``object.__new__`` is sufficient.
+    """
+
+    def load_pipeline(self):  # pragma: no cover - never called
+        raise NotImplementedError
+
+    def decode_latents(self, latents, **kwargs):  # pragma: no cover - never called
+        raise NotImplementedError
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - never called
+        raise NotImplementedError
+
+    def inference(self, *args, **kwargs):  # pragma: no cover - never called
+        raise NotImplementedError
+
+
+def _make_stub(cls=_StubAdapter):
+    """Build a pipeline-free adapter instance (bypass ``__init__``)."""
+    return object.__new__(cls)
+
+
+def test_resolve_latent_axes_infers_from_ndim():
+    adapter = _make_stub()
+    assert adapter.resolve_latent_axes(torch.randn(2, 7, 4)).layout is LatentLayout.PACKED
+    assert adapter.resolve_latent_axes(torch.randn(2, 4, 8, 8)).layout is LatentLayout.CONV
+    assert adapter.resolve_latent_axes(torch.randn(2, 4, 3, 8, 8)).layout is LatentLayout.VIDEO
+
+
+def test_latent_axes_override_takes_precedence():
+    class _OverrideAdapter(_StubAdapter):
+        LATENT_AXES = LatentAxes(layout=LatentLayout.CONV, channel=1, spatial=(2, 3))
+
+    adapter = _make_stub(_OverrideAdapter)
+    # Even a rank-3 latent resolves to the explicit override (CONV), not inferred PACKED.
+    assert adapter.resolve_latent_axes(torch.randn(2, 7, 4)).layout is LatentLayout.CONV


### PR DESCRIPTION
## Summary
- Add a resolution-invariant latent **axis-role** descriptor — `LatentLayout` / `LatentAxes` / `infer_latent_axes` — in `models/latent_geometry.py`.
- Add a `BaseAdapter` hook: `LATENT_AXES` override + `resolve_latent_axes()` (default ndim inference: rank 3 = packed `(B,Seq,C)`, 4 = conv `(B,C,H,W)`, 5 = video `(B,C,T,H,W)`). All 14 adapters resolve correctly with no override.
- Document the geometry API + per-adapter layout table in `.agents/knowledge/topics/adapter_conventions.md`; add unit tests.

## Notes
- Purely **additive**: no change to any existing inference/training path, no runtime consumer yet. This is the reusable foundation for a future consumer (e.g. a critic/value encoder).
- A lossy mean+std pooled "state summary" was intentionally **dropped** — pooling discards too much information; a task-specific encoder will be written later based on actual needs.

## Test plan
- [x] `pytest tests/models/test_latent_geometry.py` (7 passed)
- [x] `black --check --line-length 100` + `isort --check` on new/edited files
- [x] import smoke: `from flow_factory.models import LatentAxes, LatentLayout, infer_latent_axes`
- [ ] CI green