### PR TITLE
[samples,trainers] refactor: dedicated StackedSampleBatch for stacked batches

### DIFF
--- a/src/flow_factory/samples/__init__.py
+++ b/src/flow_factory/samples/__init__.py
@@ -16,6 +16,7 @@
 
 from .samples import (
     BaseSample,
+    StackedSampleBatch,
     ImageConditionSample,
     VideoConditionSample,
     T2ISample,
@@ -31,6 +32,7 @@ from .samples import (
 __all__ = [
     # Sample classes
     "BaseSample",
+    "StackedSampleBatch",
     "ImageConditionSample",
     "VideoConditionSample",
     "T2ISample",

--- a/src/flow_factory/samples/samples.py
+++ b/src/flow_factory/samples/samples.py
@@ -55,6 +55,7 @@ logger = setup_logger(__name__)
 
 __all__ = [
     'BaseSample',
+    'StackedSampleBatch',
     'ImageConditionSample',
     'VideoConditionSample',
     'T2ISample',
@@ -68,9 +69,14 @@ __all__ = [
 
 @dataclass
 class BaseSample:
-    """
-    Base output class for Adapter models.
-    The tensors are without batch dimension.
+    """Per-sample output of an Adapter (strictly without a batch dimension).
+
+    Invariant: every tensor field holds a single sample (e.g. ``image`` is
+    ``(C, H, W)``, never ``(B, C, H, W)``); ``__post_init__`` relies on this to
+    canonicalize media. To batch samples for training use ``BaseSample.stack``,
+    which returns a :class:`StackedSampleBatch` (a dict subclass) rather than a
+    batched BaseSample -- a batched BaseSample would violate this invariant and
+    corrupt media in ``__post_init__`` (which keeps only index 0).
     """
     _id_fields : ClassVar[frozenset[str]] = frozenset({
         'prompt', 'prompt_ids', 'negative_prompt', 'negative_prompt_ids',
@@ -165,7 +171,11 @@ class BaseSample:
                 )
 
     def __post_init__(self):
-        """Post-initialization processing."""
+        """Canonicalize media fields, assuming a single sample (no batch dim).
+
+        Each media field is normalized to one sample's tensor, so this must never
+        run on batched data (batches live in :class:`StackedSampleBatch`).
+        """
         # Standardize image field to tensor (C, H, W)
         if self.image is not None:
             # -> (1, C, H, W) -> (C, H, W)
@@ -190,32 +200,22 @@ class BaseSample:
         return frozenset(fields)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dict for memory tracking, excluding non-tensor fields."""
+        """Flatten to a plain dict, lifting ``extra_kwargs`` keys to the top level.
+
+        Used by ``stack()`` and ``**sample`` unpacking (e.g. reward-model kwargs).
+        """
         result = {f.name: getattr(self, f.name) for f in fields(self)}
         extra = result.pop('extra_kwargs', {})
+        collisions = set(extra) & set(result)
+        if collisions:
+            raise ValueError(
+                f"{type(self).__name__}.extra_kwargs keys collide with declared "
+                f"fields {sorted(collisions)}; extra_kwargs must hold only "
+                f"non-declared keys (got extra keys {sorted(extra)})."
+            )
         result.update(extra)
         return result
 
-    @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> BaseSample:
-        """Create instance from dict, putting unknown fields into extra_kwargs."""
-        field_names = {f.name for f in fields(cls)}
-        known = {k: v for k, v in d.items() if k in field_names and k != 'extra_kwargs'}
-        
-        # Collect unknown fields
-        extra = {k: v for k, v in d.items() if k not in field_names}
-        
-        # Merge with incoming extra_kwargs and check for conflicts
-        incoming_extra = d.get('extra_kwargs', {})
-        conflicting_keys = set(incoming_extra) & (field_names - {'extra_kwargs'})
-        if conflicting_keys:
-            raise ValueError(
-                f"extra_kwargs contains reserved field names: {conflicting_keys}"
-            )
-        extra.update(incoming_extra)
-        
-        return cls(**known, extra_kwargs=extra)
-    
     def __getattr__(self, key: str) -> Any:
         """Access attributes. Check extra_kwargs if not found.
 
@@ -257,15 +257,6 @@ class BaseSample:
     def __iter__(self):
         """Allow iteration over keys (required for some mapping operations)."""
         return iter(self.keys())
-
-    def short_rep(self) -> Dict[str, Any]:
-        """Short representation for logging (replaces large tensors with shapes)."""
-        def tensor_to_repr(v):
-            if isinstance(v, torch.Tensor) and v.numel() > 16:
-                return f"Tensor{tuple(v.shape)}"
-            return v
-
-        return {k: tensor_to_repr(v) for k, v in self.to_dict().items()}
 
     def to(
         self,
@@ -413,41 +404,93 @@ class BaseSample:
         return values
 
     @classmethod
-    def stack(cls, samples: List[BaseSample]) -> Dict[str, Union[torch.Tensor, Dict, List, Any]]:
-        """Stack per-sample BaseSamples into one batched dict.
+    def stack(cls, samples: List[BaseSample]) -> StackedSampleBatch:
+        """Collate per-sample BaseSamples into one batched ``StackedSampleBatch``.
 
-        Returns a flat ``Dict[str, Any]`` (NOT a BaseSample) -- the batch
-        interchange format between the per-sample lifecycle (``List[BaseSample]``)
-        and ``adapter.forward(**batched_kwargs)``. Each sample is flattened via
-        ``to_dict()`` (which lifts ``extra_kwargs`` keys to the top level), then
-        ``_stack_values`` collates per key:
+        Thin alias for ``StackedSampleBatch(samples)`` -- the batch type owns the
+        collation; this stays the discoverable stacking entry point. See
+        :class:`StackedSampleBatch` for the per-key collation rules and the
+        returned type.
+
+        Raises:
+            ValueError: If ``samples`` is empty.
+        """
+        return StackedSampleBatch(samples)
+
+
+class StackedSampleBatch(dict):
+    """Batched, collated view of a ``List[BaseSample]`` (built from ``samples`` by
+    its constructor; also returned by ``BaseSample.stack``).
+
+    A plain ``str``-keyed ``dict`` subclass, so it is a drop-in for the
+    optimize-loop consumption: ``batch[key]``, ``batch.get(key)``, ``.items()``,
+    ``**batch`` into ``adapter.forward``, and in-place ``batch[key] = value`` all
+    keep working unchanged. Beyond a bare dict it:
+
+    - names the "batched samples" concept (instead of an anonymous ``Dict[str, Any]``),
+    - keeps a handle to the source per-sample objects (``batch.samples``) and the
+      originating type (``batch.sample_cls``) for per-sample access / introspection,
+    - exposes read-only attribute access (``batch.all_latents`` == ``batch["all_latents"]``).
+
+    It is intentionally NOT a ``BaseSample``: a batched sample would violate
+    ``BaseSample``'s "tensors without batch dim" invariant and re-trigger
+    ``__post_init__`` media canonicalization (which assumes no batch dim and keeps
+    only index 0).
+    """
+
+    def __init__(self, samples: List[BaseSample]) -> None:
+        """Collate a non-empty ``List[BaseSample]`` into the batched mapping.
+
+        Each sample is flattened via ``BaseSample.to_dict()`` (which lifts
+        ``extra_kwargs`` keys to the top level), then ``BaseSample._stack_values``
+        collates per key:
             - ``shared_fields()`` keys: take the first sample's value (not stacked).
             - tensors with matching shapes: ``torch.stack``; mismatched: list.
             - dicts: collated recursively; other types (str, Set, PIL): list.
 
-        Args:
-            samples: Non-empty list of BaseSample instances (each without a batch dim).
-
-        Returns:
-            Dict[str, Any]: batched values keyed by field / extra_kwargs name.
-
         Raises:
-            ValueError: If samples list is empty.
+            ValueError: If ``samples`` is empty.
         """
         if not samples:
             raise ValueError("No samples to stack.")
-        
+
         sample_cls = type(samples[0])
         sample_dicts = [s.to_dict() for s in samples]
-
         all_keys: set = set()
         for d in sample_dicts:
             all_keys.update(d.keys())
 
-        return {
-            key: sample_cls._stack_values(key, [d.get(key) for d in sample_dicts])
-            for key in all_keys
-        }
+        super().__init__(
+            {
+                key: sample_cls._stack_values(key, [d.get(key) for d in sample_dicts])
+                for key in all_keys
+            }
+        )
+        # ``samples``: the per-sample objects this batch was collated from. Stored
+        # as an instance attribute (NOT a mapping key) -> excluded from ``**batch``
+        # / ``.items()`` and resolved before ``__getattr__``. Callers needing
+        # per-sample access (e.g. OPD teacher routing / ``mu_teacher`` write-back)
+        # read ``batch.samples``.
+        self.samples = samples
+
+    @property
+    def sample_cls(self) -> type[BaseSample]:
+        """Originating ``BaseSample`` subclass (all samples share one type)."""
+        return type(self.samples[0])
+
+    def __getattr__(self, name: str) -> Any:
+        """Read-only attribute access over the mapping (sugar for ``batch[name]``).
+
+        Only invoked when normal attribute lookup fails, so the real ``samples``
+        attribute, the ``sample_cls`` property, and ``dict`` methods short-circuit
+        first.
+        """
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' has no attribute or key '{name}'"
+            )
 
 
 @dataclass

--- a/src/flow_factory/trainers/abc.py
+++ b/src/flow_factory/trainers/abc.py
@@ -41,7 +41,7 @@ from ..data_utils.loader import (
 from ..rewards import load_reward_model, BaseRewardModel, MultiRewardLoader, RewardProcessor, RewardBuffer
 from ..advantage import AdvantageProcessor
 from ..logger import load_logger, LogFormatter
-from ..samples import BaseSample
+from ..samples import BaseSample, StackedSampleBatch
 from ..utils.logger_utils import setup_logger
 from ..utils.base import create_generator, create_generator_by_prompt, filter_kwargs, json_default, visit_tensor_leaves
 
@@ -487,17 +487,17 @@ class BaseTrainer(ABC):
         for sample in samples:
             sample.to('cpu', pin_memory=True)
 
-    def _iter_prefetched_sample_batches(
+    def _iter_prefetched_batches(
         self,
         samples: List[BaseSample],
         per_device_batch_size: int,
-    ) -> Iterator[Tuple[Dict[str, Any], List[BaseSample]]]:
-        """Yield ``(stacked_batch, device_resident_samples)`` for the optimize loop.
+    ) -> Iterator[StackedSampleBatch]:
+        """Yield device-resident stacked micro-batches for the optimize loop.
 
-        Same prefetch contract as :meth:`_iter_prefetched_batches`, but also hands
-        back the moved per-sample list so callers that need per-sample access
-        (teacher routing, ``mu_teacher`` write-back, group bookkeeping) get it
-        without a second move or a redundant side index.
+        Each yielded :class:`StackedSampleBatch` also exposes the moved per-sample
+        objects it was stacked from via ``batch.samples`` -- callers that need
+        per-sample access (e.g. OPD teacher routing / ``mu_teacher`` write-back)
+        read that, with no second move or a redundant side index.
 
         When samples are CPU-offloaded (pinned), the next micro-batch's H2D copy
         runs on a dedicated copy stream to overlap the current batch's compute;
@@ -507,8 +507,8 @@ class BaseTrainer(ABC):
         stack. Numerically equivalent either way; only data-movement timing changes.
 
         Yields:
-            (Dict[str, Any], List[BaseSample]): the stacked micro-batch and the
-            device-resident samples it was stacked from.
+            StackedSampleBatch: a stacked micro-batch (its source samples are at
+            ``batch.samples``).
         """
         device = self.accelerator.device
         starts = list(range(0, len(samples), per_device_batch_size))
@@ -524,45 +524,27 @@ class BaseTrainer(ABC):
                     sample.to(device)
                     for sample in samples[start:start + per_device_batch_size]
                 ]
-                yield BaseSample.stack(batch_samples), batch_samples
+                yield BaseSample.stack(batch_samples)
             return
 
         copy_stream = torch.cuda.Stream(device)
         compute_stream = torch.cuda.current_stream(device)
 
-        def _load(start: int) -> Tuple[Dict[str, Any], List[BaseSample]]:
+        def _load(start: int) -> StackedSampleBatch:
             with torch.cuda.stream(copy_stream):
                 moved = [
                     sample.to(device, non_blocking=True)
                     for sample in samples[start:start + per_device_batch_size]
                 ]
-                return BaseSample.stack(moved), moved
+                return BaseSample.stack(moved)
 
-        next_pair = _load(starts[0])
+        next_batch = _load(starts[0])
         for i, _ in enumerate(starts):
-            batch, batch_samples = next_pair
+            batch = next_batch
             compute_stream.wait_stream(copy_stream)  # batch H2D complete before use
             _record_stream_on_batch(batch, compute_stream)  # keep alive for compute stream
             if i + 1 < len(starts):
-                next_pair = _load(starts[i + 1])  # prefetch next, overlaps compute
-            yield batch, batch_samples
-
-    def _iter_prefetched_batches(
-        self,
-        samples: List[BaseSample],
-        per_device_batch_size: int,
-    ) -> Iterator[Dict[str, Any]]:
-        """Yield device-resident stacked micro-batch dicts for the optimize loop.
-
-        Thin wrapper over :meth:`_iter_prefetched_sample_batches` for callers that
-        only need the stacked dict (see there for the prefetch/offload contract).
-
-        Yields:
-            Dict[str, Any]: a stacked micro-batch (see ``BaseSample.stack``).
-        """
-        for batch, _ in self._iter_prefetched_sample_batches(
-            samples, per_device_batch_size
-        ):
+                next_batch = _load(starts[i + 1])  # prefetch next, overlaps compute
             yield batch
 
     def sample_batch(

--- a/src/flow_factory/trainers/crd.py
+++ b/src/flow_factory/trainers/crd.py
@@ -20,7 +20,8 @@ Reference:
     - https://arxiv.org/abs/2603.14128
 """
 import os
-from typing import List, Dict, Any, Union, Optional
+from dataclasses import dataclass
+from typing import List, Dict, Any, Optional
 from functools import partial
 from collections import defaultdict
 from contextlib import contextmanager
@@ -34,7 +35,7 @@ tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
 
 from .abc import BaseTrainer
 from ..hparams import CRDTrainingArguments
-from ..samples import BaseSample
+from ..samples import BaseSample, StackedSampleBatch
 from ..rewards import RewardBuffer
 from ..utils.base import filter_kwargs, create_generator, create_generator_by_prompt, to_broadcast_tensor
 from ..utils.logger_utils import setup_logger
@@ -42,6 +43,23 @@ from ..utils.noise_schedule import TimeSampler, flow_match_sigma
 from ..utils.dist import reduce_loss_info
 
 logger = setup_logger(__name__)
+
+
+@dataclass
+class _CRDBatch:
+    """A stacked micro-batch plus its pass-1 pre-computed old-model targets.
+
+    CRD uses a two-pass design: pass 1 pre-computes the old-model V predictions
+    for every micro-batch (against a frozen snapshot), pass 2 trains on them.
+    This bundles the device-resident batch with those per-timestep tensors so
+    pass 2 has typed, named access (``prepared.old_v_pred_list``) instead of
+    keying scratch onto the shared batch type.
+    """
+
+    batch: StackedSampleBatch
+    all_timesteps: torch.Tensor  # (T, B), scheduler scale [0, 1000]
+    all_random_noise: List[torch.Tensor]  # per-timestep noise (shape of clean_latents)
+    old_v_pred_list: List[torch.Tensor]  # per-timestep old-model V prediction
 
 
 # ========================= Decay Utilities =========================
@@ -395,7 +413,7 @@ class CRDTrainer(BaseTrainer):
 
     def _compute_crd_output(
         self,
-        batch: Dict[str, Any],
+        batch: StackedSampleBatch,
         timestep: torch.Tensor,
         noised_latents: torch.Tensor,
         guidance_scale: Optional[float] = None,
@@ -587,7 +605,7 @@ class CRDTrainer(BaseTrainer):
             # reused, not reloaded). The old model is a frozen snapshot
             # (_OLD_PARAMS_NAME), so per-batch old-V is independent of pass-2
             # weight updates.
-            sample_batches: List[Dict[str, Union[torch.Tensor, Any, List[Any]]]] = []
+            sample_batches: List[_CRDBatch] = []
             num_batches = (
                 len(samples) + self.training_args.per_device_batch_size - 1
             ) // self.training_args.per_device_batch_size
@@ -607,11 +625,10 @@ class CRDTrainer(BaseTrainer):
 
                     # Sample timesteps: (T, B) in scheduler scale [0, 1000]
                     all_timesteps = self._sample_timesteps(batch_size)
-                    batch['_all_timesteps'] = all_timesteps
-                    batch['_all_random_noise'] = []
+                    all_random_noise: List[torch.Tensor] = []
 
                     # Pre-compute old model predictions
-                    old_v_pred_list = []
+                    old_v_pred_list: List[torch.Tensor] = []
                     for t_idx in range(self.num_train_timesteps):
                         t_flat = all_timesteps[t_idx]  # (B,) scheduler scale [0, 1000]
                         sigma_broadcast = to_broadcast_tensor(flow_match_sigma(t_flat), clean_latents)
@@ -620,7 +637,7 @@ class CRDTrainer(BaseTrainer):
                             device=clean_latents.device,
                             dtype=clean_latents.dtype,
                         )
-                        batch['_all_random_noise'].append(noise)
+                        all_random_noise.append(noise)
                         noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
 
                         if self.use_old_for_loss:
@@ -633,14 +650,20 @@ class CRDTrainer(BaseTrainer):
                                 old_output = self._compute_crd_output(batch, t_flat, noised_latents)
                         old_v_pred_list.append(old_output['noise_pred'].detach())
 
-                    batch['_old_v_pred_list'] = old_v_pred_list
-                    sample_batches.append(batch)
+                    sample_batches.append(
+                        _CRDBatch(
+                            batch=batch,
+                            all_timesteps=all_timesteps,
+                            all_random_noise=all_random_noise,
+                            old_v_pred_list=old_v_pred_list,
+                        )
+                    )
 
             # ==================== Training Loop ====================
             self.adapter.train()
             loss_info = defaultdict(list)
 
-            for batch in tqdm(
+            for prepared in tqdm(
                 sample_batches,
                 total=len(sample_batches),
                 desc=f'Epoch {self.epoch} Training',
@@ -648,11 +671,12 @@ class CRDTrainer(BaseTrainer):
                 disable=not self.show_progress_bar,
             ):
                 # Retrieve pre-computed data
+                batch = prepared.batch
                 batch_size = batch['all_latents'].shape[0]
                 clean_latents = batch['all_latents'][:, -1]
-                all_timesteps = batch['_all_timesteps']
-                all_random_noise = batch['_all_random_noise']
-                old_v_pred_list = batch['_old_v_pred_list']
+                all_timesteps = prepared.all_timesteps
+                all_random_noise = prepared.all_random_noise
+                old_v_pred_list = prepared.old_v_pred_list
                 # Iterate through timesteps
                 for t_idx in tqdm(
                     range(self.num_train_timesteps),

--- a/src/flow_factory/trainers/dgpo.py
+++ b/src/flow_factory/trainers/dgpo.py
@@ -36,7 +36,7 @@ from diffusers.utils.torch_utils import randn_tensor
 tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
 
 from ..hparams import DGPOTrainingArguments
-from ..samples import BaseSample
+from ..samples import BaseSample, StackedSampleBatch
 from ..utils.base import (
     create_generator,
     create_generator_by_prompt,
@@ -763,8 +763,10 @@ class DGPOTrainer(BaseTrainer):
                 # here; the prefetch dividend is realised inside the single-pass
                 # trainers' optimize loops, not this builder. DGPO samples are
                 # final-latent-only, so the H2D is tiny regardless.
-                batch = BaseSample.stack([s.to(device) for s in samples_slice])
-                all_latents: torch.Tensor = batch["all_latents"]  # type: ignore[assignment]
+                batch: StackedSampleBatch = BaseSample.stack(
+                    [s.to(device) for s in samples_slice]
+                )
+                all_latents: torch.Tensor = batch["all_latents"]
                 clean_latents = all_latents[:, -1]
                 batch_size = clean_latents.shape[0]
 

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -238,8 +238,8 @@ class DiffusionOPDTrainer(BaseTrainer):
             # Swap teacher weights in OUTSIDE the autocast context.
             with self.adapter.use_named_parameters(teacher_name):
                 with self.autocast():
-                    for batch, micro_batch_samples in tqdm(
-                        self._iter_prefetched_sample_batches(
+                    for batch in tqdm(
+                        self._iter_prefetched_batches(
                             teacher_samples, per_device_batch_size
                         ),
                         total=num_batches,
@@ -258,7 +258,7 @@ class DiffusionOPDTrainer(BaseTrainer):
                         ]
                         # (B, num_train_steps, *latent)
                         mu_teacher_stacked = torch.stack(mu_teacher_steps, dim=1)
-                        for j, sample in enumerate(micro_batch_samples):
+                        for j, sample in enumerate(batch.samples):
                             sample.extra_kwargs["mu_teacher"] = (
                                 mu_teacher_stacked[j].to(self._mu_store_device).clone()
                             )
@@ -288,8 +288,8 @@ class DiffusionOPDTrainer(BaseTrainer):
             teacher_kl_count = torch.zeros(num_teachers, device=device)
             grad_norm = None
 
-            for batch, batch_samples in tqdm(
-                self._iter_prefetched_sample_batches(
+            for batch in tqdm(
+                self._iter_prefetched_batches(
                     shuffled_samples, per_device_batch_size
                 ),
                 total=num_batches,
@@ -299,7 +299,7 @@ class DiffusionOPDTrainer(BaseTrainer):
             ):
                 # Teacher index per sample in this (possibly source-mixed) micro-batch.
                 teacher_idx = torch.tensor(
-                    [self._teacher_index_for_sample(s) for s in batch_samples],
+                    [self._teacher_index_for_sample(s) for s in batch.samples],
                     device=device,
                     dtype=torch.long,
                 )  # (B,)


### PR DESCRIPTION
## Summary

Replaces `BaseSample.stack()`'s anonymous `Dict[str, Any]` return with a dedicated `StackedSampleBatch(dict)` value type, and tightens the surrounding code. This is the follow-up ("Option B") deferred from #193 — make the "batched samples" concept explicit without overloading `BaseSample`.

Pure refactor, no behavioral change: step-0 loss is **byte-identical to `main`** on CRD, DPPO, and OPD.

### Changes
- **`StackedSampleBatch(dict)`** (`samples/samples.py`): a `dict` subclass, so `batch[k]`, `.get`, `.items()`, `**batch`, and in-place `batch[k]=v` all keep working unchanged. Constructed directly from samples — `StackedSampleBatch(samples)` builds the collated mapping internally (no redundant `mapping` arg). Carries `.samples` (the source per-sample objects) and a derived `.sample_cls`, and exposes read-only attribute access (`batch.all_latents`). `BaseSample.stack()` is now a thin alias.
- **`BaseSample` cleanup**: fail-fast guard in `to_dict()` when an `extra_kwargs` key collides with a declared field; removed dead `from_dict()` / `short_rep()`; documented the per-sample-only invariant (batched data lives in `StackedSampleBatch`, never a batched `BaseSample`).
- **`trainers/abc.py`**: collapsed the two prefetch iterators into a single `_iter_prefetched_batches` yielding `StackedSampleBatch`; the per-sample list now rides on `batch.samples` (only OPD needs it).
- **`trainers/crd.py`**: pass-1 scratch (`_all_timesteps` / `_all_random_noise` / `_old_v_pred_list`) moved into a typed CRD-local `_CRDBatch` bundle (`prepared.old_v_pred_list`) instead of stringly-keyed scratch on the shared batch.
- **`trainers/opd/trainer.py`**: reads `batch.samples` for teacher routing / `mu_teacher` write-back.
- **`trainers/dgpo.py`**: typed batch local; dropped the `# type: ignore`.

### Why not return a `BaseSample`?
A batched `BaseSample` would violate its own "tensors without batch dim" invariant, and `__post_init__` re-canonicalizes media keeping only index 0 — corrupting a batch. A dedicated, drop-in batch type expresses the concept honestly while staying a `dict` for zero consumer churn.

## Test plan
- [x] Linter clean on all changed files.
- [x] CPU unit checks: `StackedSampleBatch(samples)` builds the correct mapping (tensors stacked, shared fields take first, `extra_kwargs` lifted+stacked); `.samples` identity preserved (enables `mu_teacher` write-back); `**batch` excludes `.samples`/`.sample_cls`; `to_dict()` collision guard raises; empty → `ValueError`.
- [x] **Step-0 byte-identical to `main`** (`main` worktree + `PYTHONPATH`, 2x H20, FLUX.2-klein-4B / SD3.5-medium, offload on):
  - CRD: `policy_loss=0.0052, grad_norm=0.0713`
  - DPPO: `policy_loss=-0.1053, grad_norm=0.0007`
  - OPD: `kl_div=0.0004, grad_norm=0.0003`
