### PR TITLE
[models] optimize: call text_encoder.model instead of text_encoder to…

### DIFF
--- a/src/flow_factory/models/ltx2/ltx2_t2av.py
+++ b/src/flow_factory/models/ltx2/ltx2_t2av.py
@@ -357,7 +357,7 @@ class LTX2_T2AV_Adapter(BaseAdapter):
         input_ids = tok_out.input_ids.to(device)
         attention_mask = tok_out.attention_mask.to(device)
 
-        enc_out = self.pipeline.text_encoder(
+        enc_out = self.pipeline.text_encoder.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
             output_hidden_states=True,


### PR DESCRIPTION
In `_encode_text` of `LTX2_T2AV_Adapter`, calling `self.pipeline.text_encoder(...)` runs the full `Gemma3ForConditionalGeneration.forward()`, which unnecessarily computes logits through the LM head. Since we only need `hidden_states`, switching to `self.pipeline.text_encoder.model(...)` (i.e., `Gemma3Model`) skips the LM head projection, saving compute and memory while producing identical hidden states.