### PR TITLE
[scheduler,models,trainers,docs] refactor: rename flow output to velocity

### DIFF
--- a/.agents/knowledge/topics/adapter_conventions.md
+++ b/.agents/knowledge/topics/adapter_conventions.md
@@ -20,7 +20,7 @@ All adapters that support CFG must follow a consistent two-stage pattern. Guidan
 - `forward()` receives `negative_prompt_embeds` (may be `None`).
 - **CFG condition**: `do_classifier_free_guidance = guidance_scale > 1.0 and negative_prompt_embeds is not None`.
 - If `guidance_scale > 1.0` but `negative_prompt_embeds is None`, emit `logger.warning(...)` and **fall back to the no-CFG path** (no error). The warning message must mention both the passed scale and the missing embeddings.
-- CFG formula: `noise_pred = noise_uncond + guidance_scale * (noise_cond - noise_uncond)`.
+- CFG formula: `velocity = velocity_uncond + guidance_scale * (velocity_cond - velocity_uncond)`.
 
 ### Reference implementation
 

--- a/.agents/knowledge/topics/dtype_precision.md
+++ b/.agents/knowledge/topics/dtype_precision.md
@@ -38,7 +38,7 @@ def cast_latents(self, latents, default_dtype=None):
 
 ## 1/sigma Error Amplification
 
-Scheduler math uses `1/sigma` to scale noise predictions. Near the end of the denoising schedule, sigma approaches zero and errors are amplified:
+Scheduler math uses `1/sigma` to scale velocity predictions. Near the end of the denoising schedule, sigma approaches zero and errors are amplified:
 
 ```
 Example: sigma = 0.01, epsilon_error = 1.5e-4

--- a/.agents/knowledge/topics/parity_testing.md
+++ b/.agents/knowledge/topics/parity_testing.md
@@ -59,4 +59,4 @@ def compare_tensors(name: str, a: torch.Tensor, b: torch.Tensor, atol: float = 1
 ## Cross-refs
 
 - `adapter_conventions.md` (inference/forward identity, upstream alignment rules)
-- `dtype_precision.md` (noise dtype for comparison tolerance)
+- `dtype_precision.md` (tensor dtype for comparison tolerance)

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -136,7 +136,7 @@ train:
 ```
 
 Here, `x-based` calculates the KL loss in the **latent space**,
-while v-based calculates it in the **predicted velocity space** (or **noise space**).
+while v-based calculates it in the **predicted velocity space**.
 The `kl_beta` parameter controls the coefficient of the KL divergence term.
 
 **Memory Considerations**: Since calculating KL loss requires maintaining a copy of the original model, *VRAM usage scales with the number of trainable parameters*. 
@@ -171,7 +171,7 @@ The two KL computations are **decoupled**: `kl_mask_type` selects the space of t
 ```yaml
 train:
     trainer_type: 'dppo'
-    kl_mask_type: 'x-based'    # Trust-region mask KL(current||old) space: 'x-based' (next_latents_mean) or 'v-based' (noise_pred)
+    kl_mask_type: 'x-based'    # Trust-region mask KL(current||old) space: 'x-based' (next_latents_mean) or 'v-based' (velocity)
     kl_mask_threshold: 1.0e-6  # Per-step KL trust-region; larger keeps more samples
     kl_type: 'x-based'         # KL(current||reference) penalty space: 'x-based' or 'v-based'
     kl_beta: 1.0e-3            # Optional KL(current||reference) penalty (0 disables)

--- a/guidance/new_model.md
+++ b/guidance/new_model.md
@@ -380,7 +380,7 @@ def inference(
             prompt_embeds=prompt_embeds,
             compute_log_prob=current_compute_log_prob,
             noise_level=noise_level,
-            return_kwargs=['next_latents', 'log_prob', 'noise_pred', ...],
+            return_kwargs=['next_latents', 'log_prob', 'velocity', ...],
             ...
         )
         
@@ -436,7 +436,7 @@ def inference(
 | Utility | Purpose |
 |---|---|
 | `create_trajectory_collector(indices, T)` | Selectively stores latents/log-probs only at specified timesteps |
-| `create_callback_collector(indices, T)` | Captures arbitrary per-step outputs (e.g., `noise_level`, `noise_pred`) |
+| `create_callback_collector(indices, T)` | Captures arbitrary per-step outputs (e.g., `noise_level`, `velocity`) |
 
 
 ### Step 6: Implement `forward()`
@@ -459,7 +459,7 @@ def forward(
     guidance_scale: float = 4.0,
     noise_level: Optional[float] = None,
     compute_log_prob: bool = True,
-    return_kwargs: List[str] = ['noise_pred', 'next_latents', 'log_prob', ...],
+    return_kwargs: List[str] = ['velocity', 'next_latents', 'log_prob', ...],
 ) -> SDESchedulerOutput:
     """
     Single denoising step: transformer forward + scheduler step.
@@ -471,7 +471,7 @@ def forward(
     Returns:
         SDESchedulerOutput with fields gated by `return_kwargs`:
         - next_latents: Denoised latents for the next step
-        - noise_pred: Model's velocity/noise prediction
+        - velocity: Model's velocity prediction
         - log_prob: Log-probability under the SDE formulation
         - next_latents_mean: Deterministic mean (before noise injection)
         - std_dev_t, dt: SDE statistics
@@ -482,7 +482,7 @@ def forward(
     #    (e.g., concatenate condition image latents, handle CFG doubling)
     
     # 2. Transformer forward pass
-    noise_pred = self.transformer(
+    velocity = self.transformer(
         hidden_states=latents,
         timestep=t.expand(batch_size) / 1000,
         encoder_hidden_states=prompt_embeds,
@@ -491,11 +491,11 @@ def forward(
     )[0]
     
     # 3. Post-process (e.g., extract target portion, apply CFG)
-    #    noise_pred = noise_pred[:, :latents.shape[1]]  # Remove condition tokens
+    #    velocity = velocity[:, :latents.shape[1]]  # Remove condition tokens
     
     # 4. Scheduler step — this handles SDE dynamics and log-prob computation
     output = self.scheduler.step(
-        noise_pred=noise_pred,
+        velocity=velocity,
         timestep=t,
         latents=latents,
         timestep_next=t_next,

--- a/src/flow_factory/hparams/training_args/crd.py
+++ b/src/flow_factory/hparams/training_args/crd.py
@@ -90,7 +90,7 @@ class CRDTrainingArguments(TrainingArguments):
             "help": (
                 "CFG scale for the teacher (reference) model during KL computation. "
                 "If > 1.0, the reference forward pass uses classifier-free guidance: "
-                "``noise_pred = uncond + kl_cfg * (cond - uncond)``. "
+                "``velocity = velocity_uncond + kl_cfg * (velocity_cond - velocity_uncond)``. "
                 "Set to 1.0 (default) to disable CFG on the teacher."
             )
         },

--- a/src/flow_factory/models/bagel/bagel.py
+++ b/src/flow_factory/models/bagel/bagel.py
@@ -1292,7 +1292,7 @@ class BagelAdapter(BaseAdapter):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
             return_kwargs = list(
-                set(["next_latents", "log_prob", "noise_pred"] + extra_call_back_kwargs)
+                set(["next_latents", "log_prob", "velocity"] + extra_call_back_kwargs)
             )
 
             # Single forward step: flow prediction + scheduler step. Context is
@@ -1548,7 +1548,7 @@ class BagelAdapter(BaseAdapter):
 
         # ── Scheduler step (timesteps stay in [0, 1000]) ──
         output = self.scheduler.step(
-            noise_pred=v_t,
+            velocity=v_t,
             timestep=t,
             latents=latents,
             timestep_next=t_next,
@@ -1613,11 +1613,11 @@ class BagelAdapter(BaseAdapter):
 
         Returns:
             ``SDESchedulerOutput`` with ``next_latents``, ``log_prob``,
-            ``noise_pred``, etc. depending on ``return_kwargs``.
+            ``velocity``, etc. depending on ``return_kwargs``.
         """
         if return_kwargs is None:
             return_kwargs = [
-                "noise_pred",
+                "velocity",
                 "next_latents",
                 "next_latents_mean",
                 "std_dev_t",

--- a/src/flow_factory/models/flux/flux1.py
+++ b/src/flow_factory/models/flux/flux1.py
@@ -218,7 +218,7 @@ class Flux1Adapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -308,7 +308,7 @@ class Flux1Adapter(BaseAdapter):
         noise_level: Optional[float] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs : List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs : List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """Forward pass with given timestep, timestep+1 and latents."""
         # 1. Prepare variables
@@ -320,7 +320,7 @@ class Flux1Adapter(BaseAdapter):
         guidance = guidance.expand(batch_size) # Assume List[float] has len `batch_size`
 
         # 2. transformer forward
-        noise_pred = self.transformer(
+        velocity = self.transformer(
             hidden_states=latents,
             timestep=t.expand(batch_size) / 1000,
             guidance=guidance,
@@ -334,7 +334,7 @@ class Flux1Adapter(BaseAdapter):
 
         # 3. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/flux/flux1_kontext.py
+++ b/src/flow_factory/models/flux/flux1_kontext.py
@@ -430,7 +430,7 @@ class Flux1KontextAdapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -525,7 +525,7 @@ class Flux1KontextAdapter(BaseAdapter):
         noise_level: Optional[float] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         Forward pass with given timestep, next timestep, and latents.
@@ -559,7 +559,7 @@ class Flux1KontextAdapter(BaseAdapter):
         latent_model_input = torch.cat([latents, image_latents], dim=1)
 
         # 2. Transformer foward pass
-        noise_pred = self.transformer(
+        velocity = self.transformer(
             hidden_states=latent_model_input,
             timestep=t.expand(batch_size) / 1000,  # Scale timestep to [0, 1]
             guidance=guidance,
@@ -572,11 +572,11 @@ class Flux1KontextAdapter(BaseAdapter):
         )[0]
 
         # Extract only the target latent predictions (exclude condition image part)
-        noise_pred = noise_pred[:, :latents.shape[1]]
+        velocity = velocity[:, :latents.shape[1]]
 
         # 3. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/flux/flux2.py
+++ b/src/flow_factory/models/flux/flux2.py
@@ -558,7 +558,7 @@ class Flux2Adapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self._forward(
@@ -774,7 +774,7 @@ class Flux2Adapter(BaseAdapter):
         guidance_scale: float = 4.0,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
         noise_level: Optional[float] = None,
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
@@ -813,7 +813,7 @@ class Flux2Adapter(BaseAdapter):
             latent_image_ids = torch.cat([latent_ids, image_latent_ids], dim=1)
 
         # Forward pass
-        noise_pred = self.transformer(
+        velocity = self.transformer(
             hidden_states=latent_model_input,
             timestep=t.expand(batch_size) / 1000,  # Scale timestep
             guidance=guidance,
@@ -825,11 +825,11 @@ class Flux2Adapter(BaseAdapter):
         )[0]
 
         # Extract only target latent predictions (exclude condition image part)
-        noise_pred = noise_pred[:, :latents.shape[1]]
+        velocity = velocity[:, :latents.shape[1]]
 
         # Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,
@@ -859,7 +859,7 @@ class Flux2Adapter(BaseAdapter):
         noise_level: Optional[float] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         General forward method handling both T2I and I2I, including ragged I2I batches.

--- a/src/flow_factory/models/flux/flux2_klein.py
+++ b/src/flow_factory/models/flux/flux2_klein.py
@@ -496,7 +496,7 @@ class Flux2KleinAdapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self._forward(
@@ -738,7 +738,7 @@ class Flux2KleinAdapter(BaseAdapter):
         noise_level: Optional[float] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         Core forward pass handling both T2I and I2I.
@@ -783,7 +783,7 @@ class Flux2KleinAdapter(BaseAdapter):
 
         # 2. Conditional forward pass
         with self.pipeline.transformer.cache_context("cond"):
-            noise_pred = self.transformer(
+            velocity = self.transformer(
                 hidden_states=latent_model_input,
                 timestep=t.expand(batch_size) / 1000,
                 guidance=None,
@@ -795,12 +795,12 @@ class Flux2KleinAdapter(BaseAdapter):
             )[0]
 
         # Extract only target latent predictions (exclude condition image part)
-        noise_pred = noise_pred[:, :latents.shape[1]]
+        velocity = velocity[:, :latents.shape[1]]
 
         # 3. CFG: unconditional forward pass
         if do_classifier_free_guidance:
             with self.pipeline.transformer.cache_context("uncond"):
-                neg_noise_pred = self.transformer(
+                neg_velocity = self.transformer(
                     hidden_states=latent_model_input,
                     timestep=t.expand(batch_size) / 1000,
                     guidance=None,
@@ -811,12 +811,12 @@ class Flux2KleinAdapter(BaseAdapter):
                     return_dict=False,
                 )[0]
 
-            neg_noise_pred = neg_noise_pred[:, :latents.shape[1]]
-            noise_pred = neg_noise_pred + guidance_scale * (noise_pred - neg_noise_pred)
+            neg_velocity = neg_velocity[:, :latents.shape[1]]
+            velocity = neg_velocity + guidance_scale * (velocity - neg_velocity)
 
         # 4. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,
@@ -849,7 +849,7 @@ class Flux2KleinAdapter(BaseAdapter):
         noise_level: Optional[float] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         General forward method handling both T2I and I2I, including ragged I2I batches.

--- a/src/flow_factory/models/ltx2/ltx2_i2av.py
+++ b/src/flow_factory/models/ltx2/ltx2_i2av.py
@@ -727,7 +727,7 @@ class LTX2_I2AV_Adapter(BaseAdapter):
         audio_coords: Optional[torch.Tensor] = None,
         noise_level: Optional[float] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ["next_latents", "log_prob", "noise_pred"],
+        return_kwargs: List[str] = ["next_latents", "log_prob", "velocity"],
         use_cross_timestep: bool = False,
         **kwargs,
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
@@ -1000,7 +1000,7 @@ class LTX2_I2AV_Adapter(BaseAdapter):
             # Make sure `next_latents` is included in return_kwargs
             return_kwargs = list({"next_latents"} | set(return_kwargs))
             video_output = self.scheduler.step(
-                noise_pred=gen_pred,
+                velocity=gen_pred,
                 timestep=t,
                 latents=gen_lats,
                 timestep_next=t_next,
@@ -1016,9 +1016,9 @@ class LTX2_I2AV_Adapter(BaseAdapter):
             video_output.next_latents = self.pipeline._pack_latents(
                 next_5d, patch_size, patch_size_t
             )
-            if video_output.noise_pred is not None:
-                pred_5d = torch.cat([video_pred_5d[:, :, :1], video_output.noise_pred], dim=2)
-                video_output.noise_pred = self.pipeline._pack_latents(
+            if video_output.velocity is not None:
+                pred_5d = torch.cat([video_pred_5d[:, :, :1], video_output.velocity], dim=2)
+                video_output.velocity = self.pipeline._pack_latents(
                     pred_5d, patch_size, patch_size_t
                 )
             if video_output.next_latents_mean is not None:
@@ -1030,7 +1030,7 @@ class LTX2_I2AV_Adapter(BaseAdapter):
                 )
         else:
             video_output = self.scheduler.step(
-                noise_pred=video_pred,
+                velocity=video_pred,
                 timestep=t,
                 latents=video_latents,
                 timestep_next=t_next,
@@ -1044,7 +1044,7 @@ class LTX2_I2AV_Adapter(BaseAdapter):
 
         # --- 8. Audio: SDE scheduler step (twin of video, with log_prob) ---
         audio_output = self.audio_scheduler.step(
-            noise_pred=audio_pred,
+            velocity=audio_pred,
             timestep=t,
             latents=audio_latents,
             timestep_next=t_next,
@@ -1069,9 +1069,9 @@ class LTX2_I2AV_Adapter(BaseAdapter):
                 [video_output.next_latents_mean, audio_output.next_latents_mean],
                 dim=1,
             )
-        if video_output.noise_pred is not None:
-            video_output.noise_pred = torch.cat(
-                [video_output.noise_pred, audio_pred],
+        if video_output.velocity is not None:
+            video_output.velocity = torch.cat(
+                [video_output.velocity, audio_pred],
                 dim=1,
             )
 
@@ -1307,7 +1307,7 @@ class LTX2_I2AV_Adapter(BaseAdapter):
             noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
             return_kw = list(
-                set(["next_latents", "log_prob", "noise_pred"] + extra_call_back_kwargs)
+                set(["next_latents", "log_prob", "velocity"] + extra_call_back_kwargs)
             )
             current_compute_log_prob: bool = compute_log_prob and noise_level > 0
 

--- a/src/flow_factory/models/ltx2/ltx2_t2av.py
+++ b/src/flow_factory/models/ltx2/ltx2_t2av.py
@@ -669,7 +669,7 @@ class LTX2_T2AV_Adapter(BaseAdapter):
         # SDE control
         noise_level: Optional[float] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ["next_latents", "log_prob", "noise_pred"],
+        return_kwargs: List[str] = ["next_latents", "log_prob", "velocity"],
         # LTX-2.3 compatibility
         use_cross_timestep: bool = False,
         **kwargs,
@@ -916,7 +916,7 @@ class LTX2_T2AV_Adapter(BaseAdapter):
 
         # --- 8. Video: SDE scheduler step (with log_prob) ---
         video_output = self.scheduler.step(
-            noise_pred=video_pred,
+            velocity=video_pred,
             timestep=t,
             latents=video_latents,
             timestep_next=t_next,
@@ -929,7 +929,7 @@ class LTX2_T2AV_Adapter(BaseAdapter):
 
         # --- 9. Audio: SDE scheduler step (twin of video, with log_prob) ---
         audio_output = self.audio_scheduler.step(
-            noise_pred=audio_pred,
+            velocity=audio_pred,
             timestep=t,
             latents=audio_latents,
             timestep_next=t_next,
@@ -954,9 +954,9 @@ class LTX2_T2AV_Adapter(BaseAdapter):
                 [video_output.next_latents_mean, audio_output.next_latents_mean],
                 dim=1,
             )
-        if video_output.noise_pred is not None:
-            video_output.noise_pred = torch.cat(
-                [video_output.noise_pred, audio_pred],
+        if video_output.velocity is not None:
+            video_output.velocity = torch.cat(
+                [video_output.velocity, audio_pred],
                 dim=1,
             )
 
@@ -1188,7 +1188,7 @@ class LTX2_T2AV_Adapter(BaseAdapter):
             noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
             return_kw = list(
-                set(["next_latents", "log_prob", "noise_pred"] + extra_call_back_kwargs)
+                set(["next_latents", "log_prob", "velocity"] + extra_call_back_kwargs)
             )
             current_compute_log_prob: bool = compute_log_prob and noise_level > 0
 

--- a/src/flow_factory/models/qwen_image/qwen_image.py
+++ b/src/flow_factory/models/qwen_image/qwen_image.py
@@ -400,7 +400,7 @@ class QwenImageAdapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -498,7 +498,7 @@ class QwenImageAdapter(BaseAdapter):
         noise_level: Optional[float] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         Core forward pass for T2I generation.
@@ -585,18 +585,18 @@ class QwenImageAdapter(BaseAdapter):
                 attention_kwargs=attention_kwargs,
                 return_dict=False,
             )[0]
-            noise_pred, neg_noise_pred = both_pred.chunk(2, dim=0)
+            velocity, neg_velocity = both_pred.chunk(2, dim=0)
 
-            comb_pred = neg_noise_pred + guidance_scale * (noise_pred - neg_noise_pred)
+            comb_pred = neg_velocity + guidance_scale * (velocity - neg_velocity)
 
             # Rescale norm (Qwen-Image specific)
-            cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+            cond_norm = torch.norm(velocity, dim=-1, keepdim=True)
             noise_norm = torch.norm(comb_pred, dim=-1, keepdim=True)
-            noise_pred = comb_pred * (cond_norm / noise_norm)
+            velocity = comb_pred * (cond_norm / noise_norm)
         else:
             # Single conditional forward pass (no CFG).
             with self.pipeline.transformer.cache_context("cond"):
-                noise_pred = self.transformer(
+                velocity = self.transformer(
                     hidden_states=latents,
                     timestep=timestep / 1000,
                     guidance=guidance,
@@ -609,7 +609,7 @@ class QwenImageAdapter(BaseAdapter):
 
         # 3. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/qwen_image/qwen_image_edit_plus.py
+++ b/src/flow_factory/models/qwen_image/qwen_image_edit_plus.py
@@ -795,7 +795,7 @@ class QwenImageEditPlusAdapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self._forward(
@@ -988,7 +988,7 @@ class QwenImageEditPlusAdapter(BaseAdapter):
         noise_level: Optional[float] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         Core forward pass handling both T2I and I2I.
@@ -1083,18 +1083,18 @@ class QwenImageEditPlusAdapter(BaseAdapter):
                 return_dict=False,
             )[0]
             both_pred = both_pred[:, :latents.size(1)]
-            noise_pred, neg_noise_pred = both_pred.chunk(2, dim=0)
+            velocity, neg_velocity = both_pred.chunk(2, dim=0)
 
-            comb_pred = neg_noise_pred + guidance_scale * (noise_pred - neg_noise_pred)
+            comb_pred = neg_velocity + guidance_scale * (velocity - neg_velocity)
 
             # Rescale norm (Qwen-Image-Edit Plus specific)
-            cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+            cond_norm = torch.norm(velocity, dim=-1, keepdim=True)
             noise_norm = torch.norm(comb_pred, dim=-1, keepdim=True)
-            noise_pred = comb_pred * (cond_norm / noise_norm)
+            velocity = comb_pred * (cond_norm / noise_norm)
         else:
             # Single conditional forward pass (no CFG).
             with self.pipeline.transformer.cache_context("cond"):
-                noise_pred = self.transformer(
+                velocity = self.transformer(
                     hidden_states=latent_model_input,
                     timestep=timestep / 1000,
                     guidance=guidance,
@@ -1104,11 +1104,11 @@ class QwenImageEditPlusAdapter(BaseAdapter):
                     attention_kwargs=attention_kwargs,
                     return_dict=False,
                 )[0]
-            noise_pred = noise_pred[:, :latents.size(1)]
+            velocity = velocity[:, :latents.size(1)]
 
         # 3. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,
@@ -1140,7 +1140,7 @@ class QwenImageEditPlusAdapter(BaseAdapter):
         noise_level: Optional[float] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         General forward method handling both T2I and I2I, including ragged I2I batches.

--- a/src/flow_factory/models/stable_diffusion/sd3_5.py
+++ b/src/flow_factory/models/stable_diffusion/sd3_5.py
@@ -273,7 +273,7 @@ class SD3_5Adapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -366,7 +366,7 @@ class SD3_5Adapter(BaseAdapter):
         noise_level: Optional[float] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         Core forward pass for T2I generation.
@@ -418,7 +418,7 @@ class SD3_5Adapter(BaseAdapter):
             timestep_input = timestep
 
         # 3. Transformer forward pass
-        noise_pred = self.transformer(
+        velocity = self.transformer(
             hidden_states=latents_input,
             timestep=timestep_input,
             encoder_hidden_states=prompt_embeds_input,
@@ -429,12 +429,12 @@ class SD3_5Adapter(BaseAdapter):
 
         # 4. Apply CFG
         if do_classifier_free_guidance:
-            noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
-            noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+            velocity_uncond, velocity_text = velocity.chunk(2)
+            velocity = velocity_uncond + guidance_scale * (velocity_text - velocity_uncond)
 
         # 5. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/wan/wan2_i2v.py
+++ b/src/flow_factory/models/wan/wan2_i2v.py
@@ -571,7 +571,7 @@ class Wan2_I2V_Adapter(BaseAdapter):
             self.pipeline._current_timestep = t
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -679,7 +679,7 @@ class Wan2_I2V_Adapter(BaseAdapter):
         noise_level: Optional[float] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> UniPCMultistepSDESchedulerOutput:
         """
         Core forward pass for a single denoising step.
@@ -751,7 +751,7 @@ class Wan2_I2V_Adapter(BaseAdapter):
 
         # Conditional forward pass
         with pipeline_transformer.cache_context("cond"):
-            noise_pred = transformer(
+            velocity = transformer(
                 hidden_states=latent_model_input,
                 timestep=timestep,
                 encoder_hidden_states=prompt_embeds,
@@ -763,7 +763,7 @@ class Wan2_I2V_Adapter(BaseAdapter):
         # CFG: unconditional forward pass
         if do_classifier_free_guidance:
             with pipeline_transformer.cache_context("uncond"):
-                noise_uncond = transformer(
+                velocity_uncond = transformer(
                     hidden_states=latent_model_input,
                     timestep=timestep,
                     encoder_hidden_states=negative_prompt_embeds,
@@ -771,11 +771,11 @@ class Wan2_I2V_Adapter(BaseAdapter):
                     attention_kwargs=attention_kwargs,
                     return_dict=False,
                 )[0]
-            noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
+            velocity = velocity_uncond + current_guidance_scale * (velocity - velocity_uncond)
 
         # Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/wan/wan2_t2v.py
+++ b/src/flow_factory/models/wan/wan2_t2v.py
@@ -352,7 +352,7 @@ class Wan2_T2V_Adapter(BaseAdapter):
             self.pipeline._current_timestep = t
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -444,7 +444,7 @@ class Wan2_T2V_Adapter(BaseAdapter):
         noise_level: Optional[float] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
         boundary_timestep: Optional[float] = None,
     ) -> UniPCMultistepSDESchedulerOutput:
         """
@@ -512,7 +512,7 @@ class Wan2_T2V_Adapter(BaseAdapter):
 
         # 3. Transformer forward pass
         with pipeline_transformer.cache_context("cond"):
-            noise_pred = transformer(
+            velocity = transformer(
                 hidden_states=latent_model_input,
                 timestep=timestep,
                 encoder_hidden_states=prompt_embeds,
@@ -523,18 +523,18 @@ class Wan2_T2V_Adapter(BaseAdapter):
         # 4. Apply CFG
         if do_classifier_free_guidance:
             with pipeline_transformer.cache_context("uncond"):
-                noise_uncond = transformer(
+                velocity_uncond = transformer(
                     hidden_states=latent_model_input,
                     timestep=timestep,
                     encoder_hidden_states=negative_prompt_embeds,
                     attention_kwargs=attention_kwargs,
                     return_dict=False,
                 )[0]
-            noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
+            velocity = velocity_uncond + current_guidance_scale * (velocity - velocity_uncond)
 
         # 5. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/wan/wan2_v2v.py
+++ b/src/flow_factory/models/wan/wan2_v2v.py
@@ -373,7 +373,7 @@ class Wan2_V2V_Adapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -465,7 +465,7 @@ class Wan2_V2V_Adapter(BaseAdapter):
         noise_level: Optional[float] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> UniPCMultistepSDESchedulerOutput:
         """
         Core forward pass for V2V generation.
@@ -505,7 +505,7 @@ class Wan2_V2V_Adapter(BaseAdapter):
         latent_model_input = latents.to(dtype)
 
         # 3. Transformer forward pass
-        noise_pred = self.transformer(
+        velocity = self.transformer(
             hidden_states=latent_model_input,
             timestep=timestep,
             encoder_hidden_states=prompt_embeds,
@@ -515,18 +515,18 @@ class Wan2_V2V_Adapter(BaseAdapter):
 
         # 4. Apply CFG
         if do_classifier_free_guidance:
-            noise_uncond = self.transformer(
+            velocity_uncond = self.transformer(
                 hidden_states=latent_model_input,
                 timestep=timestep,
                 encoder_hidden_states=negative_prompt_embeds,
                 attention_kwargs=attention_kwargs,
                 return_dict=False,
             )[0]
-            noise_pred = noise_uncond + guidance_scale * (noise_pred - noise_uncond)
+            velocity = velocity_uncond + guidance_scale * (velocity - velocity_uncond)
 
         # 5. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/models/z_image/z_image.py
+++ b/src/flow_factory/models/z_image/z_image.py
@@ -277,7 +277,7 @@ class ZImageAdapter(BaseAdapter):
         for i, t in enumerate(timesteps):
             current_noise_level = self.scheduler.get_noise_level_for_timestep(t)
             t_next = timesteps[i + 1] if i + 1 < len(timesteps) else torch.tensor(0, device=device)
-            return_kwargs = list(set(['next_latents', 'log_prob', 'noise_pred'] + extra_call_back_kwargs))
+            return_kwargs = list(set(['next_latents', 'log_prob', 'velocity'] + extra_call_back_kwargs))
             current_compute_log_prob = compute_log_prob and current_noise_level > 0
 
             output = self.forward(
@@ -366,7 +366,7 @@ class ZImageAdapter(BaseAdapter):
         # Other
         noise_level: Optional[float] = None,
         compute_log_prob: bool = True,
-        return_kwargs: List[str] = ['noise_pred', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
+        return_kwargs: List[str] = ['velocity', 'next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob'],
     ) -> FlowMatchEulerDiscreteSDESchedulerOutput:
         """
         Core forward pass for T2I generation.
@@ -453,7 +453,7 @@ class ZImageAdapter(BaseAdapter):
         if apply_cfg:
             pos_out = model_out_list[:batch_size]
             neg_out = model_out_list[batch_size:]
-            noise_pred = []
+            velocity = []
             
             for j in range(batch_size):
                 pos = pos_out[j].float()
@@ -468,18 +468,18 @@ class ZImageAdapter(BaseAdapter):
                     if new_pos_norm > max_new_norm:
                         pred = pred * (max_new_norm / new_pos_norm)
                 
-                noise_pred.append(pred)
+                velocity.append(pred)
             
-            noise_pred = torch.stack(noise_pred, dim=0)
+            velocity = torch.stack(velocity, dim=0)
         else:
-            noise_pred = torch.stack([out.float() for out in model_out_list], dim=0)
+            velocity = torch.stack([out.float() for out in model_out_list], dim=0)
 
-        noise_pred = noise_pred.squeeze(2)
-        noise_pred = -noise_pred  # Z-Image specific: negate noise prediction
+        velocity = velocity.squeeze(2)
+        velocity = -velocity  # Z-Image specific: negate velocity prediction
 
         # 6. Scheduler step
         output = self.scheduler.step(
-            noise_pred=noise_pred,
+            velocity=velocity,
             timestep=t,
             latents=latents,
             timestep_next=t_next,

--- a/src/flow_factory/scheduler/abc.py
+++ b/src/flow_factory/scheduler/abc.py
@@ -29,7 +29,7 @@ class SDESchedulerOutput(BaseOutput):
     std_dev_t: Optional[torch.FloatTensor] = None
     dt: Optional[torch.FloatTensor] = None
     log_prob: Optional[torch.FloatTensor] = None
-    noise_pred: Optional[torch.FloatTensor] = None
+    velocity: Optional[torch.FloatTensor] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/src/flow_factory/scheduler/flow_match_euler_discrete.py
+++ b/src/flow_factory/scheduler/flow_match_euler_discrete.py
@@ -242,7 +242,7 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
 
     def step(
         self,
-        noise_pred: torch.Tensor,
+        velocity: torch.Tensor,
         timestep: Union[float, torch.Tensor],
         latents: torch.Tensor,
         next_latents: Optional[torch.Tensor] = None,
@@ -251,7 +251,7 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
         noise_level : Optional[Union[int, float, torch.Tensor]] = None,
         compute_log_prob: bool = True,
         return_dict: bool = True,
-        return_kwargs : List[str] = ['next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob', 'noise_pred'],
+        return_kwargs : List[str] = ['next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob', 'velocity'],
         dynamics_type : Optional[Literal['Flow-SDE', 'Dance-SDE', 'CPS', 'ODE']] = None,
         sigma_max: Optional[float] = None,
     ) -> Union[FlowMatchEulerDiscreteSDESchedulerOutput, Tuple]:
@@ -307,7 +307,7 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
         # to the same precision that will be used during training (e.g. bfloat16).
         # This ensures log_prob is computed on identical values in both phases.
         _input_dtype = latents.dtype
-        noise_pred = noise_pred.float()
+        velocity = velocity.float()
         latents = latents.float()
         if next_latents is not None:
             next_latents = next_latents.float()
@@ -328,7 +328,7 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
         # 3. Compute next sample
         if dynamics_type == 'ODE':
             # ODE Sampling
-            next_latents_mean = latents + noise_pred * dt
+            next_latents_mean = latents + velocity * dt
             std_dev_t = torch.zeros_like(sigma)
 
             if next_latents is None:
@@ -345,15 +345,15 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
             sigma_max = to_broadcast_tensor(sigma_max, latents)
             std_dev_t = torch.sqrt(sigma / (1 - torch.where(sigma == 1.0, sigma_max, sigma))) * noise_level # (batch_size, 1, 1)
 
-            next_latents_mean = latents * (1 + std_dev_t**2 / (2 * sigma) * dt) + noise_pred * (1 + std_dev_t**2 * (1 - sigma) / (2 * sigma)) * dt
+            next_latents_mean = latents * (1 + std_dev_t**2 / (2 * sigma) * dt) + velocity * (1 + std_dev_t**2 * (1 - sigma) / (2 * sigma)) * dt
             
             if next_latents is None:
                 # Non-deterministic step, add noise to it
                 variance_noise = randn_tensor(
-                    noise_pred.shape,
+                    velocity.shape,
                     generator=generator,
-                    device=noise_pred.device,
-                    dtype=noise_pred.dtype,
+                    device=velocity.device,
+                    dtype=velocity.dtype,
                 )
                 # Last term of Equation (9)
                 next_latents = next_latents_mean + std_dev_t * torch.sqrt(-1 * dt) * variance_noise
@@ -371,16 +371,16 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
                 log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
 
         elif dynamics_type == "Dance-SDE":
-            pred_original_sample = latents - sigma * noise_pred
+            pred_original_sample = latents - sigma * velocity
             std_dev_t = noise_level
             log_term = 0.5 * noise_level**2 * (latents - pred_original_sample * (1 - sigma)) / sigma**2
-            next_latents_mean = latents + (noise_pred + log_term) * dt
+            next_latents_mean = latents + (velocity + log_term) * dt
             if next_latents is None:
                 variance_noise = randn_tensor(
-                    noise_pred.shape,
+                    velocity.shape,
                     generator=generator,
-                    device=noise_pred.device,
-                    dtype=noise_pred.dtype,
+                    device=velocity.device,
+                    dtype=velocity.dtype,
                 )
                 next_latents = next_latents_mean + std_dev_t * torch.sqrt(-1 * dt) * variance_noise
                 # Round-trip through storage dtype for train-inference consistency
@@ -400,16 +400,16 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
         elif dynamics_type == "CPS":
             # FlowCPS
             std_dev_t = sigma_prev * torch.sin(noise_level * torch.pi / 2)
-            x0 = latents - sigma * noise_pred
-            x1 = latents + noise_pred * (1 - sigma)
+            x0 = latents - sigma * velocity
+            x1 = latents + velocity * (1 - sigma)
             next_latents_mean = x0 * (1 - sigma_prev) + x1 * torch.sqrt(sigma_prev**2 - std_dev_t**2)
         
             if next_latents is None:
                 variance_noise = randn_tensor(
-                    noise_pred.shape,
+                    velocity.shape,
                     generator=generator,
-                    device=noise_pred.device,
-                    dtype=noise_pred.dtype,
+                    device=velocity.device,
+                    dtype=velocity.dtype,
                 )
                 next_latents = next_latents_mean + std_dev_t * variance_noise
                 # Round-trip through storage dtype for train-inference consistency
@@ -422,11 +422,11 @@ class FlowMatchEulerDiscreteSDEScheduler(FlowMatchEulerDiscreteScheduler, SDESch
 
         if not compute_log_prob:
             # # Empty tensor as placeholder
-            # log_prob = torch.empty((latents.shape[0]), dtype=torch.float32, device=noise_pred.device)
+            # log_prob = torch.empty((latents.shape[0]), dtype=torch.float32, device=velocity.device)
             log_prob = None # Use None to save memory
 
         if not return_dict:
-            return (next_latents, next_latents_mean, noise_pred, log_prob, std_dev_t, dt)
+            return (next_latents, next_latents_mean, velocity, log_prob, std_dev_t, dt)
 
         d = {}        
         for k in return_kwargs:

--- a/src/flow_factory/scheduler/unipc_multistep.py
+++ b/src/flow_factory/scheduler/unipc_multistep.py
@@ -206,7 +206,7 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
 
     def step(
         self,
-        noise_pred: torch.Tensor,
+        velocity: torch.Tensor,
         timestep: Union[int, float, torch.Tensor],
         latents: torch.Tensor,
         next_latents: Optional[torch.Tensor] = None,
@@ -215,7 +215,7 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
         noise_level : Optional[Union[int, float, torch.Tensor]] = None,
         compute_log_prob: bool = True,
         return_dict: bool = True,
-        return_kwargs : List[str] = ['next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob', 'noise_pred'],
+        return_kwargs : List[str] = ['next_latents', 'next_latents_mean', 'std_dev_t', 'dt', 'log_prob', 'velocity'],
         dynamics_type : Optional[Literal['Flow-SDE', 'Dance-SDE', 'CPS', 'ODE']] = None,
         sigma_max: Optional[float] = None,
     ) -> Union[UniPCMultistepSDESchedulerOutput, Tuple]:
@@ -223,7 +223,7 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
         SDE step for UniPC scheduler.
         
         Args:
-            noise_pred (torch.FloatTensor): The predicted noise residual.
+            velocity (torch.FloatTensor): The predicted flow velocity field.
             timestep (int, float, or torch.Tensor): The current timestep.
             latents (torch.FloatTensor): The current latent tensor.
             next_latents (torch.FloatTensor, optional): If provided, use this as the next latents instead of sampling.
@@ -284,14 +284,14 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
 
         # 0.  Use super().step() fro evaluation
         if self.is_eval:
-            next_latents_mean = super().step(noise_pred, timestep, latents, return_dict=False)[0]
+            next_latents_mean = super().step(velocity, timestep, latents, return_dict=False)[0]
             return UniPCMultistepSDESchedulerOutput(next_latents=next_latents_mean)
 
         # 1. Numerical Preparation
         # Remember input dtype so we can quantize freshly-sampled next_latents
         # to the same precision that will be used during training (e.g. bfloat16).
         _input_dtype = latents.dtype
-        noise_pred = noise_pred.float()
+        velocity = velocity.float()
         latents = latents.float()
         if next_latents is not None:
             next_latents = next_latents.float()
@@ -312,7 +312,7 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
         # 3. Compute next sample
         if dynamics_type == 'ODE':
             # ODE Sampling
-            next_latents_mean = latents + noise_pred * dt
+            next_latents_mean = latents + velocity * dt
             std_dev_t = torch.zeros_like(sigma)
 
             if next_latents is None:
@@ -329,15 +329,15 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
             sigma_max = to_broadcast_tensor(sigma_max, latents)
             std_dev_t = torch.sqrt(sigma / (1 - torch.where(sigma == 1.0, sigma_max, sigma))) * noise_level # (batch_size, 1, 1)
 
-            next_latents_mean = latents * (1 + std_dev_t**2 / (2 * sigma) * dt) + noise_pred * (1 + std_dev_t**2 * (1 - sigma) / (2 * sigma)) * dt
+            next_latents_mean = latents * (1 + std_dev_t**2 / (2 * sigma) * dt) + velocity * (1 + std_dev_t**2 * (1 - sigma) / (2 * sigma)) * dt
             
             if next_latents is None:
                 # Non-deterministic step, add noise to it
                 variance_noise = randn_tensor(
-                    noise_pred.shape,
+                    velocity.shape,
                     generator=generator,
-                    device=noise_pred.device,
-                    dtype=noise_pred.dtype,
+                    device=velocity.device,
+                    dtype=velocity.dtype,
                 )
                 # Last term of Equation (9)
                 next_latents = next_latents_mean + std_dev_t * torch.sqrt(-1 * dt) * variance_noise
@@ -354,16 +354,16 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
                 log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
 
         elif dynamics_type == "Dance-SDE":
-            pred_original_sample = latents - sigma * noise_pred
+            pred_original_sample = latents - sigma * velocity
             std_dev_t = noise_level
             log_term = 0.5 * noise_level**2 * (latents - pred_original_sample * (1 - sigma)) / sigma**2
-            next_latents_mean = latents + (noise_pred + log_term) * dt
+            next_latents_mean = latents + (velocity + log_term) * dt
             if next_latents is None:
                 variance_noise = randn_tensor(
-                    noise_pred.shape,
+                    velocity.shape,
                     generator=generator,
-                    device=noise_pred.device,
-                    dtype=noise_pred.dtype,
+                    device=velocity.device,
+                    dtype=velocity.dtype,
                 )
                 next_latents = next_latents_mean + std_dev_t * torch.sqrt(-1 * dt) * variance_noise
                 # Round-trip through storage dtype for train-inference consistency
@@ -383,16 +383,16 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
         elif dynamics_type == "CPS":
             # FlowCPS
             std_dev_t = sigma_prev * torch.sin(noise_level * torch.pi / 2)
-            x0 = latents - sigma * noise_pred
-            x1 = latents + noise_pred * (1 - sigma)
+            x0 = latents - sigma * velocity
+            x1 = latents + velocity * (1 - sigma)
             next_latents_mean = x0 * (1 - sigma_prev) + x1 * torch.sqrt(sigma_prev**2 - std_dev_t**2)
         
             if next_latents is None:
                 variance_noise = randn_tensor(
-                    noise_pred.shape,
+                    velocity.shape,
                     generator=generator,
-                    device=noise_pred.device,
-                    dtype=noise_pred.dtype,
+                    device=velocity.device,
+                    dtype=velocity.dtype,
                 )
                 next_latents = next_latents_mean + std_dev_t * variance_noise
                 # Round-trip through storage dtype for train-inference consistency
@@ -405,7 +405,7 @@ class UniPCMultistepSDEScheduler(UniPCMultistepScheduler, SDESchedulerMixin):
 
         if not compute_log_prob:
             # # Empty tensor as placeholder
-            # log_prob = torch.empty((latents.shape[0]), dtype=torch.float32, device=noise_pred.device)
+            # log_prob = torch.empty((latents.shape[0]), dtype=torch.float32, device=velocity.device)
             log_prob = None # Use None to save memory
 
         if not return_dict:

--- a/src/flow_factory/trainers/awm.py
+++ b/src/flow_factory/trainers/awm.py
@@ -281,7 +281,7 @@ class AWMTrainer(BaseTrainer):
         Returns:
             Dictionary with:
                 - log_prob: (B,)
-                - noise_pred: same shape as latents
+                - velocity: same shape as latents
         """
         t_b = timestep.view(-1)
 
@@ -291,7 +291,7 @@ class AWMTrainer(BaseTrainer):
             't_next': torch.zeros_like(t_b),
             'latents': noised_latents,
             'compute_log_prob': False,  # Compute log prob based on matching loss
-            'return_kwargs': ['noise_pred'],
+            'return_kwargs': ['velocity'],
             'noise_level': 0.0,
             **{k: v for k, v in batch.items() if k not in ['all_latents', 'timesteps', 'advantage']},
         }
@@ -305,7 +305,7 @@ class AWMTrainer(BaseTrainer):
         
         # Compute weighted log probability
         log_prob = self.compute_weighted_log_prob(
-            model_output=output.noise_pred,
+            model_output=output.velocity,
             target=target,
             timestep=timestep,
             weighting=self.weighting,
@@ -314,7 +314,7 @@ class AWMTrainer(BaseTrainer):
                 
         return {
             'log_prob': log_prob,             # (B,)
-            'noise_pred': output.noise_pred,  # Same shape as latents
+            'velocity': output.velocity,  # Same shape as latents
         }
 
     def prepare_feedback(self, samples: List[BaseSample]) -> None:
@@ -433,11 +433,11 @@ class AWMTrainer(BaseTrainer):
                                         batch, t_flat, noised_latents, clean_latents, noise
                                     )
                                 # KL-div in velocity space
-                                noise_pred = current_output['noise_pred']
-                                ref_noise_pred = ref_output['noise_pred']
+                                velocity = current_output['velocity']
+                                ref_velocity = ref_output['velocity']
 
                                 # Uniform across all dimensions except batch
-                                kl_div = ((noise_pred - ref_noise_pred) ** 2).mean(dim=tuple(range(1, noise_pred.ndim)))
+                                kl_div = ((velocity - ref_velocity) ** 2).mean(dim=tuple(range(1, velocity.ndim)))
                                 kl_loss = self.kl_beta * kl_div.mean()
                                 loss = loss + kl_loss
                                 loss_info['kl_div'].append(kl_div.detach())
@@ -451,10 +451,10 @@ class AWMTrainer(BaseTrainer):
                                         batch, t_flat, noised_latents, clean_latents, noise
                                     )
                                 # KL-div in velocity space
-                                noise_pred = current_output['noise_pred']
-                                ema_noise_pred = ema_output['noise_pred']
+                                velocity = current_output['velocity']
+                                ema_velocity = ema_output['velocity']
 
-                                ema_kl = ((noise_pred - ema_noise_pred) ** 2).mean(dim=tuple(range(1, noise_pred.ndim)))
+                                ema_kl = ((velocity - ema_velocity) ** 2).mean(dim=tuple(range(1, velocity.ndim)))
                                 ema_kl_loss = self.ema_kl_beta * ema_kl.mean()
                                 loss = loss + ema_kl_loss
                                 loss_info['ema_kl_div'].append(ema_kl.detach())

--- a/src/flow_factory/trainers/crd.py
+++ b/src/flow_factory/trainers/crd.py
@@ -432,7 +432,7 @@ class CRDTrainer(BaseTrainer):
                 from the batch if ``guidance_scale > 1.0``.
 
         Returns:
-            Dict with ``noise_pred`` (velocity prediction), shape ``(B, C, H, W)``.
+            Dict with ``velocity`` (velocity prediction), shape ``(B, C, H, W)``.
         """
         t_b = timestep.view(-1)  # Scheduler scale [0, 1000]
         device = self.accelerator.device
@@ -443,7 +443,7 @@ class CRDTrainer(BaseTrainer):
             't_next': torch.zeros_like(t_b),
             'latents': noised_latents,
             'compute_log_prob': False,
-            'return_kwargs': ['noise_pred'],
+            'return_kwargs': ['velocity'],
             'noise_level': 0.0,
             **{
                 k: (v.to(device) if isinstance(v, torch.Tensor) else v)
@@ -455,7 +455,7 @@ class CRDTrainer(BaseTrainer):
             forward_kwargs['guidance_scale'] = guidance_scale
         forward_kwargs = filter_kwargs(self.adapter.forward, **forward_kwargs)
         output = self.adapter.forward(**forward_kwargs)
-        return {'noise_pred': output.noise_pred}
+        return {'velocity': output.velocity}
 
     def prepare_feedback(self, samples: List[BaseSample]) -> None:
         """Finalize rewards, compute advantages, and log advantage metrics."""
@@ -648,7 +648,7 @@ class CRDTrainer(BaseTrainer):
                             # Use reference model (original weights)
                             with self.adapter.use_ref_parameters():
                                 old_output = self._compute_crd_output(batch, t_flat, noised_latents)
-                        old_v_pred_list.append(old_output['noise_pred'].detach())
+                        old_v_pred_list.append(old_output['velocity'].detach())
 
                     sample_batches.append(
                         _CRDBatch(
@@ -697,18 +697,18 @@ class CRDTrainer(BaseTrainer):
                         # 2. Current model forward pass
                         with self.autocast():
                             output = self._compute_crd_output(batch, t_flat, noised_latents)
-                        forward_pred = output['noise_pred']
+                        forward_pred = output['velocity']
 
                         # 3. Reference model forward pass (for KL)
                         # If kl_cfg > 1.0, the adapter's forward() will do CFG automatically:
                         # it concatenates [neg_embeds, pos_embeds] and computes:
-                        #   noise_pred = uncond + kl_cfg * (cond - uncond)
+                        #   velocity = uncond + kl_cfg * (cond - uncond)
                         # The negative embeddings come from the batch (negative_prompt_embeds,
                         # negative_pooled_prompt_embeds stored by SD3_5Sample during rollout).
                         with torch.no_grad(), self.adapter.use_ref_parameters(), self.autocast():
                             cfg = self.kl_cfg if self.kl_cfg > 1.0 else None
                             ref_output = self._compute_crd_output(batch, t_flat, noised_latents, guidance_scale=cfg)
-                            ref_pred = ref_output['noise_pred']
+                            ref_pred = ref_output['velocity']
 
                         # 4. Compute implicit reward: r_theta = -(||pred_theta - v_target||^2 - ||pred_old - v_target||^2)
                         if self.adaptive_logp:

--- a/src/flow_factory/trainers/dgpo.py
+++ b/src/flow_factory/trainers/dgpo.py
@@ -344,7 +344,7 @@ class DGPOTrainer(BaseTrainer):
             guidance_scale: CFG scale; use ``1.0`` for the uncond branch.
 
         Returns:
-            Tensor ``(B, C, ...)``: the velocity prediction ``noise_pred``.
+            Tensor ``(B, C, ...)``: the velocity prediction ``velocity``.
         """
         t = timestep.view(-1)
         forward_kwargs = {
@@ -353,7 +353,7 @@ class DGPOTrainer(BaseTrainer):
             "t_next": torch.zeros_like(t),
             "latents": noised_latents,
             "compute_log_prob": False,
-            "return_kwargs": ["noise_pred"],
+            "return_kwargs": ["velocity"],
             "noise_level": 0.0,
             "guidance_scale": guidance_scale,
             **{
@@ -361,12 +361,12 @@ class DGPOTrainer(BaseTrainer):
             },
         }
         forward_kwargs = filter_kwargs(self.adapter.forward, **forward_kwargs)
-        noise_pred = self.adapter.forward(**forward_kwargs).noise_pred
-        assert noise_pred is not None, (
-            "adapter.forward must return `noise_pred` for DGPO "
-            "(ensure 'noise_pred' is in `return_kwargs`)"
+        velocity = self.adapter.forward(**forward_kwargs).velocity
+        assert velocity is not None, (
+            "adapter.forward must return `velocity` for DGPO "
+            "(ensure 'velocity' is in `return_kwargs`)"
         )
-        return noise_pred
+        return velocity
 
     # =========================== Group Bookkeeping ============================
     def _precompute_group_info(

--- a/src/flow_factory/trainers/dpo.py
+++ b/src/flow_factory/trainers/dpo.py
@@ -68,7 +68,7 @@ class DPOTrainer(BaseTrainer):
 
     Loss:
         L = -log sigma(-beta/2 * ((theta_w_err - ref_w_err) - (theta_l_err - ref_l_err)))
-    where err = MSE(noise_pred, noise - x_0) averaged over spatial dims (same as flow_grpo train_sd3_dpo).
+    where err = MSE(velocity, noise - x_0) averaged over spatial dims (same as flow_grpo train_sd3_dpo).
 
     References:
     [1] Diffusion Model Alignment Using Direct Preference Optimization
@@ -394,11 +394,11 @@ class DPOTrainer(BaseTrainer):
         return t
 
     # ====================== Forward Helpers ======================
-    def _forward_noise_pred(self, latents: torch.Tensor, base_kwargs: Dict[str, Any]) -> torch.Tensor:
-        """Run a single forward pass and return the noise prediction."""
+    def _forward_velocity(self, latents: torch.Tensor, base_kwargs: Dict[str, Any]) -> torch.Tensor:
+        """Run a single forward pass and return the velocity prediction."""
         fwd_kwargs = {**base_kwargs, 'latents': latents}
         fwd_kwargs = filter_kwargs(self.adapter.forward, **fwd_kwargs)
-        return self.adapter.forward(**fwd_kwargs).noise_pred
+        return self.adapter.forward(**fwd_kwargs).velocity
 
     # ====================== Reward / advantage (Stages 4--5) ======================
     def prepare_feedback(self, samples: List[BaseSample]) -> None:
@@ -479,7 +479,7 @@ class DPOTrainer(BaseTrainer):
                 static_kwargs = {
                     **self.training_args,
                     'compute_log_prob': False,
-                    'return_kwargs': ['noise_pred'],
+                    'return_kwargs': ['velocity'],
                     'noise_level': 0.0,
                     **{k: v for k, v in chosen_batch.items()
                        if k not in _excluded_batch_keys},
@@ -510,13 +510,13 @@ class DPOTrainer(BaseTrainer):
 
                         # Policy forward
                         with self.autocast():
-                            theta_w_pred = self._forward_noise_pred(noised_chosen, base_kwargs)
-                            theta_l_pred = self._forward_noise_pred(noised_rejected, base_kwargs)
+                            theta_w_pred = self._forward_velocity(noised_chosen, base_kwargs)
+                            theta_l_pred = self._forward_velocity(noised_rejected, base_kwargs)
 
                         # Reference forward (frozen)
                         with torch.no_grad(), self.adapter.use_ref_parameters(), self.autocast():
-                            ref_w_pred = self._forward_noise_pred(noised_chosen, base_kwargs)
-                            ref_l_pred = self._forward_noise_pred(noised_rejected, base_kwargs)
+                            ref_w_pred = self._forward_velocity(noised_chosen, base_kwargs)
+                            ref_l_pred = self._forward_velocity(noised_rejected, base_kwargs)
 
                         # MSE errors per sample — target is flow-matching velocity (noise - x_0), same as
                         # flow_grpo train_sd3_dpo.py: target = noise - model_input

--- a/src/flow_factory/trainers/dppo.py
+++ b/src/flow_factory/trainers/dppo.py
@@ -94,7 +94,7 @@ class DPPOTrainer(GRPOTrainer):
         # policy in `kl_mask_type` space, so only that per-step quantity is stored
         # (the ref-KL penalty compares current vs reference, never the old policy).
         mask_field = (
-            "noise_pred" if self.training_args.kl_mask_type == "v-based" else "next_latents_mean"
+            "velocity" if self.training_args.kl_mask_type == "v-based" else "next_latents_mean"
         )
         return self.generate_samples(
             reward_buffer=self.reward_buffer,
@@ -113,7 +113,7 @@ class DPPOTrainer(GRPOTrainer):
         kl_guidance_scale = self.training_args.kl_guidance_scale
         kl_mask_threshold = self.training_args.kl_mask_threshold
         # Mask space picks the single rollout-old tensor stored by sample().
-        mask_field = "noise_pred" if kl_mask_type == "v-based" else "next_latents_mean"
+        mask_field = "velocity" if kl_mask_type == "v-based" else "next_latents_mean"
         for inner_epoch in range(self.training_args.num_inner_epochs):
             shuffled_samples = self._order_samples_for_optimize(samples, inner_epoch)
 
@@ -169,12 +169,12 @@ class DPPOTrainer(GRPOTrainer):
                         # feed the x-based mask's variance scaling only.
                         return_kwargs = {"log_prob"}
                         if kl_mask_type == "v-based":
-                            return_kwargs.add("noise_pred")
+                            return_kwargs.add("velocity")
                         else:
                             return_kwargs.update(("next_latents_mean", "std_dev_t", "dt"))
                         if self.enable_kl_loss:
                             return_kwargs.add(
-                                "noise_pred" if kl_type == "v-based" else "next_latents_mean"
+                                "velocity" if kl_type == "v-based" else "next_latents_mean"
                             )
                         forward_inputs["return_kwargs"] = list(return_kwargs)
                         with self.autocast():
@@ -190,7 +190,7 @@ class DPPOTrainer(GRPOTrainer):
                         # uses the exact variance-scaled Gaussian KL; the v-based mask and the
                         # ref-KL penalty below use unscaled squared error (GRPO convention).
                         if kl_mask_type == "v-based":
-                            sq = (output.noise_pred - old_mask_tensor) ** 2
+                            sq = (output.velocity - old_mask_tensor) ** 2
                             kl_new_old = sq.mean(dim=tuple(range(1, sq.ndim)))
                         else:
                             sigma_t = self._effective_sigma(output.std_dev_t, output.dt)
@@ -225,7 +225,7 @@ class DPPOTrainer(GRPOTrainer):
                                     if kl_guidance_scale is not None:
                                         ref_forward_inputs["guidance_scale"] = kl_guidance_scale
                                     if kl_type == "v-based":
-                                        ref_forward_inputs["return_kwargs"] = ["noise_pred"]
+                                        ref_forward_inputs["return_kwargs"] = ["velocity"]
                                     else:
                                         ref_forward_inputs["return_kwargs"] = ["next_latents_mean"]
                                     ref_output = self.adapter.forward(**ref_forward_inputs)
@@ -233,8 +233,8 @@ class DPPOTrainer(GRPOTrainer):
                                 # kl_div must be computed outside `torch.no_grad()` for correct gradients.
                                 if kl_type == "v-based":
                                     kl_div = torch.mean(
-                                        ((output.noise_pred - ref_output.noise_pred) ** 2),
-                                        dim=tuple(range(1, output.noise_pred.ndim)),
+                                        ((output.velocity - ref_output.velocity) ** 2),
+                                        dim=tuple(range(1, output.velocity.ndim)),
                                         keepdim=True,
                                     )
                                 else:

--- a/src/flow_factory/trainers/grpo.py
+++ b/src/flow_factory/trainers/grpo.py
@@ -174,7 +174,7 @@ class GRPOTrainer(BaseTrainer):
                         # 2. Forward pass
                         if self.enable_kl_loss:
                             if self.training_args.kl_type == 'v-based':
-                                return_kwargs = ['log_prob', 'noise_pred', 'dt']
+                                return_kwargs = ['log_prob', 'velocity', 'dt']
                             elif self.training_args.kl_type == 'x-based':
                                 return_kwargs = ['log_prob', 'next_latents', 'next_latents_mean', 'dt']
                         else:
@@ -207,7 +207,7 @@ class GRPOTrainer(BaseTrainer):
                                     ref_forward_inputs['compute_log_prob'] = False
                                     if self.training_args.kl_type == 'v-based':
                                         # KL in velocity space
-                                        ref_forward_inputs['return_kwargs'] = ['noise_pred']
+                                        ref_forward_inputs['return_kwargs'] = ['velocity']
                                         ref_output = self.adapter.forward(**ref_forward_inputs)
                                     elif self.training_args.kl_type == 'x-based':
                                         # KL in latent space
@@ -218,8 +218,8 @@ class GRPOTrainer(BaseTrainer):
                                 # See: issue #122, PR #123 (https://github.com/X-GenGroup/Flow-Factory/pull/123)
                                 if self.training_args.kl_type == 'v-based':
                                     kl_div = torch.mean(
-                                        ((output.noise_pred - ref_output.noise_pred) ** 2),
-                                        dim=tuple(range(1, output.noise_pred.ndim)), keepdim=True
+                                        ((output.velocity - ref_output.velocity) ** 2),
+                                        dim=tuple(range(1, output.velocity.ndim)), keepdim=True
                                     )
                                 elif self.training_args.kl_type == 'x-based':
                                     kl_div = torch.mean(
@@ -399,7 +399,7 @@ class GRPOGuardTrainer(GRPOTrainer):
                         return_kwargs = set(['log_prob', 'next_latents_mean', 'std_dev_t', 'dt'])
                         if self.enable_kl_loss:
                             if self.training_args.kl_type == 'v-based':
-                                return_kwargs.add('noise_pred')
+                                return_kwargs.add('velocity')
                             elif self.training_args.kl_type == 'x-based':
                                 return_kwargs.add('next_latents_mean')
 
@@ -434,7 +434,7 @@ class GRPOGuardTrainer(GRPOTrainer):
                                     ref_forward_inputs['compute_log_prob'] = False
                                     if self.training_args.kl_type == 'v-based':
                                         # KL in velocity space
-                                        ref_forward_inputs['return_kwargs'] = ['noise_pred']
+                                        ref_forward_inputs['return_kwargs'] = ['velocity']
                                         ref_output = self.adapter.forward(**ref_forward_inputs)
                                     elif self.training_args.kl_type == 'x-based':
                                         # KL in latent space
@@ -445,8 +445,8 @@ class GRPOGuardTrainer(GRPOTrainer):
                                 # See: issue #122, PR #123 (https://github.com/X-GenGroup/Flow-Factory/pull/123)
                                 if self.training_args.kl_type == 'v-based':
                                     kl_div = torch.mean(
-                                        ((output.noise_pred - ref_output.noise_pred) ** 2),
-                                        dim=tuple(range(1, output.noise_pred.ndim)), keepdim=True
+                                        ((output.velocity - ref_output.velocity) ** 2),
+                                        dim=tuple(range(1, output.velocity.ndim)), keepdim=True
                                     )
                                 elif self.training_args.kl_type == 'x-based':
                                     kl_div = torch.mean(

--- a/src/flow_factory/trainers/nft.py
+++ b/src/flow_factory/trainers/nft.py
@@ -215,7 +215,7 @@ class DiffusionNFTTrainer(BaseTrainer):
             noised_latents: Interpolated latents ``x_t = (1-σ) x_1 + σ noise`` with ``σ = t/1000``.
         
         Returns:
-            Dict with noise_pred.
+            Dict with velocity.
         """
         t_b = timestep.view(-1) # Scale [0, 1000]
 
@@ -225,7 +225,7 @@ class DiffusionNFTTrainer(BaseTrainer):
             't_next': torch.zeros_like(t_b),
             'latents': noised_latents,
             'compute_log_prob': False,
-            'return_kwargs': ['noise_pred'],
+            'return_kwargs': ['velocity'],
             'noise_level': 0.0,
             **{k: v for k, v in batch.items() if k not in ['all_latents', 'timesteps', 'advantage']},
         }
@@ -234,7 +234,7 @@ class DiffusionNFTTrainer(BaseTrainer):
         output = self.adapter.forward(**forward_kwargs)
         
         return {
-            'noise_pred': output.noise_pred,
+            'velocity': output.velocity,
         }
 
     def prepare_feedback(self, samples: List[BaseSample]) -> None:
@@ -293,7 +293,7 @@ class DiffusionNFTTrainer(BaseTrainer):
                         all_random_noise.append(noise)
                         noised_latents = (1 - sigma_broadcast) * clean_latents + sigma_broadcast * noise
                         old_output = self._compute_nft_output(batch, t_flat, noised_latents)
-                        old_v_pred_list.append(old_output['noise_pred'].detach())
+                        old_v_pred_list.append(old_output['velocity'].detach())
 
                 # ---------- Train this batch under current policy ----------
                 self.adapter.train()
@@ -315,7 +315,7 @@ class DiffusionNFTTrainer(BaseTrainer):
                         # 2. Forward pass for current policy
                         with self.autocast():
                             output = self._compute_nft_output(batch, t_flat, noised_latents)
-                        new_v_pred = output['noise_pred']
+                        new_v_pred = output['velocity']
 
                         # 3. Compute NFT loss
                         adv = batch['advantage']
@@ -358,7 +358,7 @@ class DiffusionNFTTrainer(BaseTrainer):
                                     ref_output = self._compute_nft_output(batch, t_flat, noised_latents)
                                 # KL-loss in v-space
                                 kl_div = torch.mean(
-                                    (new_v_pred - ref_output['noise_pred']) ** 2,
+                                    (new_v_pred - ref_output['velocity']) ** 2,
                                     dim=tuple(range(1, new_v_pred.ndim))
                                 )
                                 kl_loss = self.training_args.kl_beta * kl_div.mean()

--- a/src/flow_factory/utils/trajectory_collector.py
+++ b/src/flow_factory/utils/trajectory_collector.py
@@ -18,7 +18,7 @@ Trajectory & Callback Collectors for Inference
 
 Memory-efficient recording utilities for denoising trajectories.
 - ``TrajectoryCollector``: records tensors (latents, log_probs) at specified steps.
-- ``CallbackCollector``: records named callback values (noise_level, noise_pred, …)
+- ``CallbackCollector``: records named callback values (noise_level, velocity, …)
   at specified steps. Drop-in replacement for the ``defaultdict(list)`` pattern.
 
 Both produce compact storage + lightweight index maps to eliminate redundant


### PR DESCRIPTION
## Summary
- rename the historical `noise_pred` scheduler/output contract to `velocity`
- update all model adapters and trainer consumers, including dynamic callback and batch keys
- align user guidance, docstrings, comments, and agent knowledge with flow-matching terminology

## Test plan
- [x] Run velocity contract test (3/3 passing)
- [x] Compile every changed Python file
- [x] Verify no stale `noise_pred` references remain in Flow-Factory code and docs
- [x] Run `git diff --check`
- [ ] Black/isort checks report pre-existing formatting/import-order debt in unchanged portions of the touched files; this rename does not alter imports