### PR TITLE
[examples] chore: drop private-fork migration comments from DPPO teacher configs

### DIFF
--- a/examples/dppo/lora/sd3_5/geneval_teacher.yaml
+++ b/examples/dppo/lora/sd3_5/geneval_teacher.yaml
@@ -1,6 +1,4 @@
 # Checkpoint: https://huggingface.co/Jayce-Ping/GenEval-Teacher
-# DPPO teacher config migrated from private flow_dppo/geneval.yaml.
-# Mapping: grpo + mask_type: kl_adv -> dppo + kl_mask_type: v-based; kl_beta=0.
 # Trains SD3.5-Medium LoRA on dataset/geneval with GenEval reward (float32, sync).
 
 # Environment Configuration

--- a/examples/dppo/lora/sd3_5/ocr_teacher.yaml
+++ b/examples/dppo/lora/sd3_5/ocr_teacher.yaml
@@ -1,6 +1,4 @@
 # Checkpoint: https://huggingface.co/Jayce-Ping/OCR-Teacher
-# DPPO teacher config migrated from private flow_dppo/ocr.yaml.
-# Mapping: grpo + mask_type: kl_adv -> dppo + kl_mask_type: v-based; kl_beta=0.
 # Trains SD3.5-Medium LoRA on dataset/ocr with OCR reward (sync).
 
 # Environment Configuration

--- a/examples/dppo/lora/sd3_5/pickscore_teacher.yaml
+++ b/examples/dppo/lora/sd3_5/pickscore_teacher.yaml
@@ -1,6 +1,4 @@
 # Checkpoint: https://huggingface.co/Jayce-Ping/Pickscore-Teacher
-# DPPO teacher config migrated from private flow_dppo/pickscore.yaml.
-# Mapping: grpo + mask_type: kl_adv -> dppo + kl_mask_type: v-based; kl_beta=0.
 # Trains SD3.5-Medium LoRA on dataset/pickscore with PickScore reward (async).
 
 # Environment Configuration


### PR DESCRIPTION
## Summary

Follow-up to #200. Removes the two private-fork migration/mapping header comment lines from all three DPPO teacher configs:

- `# DPPO teacher config migrated from private flow_dppo/<name>.yaml.`
- `# Mapping: grpo + mask_type: kl_adv -> dppo + kl_mask_type: v-based; kl_beta=0.`

Each file header now keeps only:
- `# Checkpoint: <url>` — the published HuggingFace teacher LoRA
- `# Trains SD3.5-Medium LoRA on dataset/<name> with <reward> reward (...)` — one-line training summary

This scrubs the remaining private-fork reference from the configs, consistent with the earlier repo-wide private-fork reference cleanup. No YAML keys or values are changed — comment-only.

## Test plan

- [x] `git diff` confirms exactly 2 lines removed per file (6 deletions total), comment-only.
- [x] All three YAMLs still load via `Arguments.load_from_yaml` (`trainer_type='dppo'`, `run_name` intact).