### PR TITLE
[trainer,hparams,examples,docs] feat: support OPD loss targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased — `feature/opd-loss-targets`
+
+- Added `train.loss_target` with `xt`, `v`, and `x0` target spaces for
+  DiffusionOPD. The `v` and `x0` targets are restricted to ODE dynamics;
+  `xt` continues to support ODE and SDE.
+- Added independent `train.self_normalize`. When enabled, each sample's
+  target-space MSE is divided by its detached mean absolute student-teacher
+  error plus `1e-8`, enabling `xt_norm`, `v_norm`, and `x0_norm`.
+- Generalized the teacher cache from transition means to projected teacher
+  targets. No adapter, scheduler-output, or base-trainer interface changed.
+
+### Breaking changes
+
+- Removed the historical `0.5` multiplier from the DiffusionOPD objective.
+  Existing YAML remains valid and defaults to `loss_target: xt` with
+  `self_normalize: false`, but its loss and gradients are now 2x their
+  previous values.
+- Renamed DiffusionOPD training metrics from `train/kl_div` and
+  `train/kl_div_<teacher_name>` to `train/distill_loss` and
+  `train/distill_loss_<teacher_name>`, because the configurable targets and
+  objective scale are not generally a Gaussian KL.
+
+---
+
 ## Unreleased — `feat/diffusion-opd` (merge to `main`)
 
 **Full range:** `652f7315..e4496c6` (2026-05-26 … 2026-06-02)

--- a/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
+++ b/examples/opd/lora/sd3_5/DiffusionOPD_aligned.yaml
@@ -138,7 +138,7 @@ train:
   ema_device: "cuda"  # Device to store EMA model. Options: cpu, cuda
 
   enable_gradient_checkpointing: false  # Trade compute for memory savings
-  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher means) to CPU
+  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher targets) to CPU
   seed: 42  # Random seed for reproducibility
 
 # Scheduler Configuration

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -152,7 +152,7 @@ train:
   ema_device: "cuda"  # Device to store EMA model. Options: cpu, cuda
 
   enable_gradient_checkpointing: false  # Trade compute for memory savings
-  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher means) to CPU
+  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher targets) to CPU
   seed: 42  # Random seed for reproducibility
 
 # Scheduler Configuration

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr.yaml
@@ -1,10 +1,13 @@
 # DiffusionOPD: multi-teacher on-policy distillation (GenEval + PickScore + OCR).
 #
 # One LoRA teacher per dataset is distilled into a single student LoRA along the
-# student's own rollout trajectories via a per-step mean-matching KL:
-#     kl_div_j = 0.5 * || mu_S - mu_T ||^2 / denom
-# where `denom` is the scheduler transition variance (1.0 for ODE). Rewards are
-# used ONLY for periodic eval monitoring, never in the distillation loss.
+# student's own rollout trajectories via a configurable per-step target loss.
+# The default matches transition means:
+#     distill_loss_j = || mu_S - mu_T ||^2 / denom
+# where `denom` is the scheduler transition variance (1.0 for ODE). Set
+# `loss_target` to `v` or `x0` for ODE-only alternatives, and independently
+# enable detached error normalization with `self_normalize`. Rewards are used
+# ONLY for periodic eval monitoring, never in the distillation loss.
 #
 # Teacher checkpoints below use the original `~/checkpoints/...` paths
 # (placeholders to be uploaded); each must share the student's LoRA
@@ -12,8 +15,8 @@
 # into the student's active adapter slot.
 #
 # To distill under SDE instead of ODE, set `scheduler.dynamics_type` to an SDE
-# variant (e.g. Flow-SDE) and `scheduler.noise_level > 0`; the loss picks up the
-# transition-variance denominator automatically (no other change needed).
+# variant (e.g. Flow-SDE) and `scheduler.noise_level > 0` while keeping
+# `loss_target: xt`; the loss picks up the transition-variance denominator.
 
 # Environment Configuration
 launcher: "accelerate"  # Options: accelerate
@@ -127,6 +130,8 @@ train:
   num_inference_steps: 10  # Number of denoising timesteps in the on-policy rollout
   guidance_scale: 1.0  # Student CFG for rollout + forward (1.0 = no guidance)
   timestep_range: 0.99  # Distill the first 99% of denoising steps (upstream timestep_fraction); float f -> band [0, f]
+  loss_target: "xt"  # Options: xt, v, x0. Velocity-derived v/x0 targets require ODE dynamics.
+  self_normalize: false  # Options: true, false. Normalize by detached per-sample mean absolute error.
 
   per_device_batch_size: 3  # Batch size per GPU device
   group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr_x0_norm.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr_x0_norm.yaml
@@ -152,7 +152,7 @@ train:
   ema_device: "cuda"  # Device to store EMA model. Options: cpu, cuda
 
   enable_gradient_checkpointing: false  # Trade compute for memory savings
-  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher means) to CPU
+  offload_samples_to_cpu: false  # Offload rollout samples (+ cached teacher targets) to CPU
   seed: 42  # Random seed for reproducibility
 
 # Scheduler Configuration

--- a/examples/opd/lora/sd3_5/geneval_pickscore_ocr_x0_norm.yaml
+++ b/examples/opd/lora/sd3_5/geneval_pickscore_ocr_x0_norm.yaml
@@ -1,70 +1,86 @@
-# DiffusionOPD reproduction (mopd): multi-task on-policy distillation on SD3.5.
+# DiffusionOPD: multi-teacher on-policy distillation (GenEval + PickScore + OCR).
 #
-# Aligned to the upstream `mopd` recipe in
-# https://github.com/ali-vilab/DiffusionOPD/blob/8797d5717d9503edc8cec0705aed5354c203e547/config/opd.py#L34
-# Three task-specialized teachers are distilled into one student LoRA along the
-# student's own ODE rollout trajectories.
+# One LoRA teacher per dataset is distilled into a single student LoRA along the
+# student's own rollout trajectories via a configurable per-step target loss.
+# The default matches transition means:
+#     distill_loss_j = || mu_S - mu_T ||^2 / denom
+# where `denom` is the scheduler transition variance (1.0 for ODE). Set
+# `loss_target` to `v` or `x0` for ODE-only alternatives, and independently
+# enable detached error normalization with `self_normalize`. Rewards are used
+# ONLY for periodic eval monitoring, never in the distillation loss.
 #
-# All official checkpoints live under ONE repo, quanhaol/DiffusionOPD, as
-# subfolders (each teacher's LoRA is in <Teacher>/lora; the released distilled
-# student is in Student/lora). Flow-Factory loads a subfolder via the
-# owner/repo/subfolder path spec.
-#
-# Teacher -> dataset mapping (NOTE: upstream applies the Aesthetics teacher to
-# the `pickscore` prompt set — "aesthetic" IS the pickscore task here):
-#   - quanhaol/DiffusionOPD/AesTeacher/lora     -> dataset `pickscore`  (guidance_scale 4.5)
-#   - quanhaol/DiffusionOPD/OCRTeacher/lora     -> dataset `ocr`        (guidance_scale 4.5)
-#   - quanhaol/DiffusionOPD/GenEvalTeacher/lora -> dataset `geneval`    (guidance_scale 1.0)
-# Each must share the student's LoRA architecture; these teachers are r=32,
-# lora_alpha=64 with SD3.5 attention target modules — matching the student below.
-#
-# Batch geometry (matches upstream `mopd` on 8 GPUs):
-#   num_image_per_prompt=1   -> group_size=1
-#   train_batch_size=3       -> per_device_batch_size=3
-#   num_batches_per_epoch=3  -> 1 batch per teacher/dataset, so
-#   unique_sample_num_per_epoch = num_gpus(8) * num_batches_per_epoch(3) * per_device_batch_size(3) / group_size(1)
-#                              = 72  (== 24 prompts/teacher * 3 teachers)
+# Teacher checkpoints below use the original `~/checkpoints/...` paths
+# (placeholders to be uploaded); each must share the student's LoRA
+# architecture (same target modules, compatible rank/alpha) since it is loaded
+# into the student's active adapter slot.
 #
 # To distill under SDE instead of ODE, set `scheduler.dynamics_type` to an SDE
-# variant (e.g. Flow-SDE) and `scheduler.noise_level > 0`; the per-step loss
-# picks up the transition-variance denominator automatically.
+# variant (e.g. Flow-SDE) and `scheduler.noise_level > 0` while keeping
+# `loss_target: xt`; the loss picks up the transition-variance denominator.
 
 # Environment Configuration
 launcher: "accelerate"  # Options: accelerate
 config_file: config/deepspeed/deepspeed_zero2.yaml  # Path to distributed config file
-num_processes: 8  # Number of GPU processes to launch (geometry above assumes 8)
+num_processes: 8  # Number of GPU processes to launch
 main_process_port: 29500  # Port for distributed communication
-mixed_precision: "bf16"  # Options: no, fp16, bf16 (upstream used fp16; bf16 is the FF default)
+mixed_precision: "bf16"  # Options: no, fp16, bf16
 
-# Data Configuration — 3 datasets, one teacher each (weighted 1:1:1)
+# Data Configuration — 3 training sources (geneval / pickscore / ocr), weighted 1:1:1.
+# Below them, three eval-only *_no-cfg aliases (same test split, guidance_scale=1.0)
+# isolate the effect of classifier-free guidance at eval time; they do not train.
 data:
   datasets:
-    - name: pickscore  # Aesthetics task in upstream mopd (served by the Aes teacher)
-      dataset_dir: "dataset/pickscore"  # Folder with train.jsonl / test.jsonl
-      train:  # Training participation config
-        weight: 1  # Mixing weight (integer); ratio with other datasets sets batch allocation
-        max_dataset_size: null  # No cap on training prompts (matches upstream mopd: full prompt set)
-      eval:  # Eval participation (overrides shared `eval:` section below)
-        num_inference_steps: 40  # Override eval inference steps for this dataset
-        guidance_scale: 4.5  # Eval samples the student at its CFG (4.5)
-
-    - name: ocr  # Unique identifier (dataset tag, metrics, reward + teacher routing)
-      dataset_dir: "dataset/ocr"  # Folder with train.jsonl / test.jsonl
-      train:  # Training participation config
-        weight: 1  # Mixing weight (integer); ratio with other datasets sets batch allocation
-        max_dataset_size: null  # No cap on training prompts (matches upstream mopd: full prompt set)
-      eval:  # Eval participation (overrides shared `eval:` section below)
-        num_inference_steps: 40  # Override eval inference steps for this dataset
-        guidance_scale: 4.5  # Eval samples the student at its CFG (4.5)
-
-    - name: geneval  # Unique identifier (dataset tag, metrics, reward + teacher routing)
+    - name: geneval  # Unique identifier (source tag, metrics, reward + teacher routing)
       dataset_dir: "dataset/geneval"  # Folder with train.jsonl / test.jsonl
       train:  # Training participation config
-        weight: 1  # Mixing weight (integer); ratio with other datasets sets batch allocation
-        max_dataset_size: null  # No cap on training prompts (matches upstream mopd: full prompt set)
+        weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
+        max_dataset_size: null  # Cap on number of training prompts for this source
       eval:  # Eval participation (overrides shared `eval:` section below)
         num_inference_steps: 40  # Override eval inference steps for this dataset
-        guidance_scale: 4.5  # Eval samples the student at its CFG (4.5)
+        guidance_scale: 4.5  # Override eval guidance scale for this dataset
+
+    - name: pickscore  # Unique identifier (source tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/pickscore"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
+        max_dataset_size: null  # Cap on number of training prompts for this source
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 4.5  # Override eval guidance scale for this dataset
+
+    - name: ocr  # Unique identifier (source tag, metrics, reward + teacher routing)
+      dataset_dir: "dataset/ocr"  # Folder with train.jsonl / test.jsonl
+      train:  # Training participation config
+        weight: 1  # Mixing weight (integer); ratio with other sources sets batch allocation
+        max_dataset_size: null  # Cap on number of training prompts for this source
+      eval:  # Eval participation (overrides shared `eval:` section below)
+        num_inference_steps: 40  # Override eval inference steps for this dataset
+        guidance_scale: 4.5  # Override eval guidance scale for this dataset
+
+    # --- Eval-only no-CFG ablations (guidance_scale=1.0 vs 4.5 above) ---
+    # Same dataset_dir and test split as the matching source; train: null avoids
+    # loading train.jsonl twice. Compare W&B keys eval/{name}/... to measure CFG impact.
+
+    - name: geneval_no-cfg
+      dataset_dir: "dataset/geneval"
+      train: null
+      eval:
+        num_inference_steps: 40
+        guidance_scale: 1.0
+
+    - name: pickscore_no-cfg
+      dataset_dir: "dataset/pickscore"
+      train: null
+      eval:
+        num_inference_steps: 40
+        guidance_scale: 1.0
+
+    - name: ocr_no-cfg
+      dataset_dir: "dataset/ocr"
+      train: null
+      eval:
+        num_inference_steps: 40
+        guidance_scale: 1.0
 
   preprocessing_batch_size: 8  # Batch size for preprocessing
   dataloader_num_workers: 16  # Number of workers for DataLoader
@@ -75,7 +91,7 @@ data:
 # Model Configuration (student LoRA)
 model:
   finetune_type: 'lora'  # Options: full, lora (DiffusionOPD currently supports LoRA teachers only)
-  lora_rank: 32  # LoRA rank dimension (must match the teacher checkpoints' rank)
+  lora_rank: 32  # LoRA rank dimension
   lora_alpha: 64  # LoRA scaling factor (typically 2x rank)
   target_modules: "default"  # Options: all, default, or list of module names
   model_name_or_path: "stabilityai/stable-diffusion-3.5-medium"  # HuggingFace model ID or local path
@@ -88,42 +104,40 @@ log:
   project: "Flow-Factory"  # Project name for logging backend
   logging_backend: "wandb"  # Options: wandb, swanlab, tensorboard, none
   save_dir: "saves/"  # Directory to save model checkpoints and logs
-  save_freq: 30  # Save frequency in epochs (0 to disable) — upstream mopd save_freq
+  save_freq: 10  # Save frequency in epochs (0 to disable)
   save_model_only: true  # Save only model weights (not optimizer/scheduler state)
 
 # Training Configuration
 train:
   trainer_type: 'diffusion-opd'  # On-policy distillation trainer
 
-  # ---- Teachers: one HF LoRA per dataset, distilled into the student ----
+  # ---- Teachers: one LoRA per dataset, distilled into the student ----
   teachers:
-    - name: "aes-teacher"  # Aesthetics teacher; upstream applies it to the pickscore prompt set
-      path: "quanhaol/DiffusionOPD/AesTeacher/lora"  # HF subfolder spec (owner/repo/subfolder)
-      applicable_datasets: [pickscore]  # Distill this teacher on pickscore rollouts
-      guidance_scale: 4.5  # Teacher CFG for its forward (upstream pickscore_teacher_gs)
-    - name: "ocr-teacher"  # Unique teacher id (named snapshot + log keys)
-      path: "quanhaol/DiffusionOPD/OCRTeacher/lora"  # HF subfolder spec (owner/repo/subfolder)
-      applicable_datasets: [ocr]  # Distill this teacher on ocr rollouts
-      guidance_scale: 4.5  # Teacher CFG for its forward (upstream ocr_teacher_gs)
-    - name: "geneval-teacher"  # Unique teacher id (named snapshot + log keys)
-      path: "quanhaol/DiffusionOPD/GenEvalTeacher/lora"  # HF subfolder spec (owner/repo/subfolder)
+    - name: "teacher-geneval"  # Unique teacher id (named snapshot + log keys)
+      path: "Jayce-Ping/GenEval-Teacher"  # Teacher LoRA checkpoint
       applicable_datasets: [geneval]  # Distill this teacher on geneval rollouts
-      guidance_scale: 1.0  # Teacher queried at its no-CFG distribution (upstream geneval_teacher_gs)
+    - name: "teacher-pickscore"  # Unique teacher id (named snapshot + log keys)
+      path: "Jayce-Ping/Pickscore-Teacher"  # Teacher LoRA checkpoint
+      applicable_datasets: [pickscore]  # Distill this teacher on pickscore rollouts
+    - name: "teacher-ocr"  # Unique teacher id (named snapshot + log keys)
+      path: "Jayce-Ping/OCR-Teacher"  # Teacher LoRA checkpoint
+      applicable_datasets: [ocr]  # Distill this teacher on ocr rollouts
 
   teacher_param_device: 'cuda'  # Teacher snapshot storage: 'cuda' (fast swaps) or 'cpu' (low VRAM)
+  # guidance_scale: per-teacher CFG override via TeacherConfig.guidance_scale (null = student CFG)
 
   resolution: 512  # Training resolution. Can be int or [height, width]
   num_inference_steps: 10  # Number of denoising timesteps in the on-policy rollout
-  guidance_scale: 4.5  # Student CFG for rollout + forward (upstream sample.guidance_scale)
+  guidance_scale: 1.0  # Student CFG for rollout + forward (1.0 = no guidance)
   timestep_range: 0.99  # Distill the first 99% of denoising steps (upstream timestep_fraction); float f -> band [0, f]
-  loss_target: "xt"  # Options: xt, v, x0. Velocity-derived v/x0 targets require ODE dynamics.
-  self_normalize: false  # Options: true, false. Normalize by detached per-sample mean absolute error.
+  loss_target: "x0"  # Options: xt, v, x0. Velocity-derived v/x0 targets require ODE dynamics.
+  self_normalize: true  # Options: true, false. Normalize by detached per-sample mean absolute error.
 
-  per_device_batch_size: 3  # Batch size per GPU device (upstream train_batch_size)
-  group_size: 1  # Rollouts generated per prompt (upstream num_image_per_prompt = 1)
-  unique_sample_num_per_epoch: 72  # 24 prompts/teacher * 3 teachers (see geometry note in header)
+  per_device_batch_size: 3  # Batch size per GPU device
+  group_size: 1  # Rollouts generated per prompt (under SDE these differ; under ODE they are identical)
+  unique_sample_num_per_epoch: 72  # Total unique prompts per epoch (24 per source * 3 sources)
   num_inner_epochs: 1  # Reuse epochs over the (fixed) on-policy trajectories
-  gradient_step_per_epoch: 1  # One optimizer step per epoch (accumulate the 3 per-dataset batches)
+  gradient_step_per_epoch: 1  # Number of gradient updates per epoch
   gradient_accumulation_steps: auto  # Options: auto, or positive integer
 
   learning_rate: 3.0e-4  # Initial learning rate for AdamW optimizer
@@ -133,7 +147,7 @@ train:
   max_grad_norm: 1.0  # Max gradient norm for gradient clipping
   max_epochs: 500  # Stop after this many epochs (-1 / null = unbounded)
 
-  ema_decay: 0.99  # EMA decay rate for model weights (0 to disable)
+  ema_decay: 0.9  # EMA decay rate for model weights (0 to disable)
   ema_update_interval: 4  # Update EMA every N epochs
   ema_device: "cuda"  # Device to store EMA model. Options: cpu, cuda
 
@@ -150,16 +164,15 @@ scheduler:
 # Evaluation settings (shared defaults; per-dataset overrides above take precedence)
 eval:
   resolution: 512  # Evaluation image resolution
-  per_device_batch_size: 16  # Eval batch size per device (upstream test_batch_size)
-  guidance_scale: 4.5  # Eval guidance scale (student CFG)
+  per_device_batch_size: 8  # Eval batch size per device
+  guidance_scale: 1.0  # Eval guidance scale
   num_inference_steps: 40  # Eval denoising steps (more steps = higher quality)
-  eval_freq: 30  # Run evaluation every N epochs (0 to disable) — upstream mopd eval_freq
+  eval_freq: 10  # Run evaluation every N epochs (0 to disable)
   seed: 42  # Eval random seed
 
 # Reward Model Configuration (monitoring only — NOT used by the distillation loss)
 # Routing via `applicable_datasets`: geneval -> geneval, ocr -> ocr,
-# pick_score -> all three datasets (covers the `pickscore` dataset and provides
-# a general-quality signal on the others).
+# pick_score -> all three sources (applicable_datasets omitted = applies to all).
 rewards:
   - name: "geneval"  # Reward identifier (appears in log keys)
     reward_model: "GenEval"  # Reward model class (from registry)
@@ -175,12 +188,12 @@ rewards:
     dtype: bfloat16  # Precision for reward model inference
     applicable_datasets: ["ocr"]  # Only fires on ocr source batches
 
-  - name: "pick_score"  # General image-quality reward (covers the pickscore dataset)
+  - name: "pick_score"  # Reward identifier (appears in log keys)
     reward_model: "PickScore"  # Reward model class (from registry)
     batch_size: 32  # Inference batch size for this reward model
     device: "cuda"  # Device to run reward model on
     dtype: bfloat16  # Precision for reward model inference
-    # applicable_datasets omitted -> applies to ALL training datasets (pickscore, ocr, geneval)
+    # applicable_datasets omitted -> applies to ALL training sources (geneval, pickscore, ocr)
 
 # Eval Reward Models (same routing as training rewards)
 eval_rewards:
@@ -189,18 +202,18 @@ eval_rewards:
     batch_size: 32  # Larger batch for eval (no gradient, more memory available)
     device: "cuda"  # Device to run reward model on
     dtype: float32  # Precision for reward model inference
-    applicable_datasets: ["geneval"]  # Only scores geneval eval samples
+    applicable_datasets: ["geneval", "geneval_no-cfg"]  # CFG and no-CFG eval tracks
 
   - name: "ocr"  # Eval reward identifier
     reward_model: "OCR"  # Reward model class (from registry)
     batch_size: 32  # Larger batch for eval (no gradient, more memory available)
     device: "cuda"  # Device to run reward model on
     dtype: bfloat16  # Precision for reward model inference
-    applicable_datasets: ["ocr"]  # Only scores ocr eval samples
+    applicable_datasets: ["ocr", "ocr_no-cfg"]
 
-  - name: "pick_score"  # Eval reward identifier (covers the pickscore dataset)
+  - name: "pick_score"  # Eval reward identifier
     reward_model: "PickScore"  # Reward model class (from registry)
     batch_size: 32  # Larger batch for eval (no gradient, more memory available)
     device: "cuda"  # Device to run reward model on
     dtype: bfloat16  # Precision for reward model inference
-    # applicable_datasets omitted -> applies to all eval datasets (pickscore, ocr, geneval)
+    # applicable_datasets omitted -> all eval sources (incl. *_no-cfg aliases)

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -33,10 +33,11 @@
 
 Flow-Factory provides unified implementations of state-of-the-art RL algorithms for flow-matching models. All algorithms share the same model adapter and reward interfaces, enabling direct comparison under controlled conditions.
 
-At a high level, the supported algorithms fall into two paradigms:
+At a high level, the supported algorithms fall into three paradigms:
 
 - **Coupled paradigm (GRPO and variants)**: Training timesteps are coupled with the SDE-based sampling dynamics, requiring tractable log-probability computation for policy gradient optimization.
-- **Decoupled paradigm (DPO, DiffusionNFT, AWM, DGPO, CRD, DiffusionOPD)**: Training timesteps are decoupled from the actual sampling dynamics, making them inherently solver-agnostic — any ODE solver can be used for trajectory generation without modifying the training procedure.
+- **Decoupled paradigm (DPO, DiffusionNFT, AWM, DGPO, CRD)**: Training timesteps are decoupled from the actual sampling dynamics, making them inherently solver-agnostic.
+- **Distillation paradigm (DiffusionOPD)**: The student rolls out on-policy trajectories, then matches routed teacher targets without a reward or advantage stage.
 
 ## GRPO
 
@@ -508,33 +509,51 @@ train:
 
 ## DiffusionOPD: On-Policy Distillation
 
-This algorithm is introduced in [[14]](#ref14). **DiffusionOPD** is a *decoupled-paradigm* multi-task distillation method: instead of jointly optimizing several rewards from scratch, it first trains one task-specialized **teacher** per task (e.g. GenEval, OCR, aesthetics) and then distills their capabilities into a single unified **student** along the student's own rollout trajectories. This reduces reward conflict and catastrophic forgetting relative to multi-reward RL.
+This algorithm is introduced in [[14]](#ref14). **DiffusionOPD** is a multi-task distillation method: instead of jointly optimizing several rewards from scratch, it first trains one task-specialized **teacher** per task (e.g. GenEval, OCR, aesthetics) and then distills their capabilities into a single unified **student** along the student's own rollout trajectories. This reduces reward conflict and catastrophic forgetting relative to multi-reward RL.
 
-Unlike the policy-gradient algorithms above, the loss is a closed-form **per-step KL on the denoising transition** — a pathwise mean-matching objective that covers both stochastic SDE samplers and deterministic ODE samplers:
+Unlike the policy-gradient algorithms above, DiffusionOPD directly matches teacher and student predictions at each student-visited state. For ODE dynamics, let `x_t` be the shared current state, `v` the predicted velocity, `dt` the scheduler step, and `sigma = flow_match_sigma(t)`. The configured target `y` is:
 
 ```
-kl_div_j = 0.5 * || mu_S - mu_T ||^2 / denom
+loss_target = "xt": y = mu = x_t + v * dt
+loss_target = "v":  y = v
+loss_target = "x0": y = x_t - sigma * v
 ```
 
-where `mu_S` / `mu_T` are the student / teacher transition means at the student-visited state `x_j`, and `denom` is the scheduler's transition variance for the active dynamics (centralized in `scheduler.get_kl_divergence_denominator`):
+Here `xt` means the **one-step transition mean** `mu`, not the shared current input `x_t`. Because teacher and student receive the same `x_t`, the ODE target differences obey:
 
-| `dynamics_type` | `denom` | resulting `kl_div_j` |
+```
+MSE(xt) = dt^2 * MSE(v)
+MSE(x0) = sigma^2 * MSE(v)
+```
+
+For target error `d = y_S - y_T`, the per-sample spatial loss is:
+
+```
+self_normalize = false: mean(d^2)
+self_normalize = true:  mean(d^2) / (stop_gradient(mean(abs(d))) + 1e-8)
+```
+
+`loss_target` and `self_normalize` are independent, producing six combinations: `xt`, `xt_norm`, `v`, `v_norm`, `x0`, and `x0_norm`. The detached denominator follows DiffusionNFT-style self-normalization: it rescales each realized student-teacher gap without allowing gradients through the scale.
+
+The dynamics support matrix is:
+
+| `loss_target` | ODE | SDE | Additional denominator |
 |---|---|---|
-| `ODE` | `1.0` | pure mean matching: `0.5 * ||μ_S − μ_T||²` |
-| `Flow-SDE`, `Dance-SDE` | `std_dev_t² · (-dt)` | Gaussian transition KL: `||μ_S − μ_T||² / (2 σ̄²)` |
-| `CPS` | `std_dev_t²` | `||μ_S − μ_T||² / (2 std_dev_t²)` |
+| `xt` | Yes | Yes | SDE transition variance from `scheduler.get_kl_divergence_denominator()` |
+| `v` | Yes | No | None |
+| `x0` | Yes | No | None |
 
-There is no loss-scaling coefficient (DiffusionOPD has no REINFORCE term). Rewards are used **only** for periodic eval monitoring (`evaluate()`), never in the distillation loss.
+`v` and `x0` fail fast under non-ODE dynamics because the target conversion assumes the ODE relation `mu = x_t + v * dt`. The `xt` target remains valid for Flow-SDE, Dance-SDE, and CPS; after optional self-normalization it is divided by the scheduler transition variance. No target uses the historical `0.5` multiplier. Rewards are used **only** for periodic eval monitoring (`evaluate()`), never in the distillation loss.
 
 ### How it works (2-pass per epoch)
 
 Built directly on the multi-dataset infrastructure (`data.datasets`, per-source `source`/`source_id`, `train_dataloaders_by_source`), so each teacher is routed to one or more training datasets:
 
 1. **`sample()`** — the student rolls out on-policy trajectories over the multi-source dataloader (each sample tagged with its `source`), reusing the standard sampling pipeline.
-2. **`optimize()` PASS 1** (`no_grad`) — for each teacher (exactly **one** weight swap, via the named-parameter snapshot), forward over its routed samples' stored states `x_j` and cache the teacher means `mu_T` on each sample.
-3. **`optimize()` PASS 2** (student params only) — a standard gradient loop forwards the student at the same `x_j`, matching each sample's `mu_S` to its own cached `mu_T` (a micro-batch may mix teachers; the batch-mean is an implicit per-teacher KL averaged over the batch).
+2. **`optimize()` PASS 1** (`no_grad`) — for each teacher (exactly **one** weight swap, via the named-parameter snapshot), forward over its routed samples' stored states `x_j`, project into the configured target space, and cache the detached teacher target on each sample.
+3. **`optimize()` PASS 2** (student params only) — a standard gradient loop forwards the student at the same `x_j`, applies the same projection, and matches each sample to its own cached teacher target. A micro-batch may mix teachers.
 
-Teacher swaps are thus **M-per-epoch** (one per teacher), the gradient loop runs with student params only (no autocast-cache toggling, no DDP bypass), and the loss is a clean student-vs-cached-target MSE.
+Teacher swaps are thus **M-per-epoch** (one per teacher), the gradient loop runs with student params only (no autocast-cache toggling, no DDP bypass), and metrics are logged as `train/distill_loss` and `train/distill_loss_<teacher_name>`.
 
 Which denoising steps are distilled is set by `train.timestep_range` (default `0.99`), the same fraction idiom NFT uses: a float `f` selects the band `[0, f]` of the trajectory's step indices (the first `f`-fraction of denoising steps, skipping the near-clean tail), and a tuple is an explicit `[lo, hi]` band. This reproduces upstream DiffusionOPD's `timestep_fraction` and is **dynamics-agnostic** — it selects by trajectory step index rather than the SDE-only stochastic-step set, so it works identically under ODE and SDE.
 
@@ -560,6 +579,8 @@ train:
   teacher_param_device: 'cuda'  # teacher snapshot device: 'cuda' (fast swaps) / 'cpu' (low VRAM)
   guidance_scale: 1.0           # student CFG for rollout + forward
   timestep_range: 0.99          # distill the first 99% of denoising steps (upstream timestep_fraction)
+  loss_target: "xt"             # Options: xt, v, x0 (v/x0 require ODE)
+  self_normalize: false         # Independent detached error normalization
 
 scheduler:
   dynamics_type: "ODE"  # mean matching; switch to Flow-SDE + noise_level>0 for SDE distillation

--- a/guidance/algorithms.md
+++ b/guidance/algorithms.md
@@ -538,7 +538,7 @@ self_normalize = true:  mean(d^2) / (stop_gradient(mean(abs(d))) + 1e-8)
 The dynamics support matrix is:
 
 | `loss_target` | ODE | SDE | Additional denominator |
-|---|---|---|
+|---|---|---|---|
 | `xt` | Yes | Yes | SDE transition variance from `scheduler.get_kl_divergence_denominator()` |
 | `v` | Yes | No | None |
 | `x0` | Yes | No | None |

--- a/src/flow_factory/hparams/training_args/opd.py
+++ b/src/flow_factory/hparams/training_args/opd.py
@@ -101,10 +101,11 @@ class TeacherConfig(ArgABC):
 class DiffusionOPDTrainingArguments(TrainingArguments):
     r"""Training arguments for the DiffusionOPD distillation trainer.
 
-    Supports both ODE and SDE dynamics: the per-step loss is
-    ``kl_div_j = 0.5 * ||mu_S - mu_T||^2 / denom`` where ``denom`` is the
-    scheduler's transition variance (``1`` for ODE), so no extra config is
-    needed to switch dynamics — only ``scheduler.dynamics_type``.
+    Selects the distillation space with ``loss_target`` and independently
+    enables detached error self-normalization with ``self_normalize``.
+    ``xt`` matches transition means and supports ODE or SDE dynamics; ``v``
+    and ``x0`` are ODE-only velocity-derived targets. Under SDE, the ``xt``
+    loss remains divided by the scheduler's transition variance.
     """
 
     teachers: List[TeacherConfig] = field(
@@ -129,9 +130,40 @@ class DiffusionOPDTrainingArguments(TrainingArguments):
             )
         },
     )
+    loss_target: Literal["xt", "v", "x0"] = field(
+        default="xt",
+        metadata={
+            "help": (
+                "Distillation target space: 'xt' matches the one-step transition mean; "
+                "'v' matches velocity; 'x0' matches the predicted clean latent. "
+                "The 'v' and 'x0' targets require ODE dynamics."
+            )
+        },
+    )
+    self_normalize: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Divide each sample's target-space MSE by its detached mean absolute "
+                "student-teacher error plus 1e-8."
+            )
+        },
+    )
 
     def __post_init__(self):
         super().__post_init__()
+
+        valid_loss_targets = ("xt", "v", "x0")
+        if self.loss_target not in valid_loss_targets:
+            raise ValueError(
+                "train.loss_target must be one of "
+                f"{valid_loss_targets}, got {self.loss_target!r}."
+            )
+        if not isinstance(self.self_normalize, bool):
+            raise TypeError(
+                "train.self_normalize must be a bool, "
+                f"got {type(self.self_normalize).__name__}: {self.self_normalize!r}."
+            )
 
         # Standardize to (frac_lo, frac_hi); a float f -> (0.0, f). Mirrors NFT's
         # `timestep_range` convention so the trainer can derive distillation-step

--- a/src/flow_factory/trainers/opd/common.py
+++ b/src/flow_factory/trainers/opd/common.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 # src/flow_factory/trainers/opd/common.py
-"""Teacher-loading helper for the DiffusionOPD trainer.
+"""Shared target-space math and teacher loading for DiffusionOPD.
 
-The trainer's 2-pass design (teacher targets pre-computed in a no_grad pass,
-then a student-only gradient loop) removes the reference implementation's hot
-swap machinery, so this module needs exactly one helper: :func:`load_teachers`,
-which loads each teacher LoRA checkpoint into a named-parameter snapshot using
-the adapter primitives already in :mod:`flow_factory.models.abc`.
+Target projection is shared by the teacher and student passes; the per-sample
+loss consumes their projected outputs. Teacher loading stores each teacher LoRA
+checkpoint in a named-parameter snapshot using the adapter primitives in
+:mod:`flow_factory.models.abc`.
 """
 
 from __future__ import annotations
@@ -29,12 +28,170 @@ from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
+from ...utils.base import to_broadcast_tensor
 from ...utils.logger_utils import setup_logger
+from ...utils.noise_schedule import flow_match_sigma
 
 if TYPE_CHECKING:
     from ...models.abc import BaseAdapter
 
 logger = setup_logger(__name__, rank_zero_only=True)
+
+
+def validate_loss_target_for_dynamics(loss_target: str, dynamics_type: str) -> None:
+    """Validate that the target is defined for the scheduler dynamics.
+
+    Args:
+        loss_target: Configured target space (``xt``, ``v``, or ``x0``).
+        dynamics_type: Active scheduler dynamics.
+
+    Raises:
+        ValueError: ``v`` or ``x0`` is requested for non-ODE dynamics.
+    """
+    if loss_target in ("v", "x0") and dynamics_type != "ODE":
+        raise ValueError(
+            "DiffusionOPD velocity-derived targets require ODE dynamics: "
+            f"received loss_target={loss_target!r} with dynamics_type={dynamics_type!r}. "
+            "Use scheduler.dynamics_type='ODE' or set train.loss_target='xt'."
+        )
+
+
+def _require_matching_target(
+    value: Optional[torch.Tensor],
+    *,
+    name: str,
+    loss_target: str,
+    latents: torch.Tensor,
+) -> torch.Tensor:
+    """Validate and return one model output used as a target."""
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(
+            f"Expected `{name}` to be a torch.Tensor for loss_target={loss_target!r}, "
+            f"got {type(value).__name__}: {value!r}."
+        )
+    if value.shape != latents.shape:
+        raise ValueError(
+            "DiffusionOPD target projection requires the same shape for `latents` "
+            f"and `{name}`, got latents={tuple(latents.shape)} and "
+            f"{name}={tuple(value.shape)}."
+        )
+    return value
+
+
+def project_distillation_target(
+    *,
+    loss_target: str,
+    latents: torch.Tensor,
+    timestep: torch.Tensor,
+    next_latents_mean: Optional[torch.Tensor],
+    velocity: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Project a scheduler step output into the configured target space.
+
+    Args:
+        loss_target: Target space (``xt``, ``v``, or ``x0``).
+        latents: Current noisy latent state.
+        timestep: Current scheduler-scale timestep.
+        next_latents_mean: Predicted one-step transition mean.
+        velocity: Predicted flow velocity.
+
+    Returns:
+        The prediction represented in the configured target space.
+
+    Raises:
+        TypeError: A required input is not a tensor.
+        ValueError: The target is unsupported or a model output shape differs
+            from ``latents``.
+    """
+    if not isinstance(latents, torch.Tensor):
+        raise TypeError(
+            "Expected `latents` to be a torch.Tensor when projecting a DiffusionOPD "
+            f"target, got {type(latents).__name__}: {latents!r}."
+        )
+
+    if loss_target == "xt":
+        return _require_matching_target(
+            next_latents_mean,
+            name="next_latents_mean",
+            loss_target=loss_target,
+            latents=latents,
+        )
+    if loss_target not in ("v", "x0"):
+        raise ValueError(
+            f"DiffusionOPD loss_target must be one of ('xt', 'v', 'x0'), got {loss_target!r}."
+        )
+
+    velocity = _require_matching_target(
+        velocity,
+        name="velocity",
+        loss_target=loss_target,
+        latents=latents,
+    )
+    if loss_target == "v":
+        return velocity
+
+    if not isinstance(timestep, torch.Tensor):
+        raise TypeError(
+            "Expected `timestep` to be a torch.Tensor for loss_target='x0', "
+            f"got {type(timestep).__name__}: {timestep!r}."
+        )
+    latents_float = latents.float()
+    sigma = to_broadcast_tensor(flow_match_sigma(timestep.float()), latents_float)
+    return latents_float - sigma * velocity.float()
+
+
+def compute_per_sample_distillation_loss(
+    student_target: torch.Tensor,
+    teacher_target: torch.Tensor,
+    *,
+    self_normalize: bool,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Compute target-space MSE with optional detached self-normalization.
+
+    Args:
+        student_target: Student prediction in the configured target space.
+        teacher_target: Detached teacher prediction in the same target space.
+        self_normalize: Whether to divide by detached mean absolute error.
+        eps: Positive denominator floor added after self-normalization.
+
+    Returns:
+        Per-sample loss reduced over all non-batch dimensions.
+
+    Raises:
+        TypeError: Targets are not tensors or ``self_normalize`` is not bool.
+        ValueError: Target shapes are invalid or ``eps`` is not positive.
+    """
+    if not isinstance(student_target, torch.Tensor) or not isinstance(teacher_target, torch.Tensor):
+        raise TypeError(
+            "Expected `student_target` and `teacher_target` to be torch.Tensor values, "
+            f"got {type(student_target).__name__} and {type(teacher_target).__name__}."
+        )
+    if student_target.shape != teacher_target.shape:
+        raise ValueError(
+            "DiffusionOPD loss requires matching shapes for `student_target` and "
+            f"`teacher_target`, got {tuple(student_target.shape)} and "
+            f"{tuple(teacher_target.shape)}."
+        )
+    if student_target.ndim < 2:
+        raise ValueError(
+            "DiffusionOPD loss requires target tensors with a batch dimension and at "
+            f"least one feature dimension, got shape {tuple(student_target.shape)}."
+        )
+    if not isinstance(self_normalize, bool):
+        raise TypeError(
+            "Expected `self_normalize` to be a bool, "
+            f"got {type(self_normalize).__name__}: {self_normalize!r}."
+        )
+    if eps <= 0:
+        raise ValueError(f"Expected `eps` to be positive, got {eps!r}.")
+
+    error = student_target.float() - teacher_target.float()
+    per_sample_mse = error.square().flatten(1).mean(dim=1)
+    if not self_normalize:
+        return per_sample_mse
+    scale = error.abs().flatten(1).mean(dim=1).detach()
+    return per_sample_mse / (scale + eps)
 
 
 def load_teachers(

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -16,10 +16,10 @@
 """DiffusionOPD on-policy distillation trainer.
 
 Distills several task-specialized LoRA teachers into a single student along
-the student's own rollout trajectories using a pathwise mean-matching loss.
-Supports both ODE and SDE dynamics — the per-step transition variance is
-supplied by ``scheduler.get_kl_divergence_denominator`` so the loss is
-dynamics-agnostic.
+the student's own rollout trajectories. The target space is configurable as
+the one-step transition mean (``xt``), velocity (``v``), or predicted clean
+latent (``x0``), with optional detached self-normalization. The transition-mean
+target supports ODE and SDE dynamics; velocity-derived targets are ODE-only.
 
 Reference:
 [1] On-Policy Distillation of Diffusion Models — https://github.com/ali-vilab/DiffusionOPD
@@ -34,10 +34,10 @@ Design (2-pass, per epoch):
                  reusing the standard ``generate_samples`` pipeline.
   optimize()  -> PASS 1 (no_grad): for each teacher (ONE weight swap), forward
                  over its routed samples' stored states x_j and cache the teacher
-                 mean mu_T_j on each sample.
+                 target on each sample.
               -> PASS 2 (student params only): standard gradient loop that
-                 forwards the student at the same x_j and matches mu_S to the
-                 cached mu_T_j.
+                 forwards the student at the same x_j and matches its projected
+                 target to the cached teacher target.
 
 This keeps teacher swaps to M-per-epoch, runs the gradient loop with student
 params only (no autocast-cache disable, no DDP bypass), and reuses proven FF
@@ -60,13 +60,119 @@ tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
 from ...hparams import DiffusionOPDTrainingArguments
 from ...hparams.training_args.opd import resolve_distill_step_band
 from ...samples import BaseSample
-from ...utils.base import filter_kwargs
+from ...utils.base import filter_kwargs, to_broadcast_tensor
 from ...utils.logger_utils import setup_logger
+from ...utils.noise_schedule import flow_match_sigma
 from ...utils.trajectory_collector import compute_trajectory_indices
 from ..abc import BaseTrainer
 from .common import load_teachers
 
 logger = setup_logger(__name__)
+
+
+def _validate_loss_target_for_dynamics(loss_target: str, dynamics_type: str) -> None:
+    """Validate that the configured target is defined for the scheduler dynamics."""
+    if loss_target in ("v", "x0") and dynamics_type != "ODE":
+        raise ValueError(
+            "DiffusionOPD velocity-derived targets require ODE dynamics: "
+            f"received loss_target={loss_target!r} with dynamics_type={dynamics_type!r}. "
+            "Use scheduler.dynamics_type='ODE' or set train.loss_target='xt'."
+        )
+
+
+def _project_distillation_target(
+    *,
+    loss_target: str,
+    latents: torch.Tensor,
+    timestep: torch.Tensor,
+    next_latents_mean: Optional[torch.Tensor],
+    velocity: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Project a scheduler step output into the configured distillation space."""
+    if not isinstance(latents, torch.Tensor):
+        raise TypeError(
+            "Expected `latents` to be a torch.Tensor when projecting a DiffusionOPD "
+            f"target, got {type(latents).__name__}: {latents!r}."
+        )
+    if not isinstance(timestep, torch.Tensor):
+        raise TypeError(
+            "Expected `timestep` to be a torch.Tensor when projecting a DiffusionOPD "
+            f"target, got {type(timestep).__name__}: {timestep!r}."
+        )
+
+    if loss_target == "xt":
+        if not isinstance(next_latents_mean, torch.Tensor):
+            raise ValueError(
+                "Expected `next_latents_mean` to be a torch.Tensor for "
+                f"loss_target='xt', got {type(next_latents_mean).__name__}."
+            )
+        target = next_latents_mean
+        target_name = "next_latents_mean"
+    elif loss_target in ("v", "x0"):
+        if not isinstance(velocity, torch.Tensor):
+            raise ValueError(
+                "Expected `velocity` to be a torch.Tensor for "
+                f"loss_target={loss_target!r}, got {type(velocity).__name__}."
+            )
+        target = velocity
+        target_name = "velocity"
+    else:
+        raise ValueError(
+            "DiffusionOPD loss_target must be one of ('xt', 'v', 'x0'), " f"got {loss_target!r}."
+        )
+
+    if target.shape != latents.shape:
+        raise ValueError(
+            "DiffusionOPD target projection requires `latents` and "
+            f"`{target_name}` to have the same shape, got "
+            f"latents={tuple(latents.shape)} and {target_name}={tuple(target.shape)}."
+        )
+    if loss_target != "x0":
+        return target
+
+    latents_float = latents.float()
+    sigma = to_broadcast_tensor(flow_match_sigma(timestep.float()), latents_float)
+    return latents_float - sigma * target.float()
+
+
+def _compute_per_sample_distillation_loss(
+    student_target: torch.Tensor,
+    teacher_target: torch.Tensor,
+    *,
+    self_normalize: bool,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Compute target-space MSE with optional detached self-normalization."""
+    if not isinstance(student_target, torch.Tensor) or not isinstance(teacher_target, torch.Tensor):
+        raise TypeError(
+            "Expected `student_target` and `teacher_target` to be torch.Tensor values, "
+            f"got {type(student_target).__name__} and {type(teacher_target).__name__}."
+        )
+    if student_target.shape != teacher_target.shape:
+        raise ValueError(
+            "DiffusionOPD loss requires matching shapes for `student_target` and "
+            f"`teacher_target`, got {tuple(student_target.shape)} and "
+            f"{tuple(teacher_target.shape)}."
+        )
+    if student_target.ndim < 2:
+        raise ValueError(
+            "DiffusionOPD loss requires target tensors with a batch dimension and at "
+            f"least one feature dimension, got shape {tuple(student_target.shape)}."
+        )
+    if not isinstance(self_normalize, bool):
+        raise TypeError(
+            "Expected `self_normalize` to be a bool, "
+            f"got {type(self_normalize).__name__}: {self_normalize!r}."
+        )
+    if eps <= 0:
+        raise ValueError(f"Expected `eps` to be positive, got {eps!r}.")
+
+    error = student_target.float() - teacher_target.float()
+    per_sample_mse = error.square().flatten(1).mean(dim=1)
+    if not self_normalize:
+        return per_sample_mse
+    scale = error.abs().flatten(1).mean(dim=1).detach()
+    return per_sample_mse / (scale + eps)
 
 
 class DiffusionOPDTrainer(BaseTrainer):
@@ -82,8 +188,12 @@ class DiffusionOPDTrainer(BaseTrainer):
 
         scheduler = self.adapter.scheduler
         self._is_sde = scheduler.dynamics_type != "ODE"
-        # Teacher mu_T and student mu_S are computed at the SAME stored state x_j
-        # with the SAME noise_level so the transition means are comparable.
+        _validate_loss_target_for_dynamics(
+            self.training_args.loss_target,
+            scheduler.dynamics_type,
+        )
+        # Teacher and student targets are computed at the SAME stored state x_j
+        # with the SAME noise_level so their projections are comparable.
         self._student_noise_level = float(scheduler.noise_level) if self._is_sde else 0.0
 
         # --- Teachers: load each LoRA checkpoint into a named snapshot ---
@@ -131,7 +241,7 @@ class DiffusionOPDTrainer(BaseTrainer):
                         "with this `name` and `train.enabled: true`."
                     )
 
-        self._mu_store_device = (
+        self._teacher_target_store_device = (
             "cpu" if self.training_args.offload_samples_to_cpu else self.accelerator.device
         )
 
@@ -140,7 +250,9 @@ class DiffusionOPDTrainer(BaseTrainer):
             f"{self._teacher_names}, dynamics={scheduler.dynamics_type!r} "
             f"(is_sde={self._is_sde}, student_noise_level={self._student_noise_level}), "
             f"datasets={sorted(self._available_sources)}, "
-            f"student_gs={student_gs}, teacher_gs={self._teacher_gs}."
+            f"student_gs={student_gs}, teacher_gs={self._teacher_gs}, "
+            f"loss_target={self.training_args.loss_target!r}, "
+            f"self_normalize={self.training_args.self_normalize}."
         )
 
     # =============================== Lifecycle ===============================
@@ -198,7 +310,7 @@ class DiffusionOPDTrainer(BaseTrainer):
 
     # =============================== Optimization ===============================
     def optimize(self, samples: List[BaseSample]) -> None:
-        """Two-pass distillation: cache teacher means, then student gradient loop."""
+        """Cache teacher targets, then optimize the student in the selected target space."""
         if not samples:
             logger.warning("DiffusionOPD optimize() received no samples; skipping epoch.")
             return
@@ -221,7 +333,7 @@ class DiffusionOPDTrainer(BaseTrainer):
         samples: List[BaseSample],
         train_timesteps: torch.Tensor,
     ) -> None:
-        """PASS 1: cache each teacher's per-step mean mu_T on its routed samples.
+        """PASS 1: cache each teacher's projected target on its routed samples.
 
         One ``use_named_parameters`` swap per teacher (performed OUTSIDE the
         autocast block); a per-teacher ``autocast`` scope gives each teacher a
@@ -243,28 +355,27 @@ class DiffusionOPDTrainer(BaseTrainer):
             with self.adapter.use_named_parameters(teacher_name):
                 with self.autocast():
                     for batch in tqdm(
-                        self._iter_prefetched_batches(
-                            teacher_samples, per_device_batch_size
-                        ),
+                        self._iter_prefetched_batches(teacher_samples, per_device_batch_size),
                         total=num_batches,
                         desc=f"Epoch {self.epoch} Teacher[{teacher_name}] targets",
                         disable=not self.show_progress_bar,
                     ):
-                        # mu_T at each training step: (B, *latent) per step.
-                        mu_teacher_steps = [
+                        # Teacher target at each training step: (B, *latent) per step.
+                        teacher_target_steps = [
                             self._forward_step(
                                 batch,
                                 timestep_index,
                                 guidance_scale=teacher_gs,
-                                return_kwargs=["next_latents_mean"],
                             )[0].detach()
                             for timestep_index in train_timesteps
                         ]
                         # (B, num_train_steps, *latent)
-                        mu_teacher_stacked = torch.stack(mu_teacher_steps, dim=1)
+                        teacher_target_stacked = torch.stack(teacher_target_steps, dim=1)
                         for j, sample in enumerate(batch.samples):
-                            sample.extra_kwargs["mu_teacher"] = (
-                                mu_teacher_stacked[j].to(self._mu_store_device).clone()
+                            sample.extra_kwargs["teacher_target"] = (
+                                teacher_target_stacked[j]
+                                .to(self._teacher_target_store_device)
+                                .clone()
                             )
             # Belt-and-suspenders guard against a nested-autocast cache edge case.
             torch.clear_autocast_cache()
@@ -274,7 +385,7 @@ class DiffusionOPDTrainer(BaseTrainer):
         samples: List[BaseSample],
         train_timesteps: torch.Tensor,
     ) -> None:
-        """PASS 2: student-only gradient loop matching mu_S to the cached mu_T."""
+        """PASS 2: match student targets to cached teacher targets."""
         device = self.accelerator.device
         per_device_batch_size = self.training_args.per_device_batch_size
         num_batches = math.ceil(len(samples) / per_device_batch_size)
@@ -284,18 +395,16 @@ class DiffusionOPDTrainer(BaseTrainer):
             shuffled_samples = self._order_samples_for_optimize(samples, inner_epoch)
 
             self.adapter.train()
-            # Per-teacher KL accumulators over the current gradient-accumulation window.
+            # Per-teacher loss accumulators over the current gradient-accumulation window.
             # Fixed (num_teachers,) shape so the cross-rank reduce in `_log_distill_metrics`
             # is collective-safe regardless of which teachers each rank's micro-batches held.
             num_teachers = len(self._teacher_names)
-            teacher_kl_sum = torch.zeros(num_teachers, device=device)
-            teacher_kl_count = torch.zeros(num_teachers, device=device)
+            teacher_loss_sum = torch.zeros(num_teachers, device=device)
+            teacher_loss_count = torch.zeros(num_teachers, device=device)
             grad_norm = None
 
             for batch in tqdm(
-                self._iter_prefetched_batches(
-                    shuffled_samples, per_device_batch_size
-                ),
+                self._iter_prefetched_batches(shuffled_samples, per_device_batch_size),
                 total=num_batches,
                 desc=f"Epoch {self.epoch} Distill",
                 position=0,
@@ -307,15 +416,15 @@ class DiffusionOPDTrainer(BaseTrainer):
                     device=device,
                     dtype=torch.long,
                 )  # (B,)
-                # mu_teacher rides BaseSample.to() with the sample; ensure on device.
-                mu_teacher_all = batch["mu_teacher"]
-                if not isinstance(mu_teacher_all, torch.Tensor):
+                # teacher_target rides BaseSample.to() with the sample; ensure on device.
+                teacher_target_all = batch["teacher_target"]
+                if not isinstance(teacher_target_all, torch.Tensor):
                     raise RuntimeError(
-                        "Expected cached teacher means `mu_teacher` (a tensor) on every "
-                        f"sample, got {type(mu_teacher_all).__name__}. PASS 1 "
+                        "Expected cached `teacher_target` (a tensor) on every sample, "
+                        f"got {type(teacher_target_all).__name__}. PASS 1 "
                         "(_precompute_teacher_targets) must run before PASS 2."
                     )
-                mu_teacher_all = mu_teacher_all.to(device)
+                teacher_target_all = teacher_target_all.to(device)
 
                 for idx, timestep_index in enumerate(
                     tqdm(
@@ -328,39 +437,45 @@ class DiffusionOPDTrainer(BaseTrainer):
                 ):
                     with self.accumulate_gradients():
                         with self.autocast():
-                            # mu_S: (B, *latent) student transition mean at this step.
-                            mu_S, std_dev_t, dt = self._forward_step(
+                            student_target, std_dev_t, dt = self._forward_step(
                                 batch,
                                 timestep_index,
                                 guidance_scale=self.training_args.guidance_scale,
-                                return_kwargs=["next_latents_mean", "std_dev_t", "dt"],
+                                include_transition_stats=True,
                             )
-                            # Each sample is matched to ITS OWN routed teacher: mu_teacher
-                            # was cached per-sample in PASS 1, so a micro-batch may mix teachers.
-                            mu_T = mu_teacher_all[:, idx]  # (B, *latent) this sample's teacher mean
-                            # Per-sample MSE between student and teacher transition means.
-                            per_sample_mse = (
-                                (mu_S.float() - mu_T.float()).pow(2).flatten(1).mean(dim=1)
-                            )  # (B,)
-                            # Transition variance sigma_bar^2: 1.0 (ODE) or (B, 1, 1) (SDE).
-                            denom = self.adapter.scheduler.get_kl_divergence_denominator(
-                                std_dev_t, dt
+                            # Each sample is matched to its own routed teacher target.
+                            teacher_target = teacher_target_all[:, idx]
+                            per_sample_distill_loss = _compute_per_sample_distillation_loss(
+                                student_target,
+                                teacher_target,
+                                self_normalize=self.training_args.self_normalize,
                             )
-                            if isinstance(denom, torch.Tensor):
-                                # denom is per-sample-constant, so reduce (B,1,1) -> (B,).
-                                denom = denom.reshape(per_sample_mse.shape[0], -1).mean(
+                            if self._is_sde:
+                                # Validation guarantees SDE uses the xt transition-mean target.
+                                denom = self.adapter.scheduler.get_kl_divergence_denominator(
+                                    std_dev_t, dt
+                                )
+                                if not isinstance(denom, torch.Tensor):
+                                    raise TypeError(
+                                        "Expected an SDE KL denominator tensor for "
+                                        f"dynamics_type={self.adapter.scheduler.dynamics_type!r}, "
+                                        f"got {type(denom).__name__}: {denom!r}."
+                                    )
+                                denom = denom.reshape(per_sample_distill_loss.shape[0], -1).mean(
                                     dim=1
-                                )  # (B,)
-                            per_sample_kl = 0.5 * (per_sample_mse / denom)  # (B,)
-                            loss = per_sample_kl.mean()  # scalar (mean over batch)
+                                )
+                                per_sample_distill_loss = per_sample_distill_loss / denom
+                            loss = per_sample_distill_loss.mean()
 
                         self.accelerator.backward(loss)
 
-                        # Accumulate per-teacher KL sums/counts for logging (detached).
+                        # Accumulate per-teacher loss sums/counts for logging (detached).
                         with torch.no_grad():
-                            teacher_kl_sum.index_add_(0, teacher_idx, per_sample_kl.detach())
-                            teacher_kl_count.index_add_(
-                                0, teacher_idx, torch.ones_like(per_sample_kl)
+                            teacher_loss_sum.index_add_(
+                                0, teacher_idx, per_sample_distill_loss.detach()
+                            )
+                            teacher_loss_count.index_add_(
+                                0, teacher_idx, torch.ones_like(per_sample_distill_loss)
                             )
 
                         if self.accelerator.sync_gradients:
@@ -371,41 +486,40 @@ class DiffusionOPDTrainer(BaseTrainer):
                             self.optimizer.step()
                             self.optimizer.zero_grad()
                             self._log_distill_metrics(
-                                teacher_kl_sum, teacher_kl_count, grad_norm
+                                teacher_loss_sum, teacher_loss_count, grad_norm
                             )
                             self.step += 1
-                            teacher_kl_sum.zero_()
-                            teacher_kl_count.zero_()
+                            teacher_loss_sum.zero_()
+                            teacher_loss_count.zero_()
 
     # =============================== Helpers ===============================
     def _log_distill_metrics(
         self,
-        teacher_kl_sum: torch.Tensor,
-        teacher_kl_count: torch.Tensor,
+        teacher_loss_sum: torch.Tensor,
+        teacher_loss_count: torch.Tensor,
         grad_norm: Optional[torch.Tensor],
     ) -> None:
-        """Globally reduce per-teacher KL sums/counts and log per-teacher + overall means.
+        """Globally reduce per-teacher loss sums/counts and log their means.
 
-        Logs one ``train/kl_div_{teacher_name}`` per teacher seen this window
-        (the KL averaged over that teacher's samples x timesteps) plus the
-        overall ``train/kl_div`` (averaged across all teachers). The reduce
+        Logs one ``train/distill_loss_{teacher_name}`` per teacher seen this
+        window plus the overall ``train/distill_loss``. The reduce
         operates on fixed ``(num_teachers,)`` tensors, identical on every rank,
         so it is collective-safe even when teachers are unevenly distributed
         across ranks/micro-batches.
         """
         # Pack sum + count into one tensor so the cross-rank reduction is a single
         # collective (the pack-and-reduce idiom used across utils/dist.py).
-        packed = torch.stack([teacher_kl_sum, teacher_kl_count])  # (2, num_teachers)
+        packed = torch.stack([teacher_loss_sum, teacher_loss_count])
         packed = cast(torch.Tensor, self.accelerator.reduce(packed, reduction="sum"))
         g_sum, g_count = packed[0], packed[1]
 
         metrics: Dict[str, Any] = {}
         total_count = g_count.sum()
         if total_count > 0:
-            metrics["kl_div"] = g_sum.sum() / total_count
+            metrics["distill_loss"] = g_sum.sum() / total_count
         for teacher_idx, name in enumerate(self._teacher_names):
             if g_count[teacher_idx] > 0:
-                metrics[f"kl_div_{name}"] = g_sum[teacher_idx] / g_count[teacher_idx]
+                metrics[f"distill_loss_{name}"] = g_sum[teacher_idx] / g_count[teacher_idx]
         if grad_norm is not None:
             metrics["grad_norm"] = grad_norm
 
@@ -461,16 +575,14 @@ class DiffusionOPDTrainer(BaseTrainer):
         batch: Dict[str, Any],
         timestep_index: Union[int, torch.Tensor],
         guidance_scale: float,
-        return_kwargs: List[str],
+        include_transition_stats: bool = False,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
-        """Forward the adapter at stored trajectory step ``timestep_index``.
+        """Forward one stored step and return its configured target projection.
 
         Replays the rollout transition ``x_j -> x_{j+1}`` (current/next latents
         and ``t``/``t_next`` come from the stored trajectory, fetched via the
-        same index maps GRPO uses). Returns ``(mu, std_dev_t, dt)`` where ``mu``
-        is the (validated non-None) transition mean ``next_latents_mean`` and
-        ``std_dev_t``/``dt`` are the SDE statistics used by the loss denominator
-        (present on the student pass, ``None``/zero under ODE).
+        same index maps GRPO uses). Returns ``(target, std_dev_t, dt)``;
+        transition statistics are requested only for the student pass.
         """
         latents_index_map = batch["latent_index_map"]
         num_timesteps = batch["timesteps"].shape[1]
@@ -498,12 +610,20 @@ class DiffusionOPDTrainer(BaseTrainer):
             "guidance_scale": guidance_scale,
         }
         forward_inputs = filter_kwargs(self.adapter.forward, **forward_inputs)
-        forward_inputs["return_kwargs"] = list(return_kwargs)
+        target_output_name = (
+            "next_latents_mean" if self.training_args.loss_target == "xt" else "velocity"
+        )
+        return_kwargs = [target_output_name]
+        if include_transition_stats:
+            return_kwargs.extend(["std_dev_t", "dt"])
+        forward_inputs["return_kwargs"] = return_kwargs
         output = self.adapter.forward(**forward_inputs)
 
-        if output.next_latents_mean is None:
-            raise RuntimeError(
-                "DiffusionOPD requires `next_latents_mean` from adapter.forward, got None. "
-                f"Ensure the adapter/scheduler returns it (return_kwargs={list(return_kwargs)})."
-            )
-        return output.next_latents_mean, output.std_dev_t, output.dt
+        target = _project_distillation_target(
+            loss_target=self.training_args.loss_target,
+            latents=latents,
+            timestep=t,
+            next_latents_mean=output.next_latents_mean,
+            velocity=output.velocity,
+        )
+        return target, output.std_dev_t, output.dt

--- a/src/flow_factory/trainers/opd/trainer.py
+++ b/src/flow_factory/trainers/opd/trainer.py
@@ -60,119 +60,18 @@ tqdm = partial(tqdm_.tqdm, dynamic_ncols=True)
 from ...hparams import DiffusionOPDTrainingArguments
 from ...hparams.training_args.opd import resolve_distill_step_band
 from ...samples import BaseSample
-from ...utils.base import filter_kwargs, to_broadcast_tensor
+from ...utils.base import filter_kwargs
 from ...utils.logger_utils import setup_logger
-from ...utils.noise_schedule import flow_match_sigma
 from ...utils.trajectory_collector import compute_trajectory_indices
 from ..abc import BaseTrainer
-from .common import load_teachers
+from .common import (
+    compute_per_sample_distillation_loss,
+    load_teachers,
+    project_distillation_target,
+    validate_loss_target_for_dynamics,
+)
 
 logger = setup_logger(__name__)
-
-
-def _validate_loss_target_for_dynamics(loss_target: str, dynamics_type: str) -> None:
-    """Validate that the configured target is defined for the scheduler dynamics."""
-    if loss_target in ("v", "x0") and dynamics_type != "ODE":
-        raise ValueError(
-            "DiffusionOPD velocity-derived targets require ODE dynamics: "
-            f"received loss_target={loss_target!r} with dynamics_type={dynamics_type!r}. "
-            "Use scheduler.dynamics_type='ODE' or set train.loss_target='xt'."
-        )
-
-
-def _project_distillation_target(
-    *,
-    loss_target: str,
-    latents: torch.Tensor,
-    timestep: torch.Tensor,
-    next_latents_mean: Optional[torch.Tensor],
-    velocity: Optional[torch.Tensor],
-) -> torch.Tensor:
-    """Project a scheduler step output into the configured distillation space."""
-    if not isinstance(latents, torch.Tensor):
-        raise TypeError(
-            "Expected `latents` to be a torch.Tensor when projecting a DiffusionOPD "
-            f"target, got {type(latents).__name__}: {latents!r}."
-        )
-    if not isinstance(timestep, torch.Tensor):
-        raise TypeError(
-            "Expected `timestep` to be a torch.Tensor when projecting a DiffusionOPD "
-            f"target, got {type(timestep).__name__}: {timestep!r}."
-        )
-
-    if loss_target == "xt":
-        if not isinstance(next_latents_mean, torch.Tensor):
-            raise ValueError(
-                "Expected `next_latents_mean` to be a torch.Tensor for "
-                f"loss_target='xt', got {type(next_latents_mean).__name__}."
-            )
-        target = next_latents_mean
-        target_name = "next_latents_mean"
-    elif loss_target in ("v", "x0"):
-        if not isinstance(velocity, torch.Tensor):
-            raise ValueError(
-                "Expected `velocity` to be a torch.Tensor for "
-                f"loss_target={loss_target!r}, got {type(velocity).__name__}."
-            )
-        target = velocity
-        target_name = "velocity"
-    else:
-        raise ValueError(
-            "DiffusionOPD loss_target must be one of ('xt', 'v', 'x0'), " f"got {loss_target!r}."
-        )
-
-    if target.shape != latents.shape:
-        raise ValueError(
-            "DiffusionOPD target projection requires `latents` and "
-            f"`{target_name}` to have the same shape, got "
-            f"latents={tuple(latents.shape)} and {target_name}={tuple(target.shape)}."
-        )
-    if loss_target != "x0":
-        return target
-
-    latents_float = latents.float()
-    sigma = to_broadcast_tensor(flow_match_sigma(timestep.float()), latents_float)
-    return latents_float - sigma * target.float()
-
-
-def _compute_per_sample_distillation_loss(
-    student_target: torch.Tensor,
-    teacher_target: torch.Tensor,
-    *,
-    self_normalize: bool,
-    eps: float = 1e-8,
-) -> torch.Tensor:
-    """Compute target-space MSE with optional detached self-normalization."""
-    if not isinstance(student_target, torch.Tensor) or not isinstance(teacher_target, torch.Tensor):
-        raise TypeError(
-            "Expected `student_target` and `teacher_target` to be torch.Tensor values, "
-            f"got {type(student_target).__name__} and {type(teacher_target).__name__}."
-        )
-    if student_target.shape != teacher_target.shape:
-        raise ValueError(
-            "DiffusionOPD loss requires matching shapes for `student_target` and "
-            f"`teacher_target`, got {tuple(student_target.shape)} and "
-            f"{tuple(teacher_target.shape)}."
-        )
-    if student_target.ndim < 2:
-        raise ValueError(
-            "DiffusionOPD loss requires target tensors with a batch dimension and at "
-            f"least one feature dimension, got shape {tuple(student_target.shape)}."
-        )
-    if not isinstance(self_normalize, bool):
-        raise TypeError(
-            "Expected `self_normalize` to be a bool, "
-            f"got {type(self_normalize).__name__}: {self_normalize!r}."
-        )
-    if eps <= 0:
-        raise ValueError(f"Expected `eps` to be positive, got {eps!r}.")
-
-    error = student_target.float() - teacher_target.float()
-    per_sample_mse = error.square().flatten(1).mean(dim=1)
-    if not self_normalize:
-        return per_sample_mse
-    scale = error.abs().flatten(1).mean(dim=1).detach()
-    return per_sample_mse / (scale + eps)
 
 
 class DiffusionOPDTrainer(BaseTrainer):
@@ -188,7 +87,7 @@ class DiffusionOPDTrainer(BaseTrainer):
 
         scheduler = self.adapter.scheduler
         self._is_sde = scheduler.dynamics_type != "ODE"
-        _validate_loss_target_for_dynamics(
+        validate_loss_target_for_dynamics(
             self.training_args.loss_target,
             scheduler.dynamics_type,
         )
@@ -445,7 +344,7 @@ class DiffusionOPDTrainer(BaseTrainer):
                             )
                             # Each sample is matched to its own routed teacher target.
                             teacher_target = teacher_target_all[:, idx]
-                            per_sample_distill_loss = _compute_per_sample_distillation_loss(
+                            per_sample_distill_loss = compute_per_sample_distillation_loss(
                                 student_target,
                                 teacher_target,
                                 self_normalize=self.training_args.self_normalize,
@@ -619,7 +518,7 @@ class DiffusionOPDTrainer(BaseTrainer):
         forward_inputs["return_kwargs"] = return_kwargs
         output = self.adapter.forward(**forward_inputs)
 
-        target = _project_distillation_target(
+        target = project_distillation_target(
             loss_target=self.training_args.loss_target,
             latents=latents,
             timestep=t,


### PR DESCRIPTION
## Summary
- add orthogonal `loss_target` (`xt`, `v`, `x0`) and `self_normalize` controls to DiffusionOPD
- project teacher/student outputs into the selected target space, restrict velocity-derived targets to ODE, and rename metrics to `distill_loss`
- document the intentional removal of the `0.5` scale and add an x0 self-normalized GenEval/PickScore/OCR config

## Test plan
- [x] Run 28 focused CPU regression tests for target projection, normalization, validation, and ODE identities
- [x] Parse the OPD example configs and verify the x0 normalized clone differs only in the two requested values
- [x] Run Black/isort checks on changed Python files, compile checks, IDE lints, and `git diff --check`
- [ ] Run an end-to-end multi-GPU SD3.5 OPD training smoke test with teacher checkpoints